### PR TITLE
futures-fix: added compiler pragma to test source files

### DIFF
--- a/durango/src/lib.rs
+++ b/durango/src/lib.rs
@@ -9,6 +9,9 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+// NB: added to avoid a compile-failure in Rust's futures library.
+#![feature(proc_macro_hygiene)]
+
 pub mod durango;
 pub use self::durango::*;
 pub mod attestation;

--- a/durango/src/tests.rs
+++ b/durango/src/tests.rs
@@ -17,9 +17,6 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-// NB: added to avoid a compile-failure in Rust's future's library.
-#![feature(proc_macro_hygiene)]
-
 const POLICY_FILENAME: &'static str = "../test-collateral/one_data_source_policy.json";
 const TRIPLE_POLICY_FILENAME: &'static str = "../test-collateral/triple_policy.json";
 const CLIENT_CERT_FILENAME: &'static str = "../test-collateral/client_rsa_cert.pem";

--- a/durango/src/tests.rs
+++ b/durango/src/tests.rs
@@ -17,6 +17,9 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+// NB: added to avoid a compile-failure in Rust's future's library.
+#![feature(proc_macro_hygiene)]
+
 const POLICY_FILENAME: &'static str = "../test-collateral/one_data_source_policy.json";
 const TRIPLE_POLICY_FILENAME: &'static str = "../test-collateral/triple_policy.json";
 const CLIENT_CERT_FILENAME: &'static str = "../test-collateral/client_rsa_cert.pem";

--- a/veracruz-test/src/main.rs
+++ b/veracruz-test/src/main.rs
@@ -12,6 +12,9 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+// NB: added to avoid a compile failure in Rust's futures library.
+#![feature(proc_macro_hygiene)]
+
 #[cfg(test)]
 mod tests {
     // Policies


### PR DESCRIPTION
To fix a regression in the Rust futures library.