### PR TITLE
Added Rustdoc support for SDK

### DIFF
--- a/chihuahua/src/hcall/common.rs
+++ b/chihuahua/src/hcall/common.rs
@@ -3,18 +3,17 @@
 //! ## About
 //!
 //! The Veracruz H-call interface consists of the following functions:
-//!
-//!     - `__veracruz_hcall_input_count()` which returns the count of secret
-//!       data sources available to the program,
-//!     - `__veracruz_hcall_read_input()` which fills a WASM buffer with a
-//!       particular input,
-//!     - `__veracruz_hcall_input_size()` which returns the size, in bytes, of a
-//!       particular input,
-//!     - `__veracruz_hcall_write_output()` which can be used by the WASM
-//!       program to register its result by pointing the host to a WASM buffer
-//!       which is then copied into the host,
-//!     - `__veracruz_hcall_getrandom()` which fills a WASM buffer with random
-//!       bytes taken from a platform-specific entropy source.
+//! - `__veracruz_hcall_input_count()` which returns the count of secret
+//!   data sources available to the program,
+//! - `__veracruz_hcall_read_input()` which fills a WASM buffer with a
+//!   particular input,
+//! - `__veracruz_hcall_input_size()` which returns the size, in bytes, of a
+//!   particular input,
+//! - `__veracruz_hcall_write_output()` which can be used by the WASM
+//!   program to register its result by pointing the host to a WASM buffer
+//!   which is then copied into the host,
+//! - `__veracruz_hcall_getrandom()` which fills a WASM buffer with random
+//!   bytes taken from a platform-specific entropy source.
 //!
 //! The implementation of some of these functions relies on execution-engine
 //! specific details, so they are mostly implemented in the engine-specific
@@ -30,20 +29,19 @@
 //! track of the state of the host as material is provisioned into the Veracruz
 //! enclave, and is used by the host to implement some (actually, most) of the
 //! H-calls mentioned above.  In particular, the host state keeps track of:
-//!
-//!     - The number of expected data sources that the host is expecting,
-//!       derived from the policy,
-//!     - The number of expected data sources already provisioned, and various
-//!       bits of metadata about them (e.g. who provisioned them),
-//!     - The current machine state, e.g. `MachineState::ReadyToExecute`,
-//!     - Any result that the WASM program executing on Veracruz may have
-//!       written to the host with the `__veracruz_hcall_write_output()` H-call.
-//!       Note that this is stored as an uninterpreted set of bytes in the host,
-//!       the host doesn't necessarily know how to interpret it: that's a detail
-//!       to be agreed between the participants in the computation,
-//!     - Some WASM engine specific details, including a reference to the WASM
-//!       module executing and the linear memory of the module.  As these types
-//!       are engine-specific, we abstract over them with type-variables here.
+//! - The number of expected data sources that the host is expecting,
+//!   derived from the policy,
+//! - The number of expected data sources already provisioned, and various
+//!   bits of metadata about them (e.g. who provisioned them),
+//! - The current machine state, e.g. `MachineState::ReadyToExecute`,
+//! - Any result that the WASM program executing on Veracruz may have
+//!   written to the host with the `__veracruz_hcall_write_output()` H-call.
+//!   Note that this is stored as an uninterpreted set of bytes in the host,
+//!   the host doesn't necessarily know how to interpret it: that's a detail
+//!   to be agreed between the participants in the computation,
+//! - Some WASM engine specific details, including a reference to the WASM
+//!   module executing and the linear memory of the module.  As these types
+//!   are engine-specific, we abstract over them with type-variables here.
 //!
 //! We also include a lot of generic material for working with the host state,
 //! including functions for changing various values, and bumping the host state

--- a/chihuahua/src/hcall/wasmi.rs
+++ b/chihuahua/src/hcall/wasmi.rs
@@ -16,7 +16,7 @@ use platform_services::{getrandom, result};
 use wasmi::{
     Error, ExternVal, Externals, FuncInstance, FuncRef, GlobalDescriptor, GlobalRef,
     MemoryDescriptor, MemoryRef, Module, ModuleImportResolver, ModuleInstance, ModuleRef,
-    RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableRef, Trap, TrapKind, ValueType,
+    RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableRef, Trap, ValueType,
 };
 
 use crate::{

--- a/chihuahua/src/hcall/wasmtime.rs
+++ b/chihuahua/src/hcall/wasmtime.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 #[cfg(feature = "sgx")]
 use std::sync::SgxMutex as Mutex;
 
-use std::{string::String, vec::Vec};
+use std::vec::Vec;
 
 use byteorder::{ByteOrder, LittleEndian};
 use wasmtime::{Caller, Extern, ExternType, Func, Instance, Module, Store, Trap, ValType};

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -55,7 +55,7 @@ DATA_GENERATORS = idash2017-logistic-regression-generator \
 DATA_GENERATORS_PATH = data-generators
 RELATIVE_DATA_GEN = $(addprefix $(DATA_GENERATORS_PATH)/, $(DATA_GENERATORS))
 
-.PHONY: all clean fmt freestanding-chihuahua libveracruz veracruz-rt tlaxcala env
+.PHONY: all clean doc fmt freestanding-chihuahua libveracruz veracruz-rt tlaxcala env
 
 all: tlaxcala $(RELATIVE_DATA) $(RELATIVE_EXAMPLES) freestanding-chihuahua libveracruz veracruz-rt veracruz-getrandom veracruz-rand
 
@@ -103,11 +103,19 @@ fmt:
 		$(MAKE) -C $$data fmt; \
 	done
 	for example in $(addprefix $(EXAMPLE_DIR),$(basename $(notdir $(RELATIVE_EXAMPLES)))); do \
-        $(MAKE) -C $$example fmt; \
-    done
+        	$(MAKE) -C $$example fmt; \
+    	done
 	$(MAKE) -C freestanding-chihuahua/ fmt
 	$(MAKE) -C libveracruz/ fmt
 	$(MAKE) -C veracruz-rt/ fmt
+
+doc:
+	for example in $(addprefix $(EXAMPLE_DIR),$(basename $(notdir $(RELATIVE_EXAMPLES)))); do \
+                $(MAKE) -C $$example doc; \
+        done
+	$(MAKE) -C freestanding-chihuahua/ doc
+	$(MAKE) -C libveracruz/ doc
+	$(MAKE) -C veracruz-rt/ doc
 
 clean:
 	for data in $(RELATIVE_DATA_GEN); do \

--- a/sdk/examples/idash2017-logistic-regression/Makefile
+++ b/sdk/examples/idash2017-logistic-regression/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all doc clean fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/idash2017-logistic-regression/src/main.rs
+++ b/sdk/examples/idash2017-logistic-regression/src/main.rs
@@ -21,7 +21,7 @@
 //! Ensured form of outputs: A Pinecone-encoded Rust vector of `f64` values describing the parameters
 //!                          of the learnt logistic regression model.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/sdk/examples/intersection-set-sum/Makefile
+++ b/sdk/examples/intersection-set-sum/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/intersection-set-sum/src/main.rs
+++ b/sdk/examples/intersection-set-sum/src/main.rs
@@ -18,7 +18,7 @@
 //!                          a gradient and a Y-intercept, representing the best linear fit for the
 //!                          input data.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/sdk/examples/linear-regression/Makefile
+++ b/sdk/examples/linear-regression/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/linear-regression/src/main.rs
+++ b/sdk/examples/linear-regression/src/main.rs
@@ -16,7 +16,7 @@
 //!                          a gradient and a Y-intercept, representing the best linear fit for the
 //!                          input data.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/sdk/examples/logistic-regression/Makefile
+++ b/sdk/examples/logistic-regression/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/moving-average-convergence-divergence/Makefile
+++ b/sdk/examples/moving-average-convergence-divergence/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/moving-average-convergence-divergence/src/main.rs
+++ b/sdk/examples/moving-average-convergence-divergence/src/main.rs
@@ -15,7 +15,7 @@
 //! Assumed form of inputs:  a Pinecone-encoded Rust vector of `f64` values.
 //! Ensured form of outputs: A Pinecone-encoded Rust vector of `f64` values.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/sdk/examples/nop/Makefile
+++ b/sdk/examples/nop/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/nop/src/main.rs
+++ b/sdk/examples/nop/src/main.rs
@@ -1,6 +1,6 @@
 //! A trivial, no-operation example.
 //!
-//! ## Context
+//! ## Context
 //!
 //! A basic test for Veracruz.
 //!

--- a/sdk/examples/private-set-intersection-sum/Makefile
+++ b/sdk/examples/private-set-intersection-sum/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/private-set-intersection-sum/src/main.rs
+++ b/sdk/examples/private-set-intersection-sum/src/main.rs
@@ -6,7 +6,7 @@
 //! Assumed form of inputs:  an arbitrary number of Pinecone-encoded `HashSet<Person>` (see below).
 //! Ensured form of outputs: A Pinecone-encoded `HashSet<Person>` (see below).
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/sdk/examples/private-set-intersection/Makefile
+++ b/sdk/examples/private-set-intersection/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/private-set-intersection/src/main.rs
+++ b/sdk/examples/private-set-intersection/src/main.rs
@@ -1,6 +1,6 @@
 //! Private set intersection example.
 //!
-//! ## Context
+//! ## Context
 //!
 //! Inputs:                  an arbitrary number.
 //! Assumed form of inputs:  an arbitrary number of Pinecone-encoded `HashSet<Person>` (see below).

--- a/sdk/examples/random-source/Makefile
+++ b/sdk/examples/random-source/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/random-source/src/main.rs
+++ b/sdk/examples/random-source/src/main.rs
@@ -1,6 +1,6 @@
 //! Test of the trusted random source platform service.
 //!
-//! ## Context
+//! ## Context
 //!
 //! Test program for random number generation.
 //!
@@ -14,7 +14,7 @@
 //!
 //! The Veracruz Development Team.
 //!
-//! ## Copyright
+//! ## Copyright
 //!
 //! See the file `LICENSING.markdown` in the Veracruz root directory for licensing
 //! and copyright information.

--- a/sdk/examples/string-edit-distance/Makefile
+++ b/sdk/examples/string-edit-distance/Makefile
@@ -10,10 +10,13 @@ endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/examples/string-edit-distance/src/main.rs
+++ b/sdk/examples/string-edit-distance/src/main.rs
@@ -1,6 +1,6 @@
 //! String edit distance of two UTF-8 strings.
 //!
-//! ## Context
+//! ## Context
 //!
 //! Inputs:                  2.
 //! Assumed form of inputs:  UTF-8 strings to compare.
@@ -12,7 +12,7 @@
 //!
 //! The Veracruz Development Team.
 //!
-//! ## Copyright
+//! ## Copyright
 //!
 //! See the file `LICENSING.markdown` in the Veracruz root directory for licensing
 //! and copyright information.

--- a/sdk/freestanding-chihuahua/Makefile
+++ b/sdk/freestanding-chihuahua/Makefile
@@ -9,10 +9,13 @@
 # See the `LICENSE.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
 
-.PHONY: all clean fmt
+.PHONY: all clean doc fmt
 
 all:
 	cargo build --release
+
+doc:
+	cargo doc
 
 fmt:
 	cargo fmt

--- a/sdk/libveracruz/Makefile
+++ b/sdk/libveracruz/Makefile
@@ -1,3 +1,14 @@
+# Makefile for Rust libveracruz
+#
+# # Authors
+#
+# The Veracruz Development Team.
+#
+# # Copyright and licensing
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
 PLATFORM = $(shell uname)
 
 ifeq ($(PLATFORM), Darwin)

--- a/sdk/libveracruz/Makefile
+++ b/sdk/libveracruz/Makefile
@@ -13,6 +13,9 @@ VERACRUZ_TARGET_PATH = $(shell cd ../ && pwd)
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
 
+doc:
+	cargo doc
+
 fmt:
 	cargo fmt
 

--- a/sdk/libveracruz/Makefile
+++ b/sdk/libveracruz/Makefile
@@ -1,13 +1,15 @@
 # Makefile for Rust libveracruz
 #
-# # Authors
+# AUTHORS
 #
 # The Veracruz Development Team.
 #
-# # Copyright and licensing
+# COPYRIGHT AND LICENSING
 #
 # See the `LICENSE.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
+
+.PHONY: all clean doc fmt
 
 PLATFORM = $(shell uname)
 

--- a/sdk/libveracruz/src/data_description.rs
+++ b/sdk/libveracruz/src/data_description.rs
@@ -16,7 +16,7 @@ use crate::return_code;
 use serde::Serialize;
 
 /// A function that writes a result back to the Veracruz host. The function
-/// fails with [`result_type::ErrorCode::InvariantFailed`] if the return value cannot be encoded as
+/// fails with [`return_code::ErrorCode::InvariantFailed`] if the return value cannot be encoded as
 /// Pinecone, or if the synthesized function has been called once already.
 pub fn write_result<T: Serialize>(result: T) -> return_code::Veracruz {
     match pinecone::to_vec(&result) {

--- a/sdk/veracruz-rt/Makefile
+++ b/sdk/veracruz-rt/Makefile
@@ -1,3 +1,14 @@
+# Makefile for the Veracruz runtime library
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT AND LICENSING
+#
+# See the `LICENSE.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
 PLATFORM = $(shell uname)
 
 ifeq ($(PLATFORM), Darwin)
@@ -7,6 +18,8 @@ endif
 ifeq ($(PLATFORM), Linux)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
+
+.PHONY: all clean doc fmt
 
 VERACRUZ_TARGET_PATH = $(shell cd ../ && pwd)
 

--- a/sdk/veracruz-rt/Makefile
+++ b/sdk/veracruz-rt/Makefile
@@ -13,6 +13,9 @@ VERACRUZ_TARGET_PATH = $(shell cd ../ && pwd)
 all:
 	XARGO_RUST_SRC=$(RUST_STDLIB_SRC_DIR) RUST_TARGET_PATH=$(VERACRUZ_TARGET_PATH) xargo build --target wasm32-arm-veracruz --release
 
+doc:
+	cargo doc
+
 fmt:
 	cargo fmt
 


### PR DESCRIPTION
As part of a wider task of getting Rustdoc built for the entire Veracruz codebase, where appropriate, this change adds:

- New Makefile targets for building Rustdocs for the major components of the Veracruz SDK,
- Various fixes to Rustdocs appearing in source files in the SDK,
- Fixes to the Rustdocs appearing in `chihuahua`.

Documentation for the SDK can now be built by typing `make doc` in the top-level SDK Makefile.  Documentation appears under `target/doc/` in each subdirectory of the SDK, e.g. `examples/linear-regression/target/doc/linear-regression/index.html`.