### PR TITLE
Minor modification before using the new docker image

### DIFF
--- a/jalisco/Makefile
+++ b/jalisco/Makefile
@@ -49,7 +49,6 @@ $(OUT_DIR)/stripped_ta: $(OUT_DIR)/jalisco
 
 $(OUT_DIR)/jalisco: $(TZ_Src)
 	@echo $(INFO_COLOR)"XARGO <=  $(TZ_Src)" $(RESET_COLOR)
-	cargo fmt
 	@xargo build --target $(TZ_TARGET) --release -vv --out-dir $(OUT_DIR) -Z unstable-options
 	@echo $(INFO_COLOR)"GEN   =>  jalisco" $(RESET_COLOR)
 

--- a/sdk/rust-language-support/examples/idash2017-logistic-regression/Makefile
+++ b/sdk/rust-language-support/examples/idash2017-logistic-regression/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/idash2017-logistic-regression/Makefile
+++ b/sdk/rust-language-support/examples/idash2017-logistic-regression/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/intersection-set-sum/Makefile
+++ b/sdk/rust-language-support/examples/intersection-set-sum/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/intersection-set-sum/Makefile
+++ b/sdk/rust-language-support/examples/intersection-set-sum/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/linear-regression/Makefile
+++ b/sdk/rust-language-support/examples/linear-regression/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/linear-regression/Makefile
+++ b/sdk/rust-language-support/examples/linear-regression/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/logistic-regression/Makefile
+++ b/sdk/rust-language-support/examples/logistic-regression/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/logistic-regression/Makefile
+++ b/sdk/rust-language-support/examples/logistic-regression/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/moving-average-convergence-divergence/Makefile
+++ b/sdk/rust-language-support/examples/moving-average-convergence-divergence/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/moving-average-convergence-divergence/Makefile
+++ b/sdk/rust-language-support/examples/moving-average-convergence-divergence/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/nop/Makefile
+++ b/sdk/rust-language-support/examples/nop/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/nop/Makefile
+++ b/sdk/rust-language-support/examples/nop/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/number-stream-accumulation/Makefile
+++ b/sdk/rust-language-support/examples/number-stream-accumulation/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/number-stream-accumulation/Makefile
+++ b/sdk/rust-language-support/examples/number-stream-accumulation/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/private-set-intersection-sum/Makefile
+++ b/sdk/rust-language-support/examples/private-set-intersection-sum/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/private-set-intersection-sum/Makefile
+++ b/sdk/rust-language-support/examples/private-set-intersection-sum/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/private-set-intersection/Makefile
+++ b/sdk/rust-language-support/examples/private-set-intersection/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/private-set-intersection/Makefile
+++ b/sdk/rust-language-support/examples/private-set-intersection/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/random-source/Makefile
+++ b/sdk/rust-language-support/examples/random-source/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/random-source/Makefile
+++ b/sdk/rust-language-support/examples/random-source/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/string-edit-distance/Makefile
+++ b/sdk/rust-language-support/examples/string-edit-distance/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/examples/string-edit-distance/Makefile
+++ b/sdk/rust-language-support/examples/string-edit-distance/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)

--- a/sdk/rust-language-support/libveracruz/Makefile
+++ b/sdk/rust-language-support/libveracruz/Makefile
@@ -12,13 +12,14 @@
 .PHONY: all clean doc fmt
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)

--- a/sdk/rust-language-support/libveracruz/Makefile
+++ b/sdk/rust-language-support/libveracruz/Makefile
@@ -12,14 +12,14 @@
 .PHONY: all clean doc fmt
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 VERACRUZ_TARGET_PATH = $(shell cd ../../ && pwd)

--- a/sdk/rust-language-support/veracruz-rt/Makefile
+++ b/sdk/rust-language-support/veracruz-rt/Makefile
@@ -10,13 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
+RUSTUP_PATH ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 .PHONY: all clean doc fmt

--- a/sdk/rust-language-support/veracruz-rt/Makefile
+++ b/sdk/rust-language-support/veracruz-rt/Makefile
@@ -10,14 +10,14 @@
 # licensing and copyright information.
 
 PLATFORM = $(shell uname)
-RUSTUP_PATH ?= ~/.rustup
+RUSTUP_HOME ?= ~/.rustup
 
 ifeq ($(PLATFORM), Darwin)
 	RUST_STDLIB_SRC_DIR ?= ~/.rustup/toolchains/nightly-2020-05-07-x86_64-apple-darwin/lib/rustlib/src/rust/src
 endif
 
 ifeq ($(PLATFORM), Linux)
-	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_PATH)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
+	RUST_STDLIB_SRC_DIR ?= $(RUSTUP_HOME)/toolchains/nightly-2020-05-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src
 endif
 
 .PHONY: all clean doc fmt


### PR DESCRIPTION
This commit contains minor changes to veracruz that is necessary for the [new docker image](https://github.com/veracruz-project/veracruz-docker-image/pull/2):
- Use `RUSTUP_PATH` variable in compiling sdk. The variable points to the path to rustup directory with the default being ~/.rustup.
- remove a `cargo fmt` when compiling jalisco. It is not a necessary step and the new minimum image does not have cargo-fmt. 

NOTE: it is backward compatible, hence it should be able to be merged without breaking in the old image.