### PR TITLE
Make instructions consistent with current  structure

### DIFF
--- a/BUILD_INSTRUCTIONS.markdown
+++ b/BUILD_INSTRUCTIONS.markdown
@@ -16,10 +16,16 @@ token after creating an account here:
 
 https://api.portal.trustedservices.intel.com/EPID-attestation
 
+Clone the Veracruz repository:
+
+```
+git clone git@github.com:veracruz-project/veracruz.git
+export VERACRUZ_ROOT=$PWD/veracruz
+```
 Once you have a local copy of the Veracruz source and your token:
 
 ```
-cd SGXRustOPTEEDevelDocker
+cd veracruz-docker-image
 make VERACRUZ_ROOT=<path to your veracruz directory> IAS_TOKEN=<your Intel Attestation Service token>
 ````
 

--- a/BUILD_INSTRUCTIONS.markdown
+++ b/BUILD_INSTRUCTIONS.markdown
@@ -19,7 +19,7 @@ https://api.portal.trustedservices.intel.com/EPID-attestation
 Clone the Veracruz repository:
 
 ```
-git clone git@github.com:veracruz-project/veracruz.git
+git clone git@github.com:veracruz-project/veracruz.git --recursive
 export VERACRUZ_ROOT=$PWD/veracruz
 ```
 Once you have a local copy of the Veracruz source and your token:

--- a/BUILD_INSTRUCTIONS.markdown
+++ b/BUILD_INSTRUCTIONS.markdown
@@ -26,7 +26,7 @@ Once you have a local copy of the Veracruz source and your token:
 
 ```
 cd veracruz-docker-image
-make VERACRUZ_ROOT=<path to your veracruz directory> IAS_TOKEN=<your Intel Attestation Service token>
+make IAS_TOKEN=<your Intel Attestation Service token>
 ````
 
 Note that building the Docker image will take a long time (we appreciate any


### PR DESCRIPTION
Correct the build instructions to match the current repository names and locations.