### PR TITLE
CI script for AWS CodeBuild.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,17 @@ sgx-sinaloa-test: sgx test_cases
 		&& RUSTFLAGS=$(SGX_RUST_FLAG) cargo test --features sgx \
 		&& RUSTFLAGS=$(SGX_RUST_FLAG) cargo test test_debug --features sgx  -- --ignored --test-threads=1
 
+sgx-sinaloa-test-dry-run: sgx test_cases
+	cd sinaloa-test \
+		&& RUSTFLAGS=$(SGX_RUST_FLAG) cargo test --features sgx --no-run 
+
 sgx-sinaloa-performance: sgx test_cases
 	cd sinaloa-test \
 		&& RUSTFLAGS=$(SGX_RUST_FLAG) cargo test test_performance_ --features sgx -- --ignored 
+
+sgx-veracruz-test-dry-run: sgx test_cases
+	cd veracruz-test \
+		&& RUSTFLAGS=$(SGX_RUST_FLAG) cargo test --features sgx --no-run
 
 sgx-veracruz-test: sgx test_cases
 	cd veracruz-test \

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,9 +10,17 @@ env:
 phases:
   pre_build:
     commands:
+      # Set up the environment for trustzone backend
       - pushd /work/rust-optee-trustzone-sdk && source environment && popd
+      # clean the repostory, which automatically downloads the rust toolchain specified in the repostory
       - make clean
   build:
     commands:
+      # compiling and running tests on trustzone
+      - make trustzone-durango-test
       - make trustzone-sinaloa-test
       - make trustzone-veracruz-test
+      # compiling and running some tests on sgx; other tests requires SGX enable machine.
+      - make sgx-durango-test
+      - make sgx-sinaloa-test-dry-run
+      - make sgx-veracruz-test-dry-run

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+# Running as the root user as the default.
+#run-as: Linux-user-name
+
+env:
+  # use bash as the default shell
+  shell: bash
+
+phases:
+  pre_build:
+    commands:
+      - pushd /work/rust-optee-trustzone-sdk && source environment && popd
+      - make clean
+  build:
+    commands:
+      - make trustzone-sinaloa-test
+      - make trustzone-veracruz-test


### PR DESCRIPTION
CI script for AWS CodeBuild:
- build and run all tests on Trustzone backend.
- build and run Durango tests on SGX backend.