### PR TITLE
Handle unhandled error related to execution strategy selection in Mexico City

### DIFF
--- a/mexico-city/src/managers/baja_manager.rs
+++ b/mexico-city/src/managers/baja_manager.rs
@@ -24,11 +24,9 @@ pub fn init_baja(policy_json: &str) -> Result<(), MexicoCityError> {
     }
 
     {
+        let state = ProtocolState::new(policy.clone(), hex::encode(policy_hash.as_ref()))?;
         let mut protocol_state = super::PROTOCOL_STATE.lock()?;
-        *protocol_state = Some(ProtocolState::new(
-            policy.clone(),
-            hex::encode(policy_hash.as_ref()),
-        ));
+        *protocol_state = Some(state);
     }
 
     //TODO: change the error type

--- a/mexico-city/src/managers/error.rs
+++ b/mexico-city/src/managers/error.rs
@@ -38,6 +38,8 @@ pub enum MexicoCityError {
     UnsafeCallError(&'static str, u32),
     #[error(display = "MexicoCity: Received no data.")]
     NoDataError,
+    #[error(display = "MexicoCity: Global policy requested an execution strategy unavailable on this platform.")]
+    InvalidExecutionStrategyError,
     #[error(display = "MexicoCity: Unavailable baja session with ID {}.", _0)]
     UnavailableBajaSessionError(u64),
     #[error(display = "MexicoCity: Unavailable protocol state.")]

--- a/mexico-city/src/managers/mod.rs
+++ b/mexico-city/src/managers/mod.rs
@@ -122,7 +122,7 @@ impl ProtocolState {
             veracruz_utils::ExecutionStrategy::JIT => chihuahua::factory::ExecutionStrategy::JIT,
         };
 
-        match multi_threaded_chihuahua(
+        let host_state = multi_threaded_chihuahua(
             &execution_strategy,
             &expected_data_sources,
             expected_shutdown_sources
@@ -130,14 +130,14 @@ impl ProtocolState {
                 .map(|e| *e as u64)
                 .collect::<Vec<u64>>()
                 .as_slice(),
-        ) {
-            None => Err(MexicoCityError::InvalidExecutionStrategyError),
-            Some(host_state) => ProtocolState {
-                host_state,
-                global_policy,
-                global_policy_hash,
-            },
-        }
+        )
+        .ok_or(MexicoCityError::InvalidExecutionStrategyError)?;
+
+        Ok(ProtocolState {
+            host_state,
+            global_policy,
+            global_policy_hash,
+        })
     }
 
     /// Returns the global policy associated with the protocol state.


### PR DESCRIPTION
1. Removed `unwrap()` in `ProvisioningState::new()` that caused a runtime-failure if the selected execution strategy is not available for the given platform.
2. Added a new MexicoCityError case corresponding to this situation.
3. Explicitly handled the error in baja_manager.rs, propagating it upward.