### PR TITLE
Cleanup and refactoring throughout the Baja codebase

### DIFF
--- a/baja/src/baja.rs
+++ b/baja/src/baja.rs
@@ -349,17 +349,17 @@ impl Baja {
         // temporary problems on TrustZone, so instead of randomly generating
         // it, we're using a fixed value for now.  This **does not** compromise
         // the security of the system in any way.
-        let name = {
-            // let mut temp = vec![0; 3];
-            // let rng = SystemRandom::new();
-            // rng.fill(&mut temp).map_err(|_| "Error generating random bytes")?;
-            // It must be a valid DNS name, which must not be all numeric
-            // so we add an a at the beginning to be sure
-            // let full_string =
-            //   format!("a{:02x}{:02x}{:02x}", temp[0], temp[1], temp[2]);
-            // full_string[..7].to_string()
-            FIXED_SERVER_NAME.to_string()
-        };
+        //
+        // let mut temp = vec![0; 3];
+        // let rng = SystemRandom::new();
+        // rng.fill(&mut temp).map_err(|_| "Error generating random bytes")?;
+        // It must be a valid DNS name, which must not be all numeric
+        // so we add an a at the beginning to be sure
+        // let full_string =
+        //   format!("a{:02x}{:02x}{:02x}", temp[0], temp[1], temp[2]);
+        // full_string[..7].to_string()
+
+        let name = FIXED_SERVER_NAME.to_string();
 
         let server_certificate_buffer = generate_certificate(
             name.clone().into_bytes(),

--- a/baja/src/baja.rs
+++ b/baja/src/baja.rs
@@ -1,4 +1,7 @@
-//! Baja
+//! Baja contexts
+//!
+//! Contexts contain meta-data, such as certificates and principals and their
+//! roles, necessary to establish and manage a Baja session.
 //!
 //! ## Authors
 //!
@@ -9,96 +12,122 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use super::BajaError;
-use crate::baja_session::BajaSession;
-use ring;
-use rustls;
-use std::string::{String, ToString};
-use std::vec::Vec;
-use veracruz_utils;
+use std::{
+    io::Cursor,
+    string::{String, ToString},
+    vec::Vec,
+};
 
-pub struct Baja {
-    pub server_cert_buffer: Vec<u8>,
-    pub server_cert: rustls::Certificate,
-    pub server_config: rustls::ServerConfig,
-    pub policy: veracruz_utils::VeracruzPolicy,
-    pub name: String,
-    client_identities: Vec<(u32, rustls::Certificate, Vec<veracruz_utils::VeracruzRole>)>,
-}
+use crate::{
+    baja_session::{BajaSession, Principal},
+    error::BajaError,
+};
+use veracruz_utils::{VeracruzPolicy, VeracruzRole};
 
+use ring::{rand::SystemRandom, signature::EcdsaKeyPair};
+use rustls::{AllowAnyAuthenticatedClient, Certificate, CipherSuite, RootCertStore, ServerConfig};
+
+////////////////////////////////////////////////////////////////////////////////
+// Constants.
+////////////////////////////////////////////////////////////////////////////////
+
+/// The template of bytes for the cryptographic certificate.
+const CERTIFICATE_TEMPLATE: [u8; 536] = [
+    0x30, 0x82, 0x02, 0x14, 0x30, 0x82, 0x01, 0xb9, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x14, 0x44,
+    0x82, 0x4b, 0x6c, 0x8d, 0xb7, 0x8c, 0x7d, 0x94, 0xd9, 0x56, 0x8f, 0x1e, 0xd2, 0x42, 0xc1, 0xd2,
+    0x3a, 0x5e, 0xc9, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x30,
+    0x77, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03, 0x55, 0x04, 0x06, 0x13, 0x02, 0x55, 0x53, 0x31, 0x0e,
+    0x30, 0x0c, 0x06, 0x03, 0x55, 0x04, 0x08, 0x0c, 0x05, 0x54, 0x65, 0x78, 0x61, 0x73, 0x31, 0x0f,
+    0x30, 0x0d, 0x06, 0x03, 0x55, 0x04, 0x07, 0x0c, 0x06, 0x41, 0x75, 0x73, 0x74, 0x69, 0x6e, 0x31,
+    0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x0a, 0x0c, 0x07, 0x41, 0x72, 0x6d, 0x20, 0x4c, 0x74,
+    0x64, 0x31, 0x23, 0x30, 0x21, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01,
+    0x16, 0x14, 0x64, 0x65, 0x72, 0x65, 0x6b, 0x2e, 0x6d, 0x69, 0x6c, 0x6c, 0x65, 0x72, 0x40, 0x61,
+    0x72, 0x6d, 0x2e, 0x63, 0x6f, 0x6d, 0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c,
+    0x07, 0x61, 0x62, 0x63, 0x66, 0x64, 0x34, 0x62, 0x30, 0x1e, 0x17, 0x0d, 0x31, 0x39, 0x30, 0x37,
+    0x30, 0x38, 0x32, 0x31, 0x35, 0x33, 0x35, 0x31, 0x5a, 0x17, 0x0d, 0x31, 0x39, 0x30, 0x37, 0x30,
+    0x39, 0x32, 0x31, 0x35, 0x33, 0x35, 0x31, 0x5a, 0x30, 0x77, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03,
+    0x55, 0x04, 0x06, 0x13, 0x02, 0x55, 0x53, 0x31, 0x0e, 0x30, 0x0c, 0x06, 0x03, 0x55, 0x04, 0x08,
+    0x0c, 0x05, 0x54, 0x65, 0x78, 0x61, 0x73, 0x31, 0x0f, 0x30, 0x0d, 0x06, 0x03, 0x55, 0x04, 0x07,
+    0x0c, 0x06, 0x41, 0x75, 0x73, 0x74, 0x69, 0x6e, 0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04,
+    0x0a, 0x0c, 0x07, 0x41, 0x72, 0x6d, 0x20, 0x4c, 0x74, 0x64, 0x31, 0x23, 0x30, 0x21, 0x06, 0x09,
+    0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01, 0x16, 0x14, 0x64, 0x65, 0x72, 0x65, 0x6b,
+    0x2e, 0x6d, 0x69, 0x6c, 0x6c, 0x65, 0x72, 0x40, 0x61, 0x72, 0x6d, 0x2e, 0x63, 0x6f, 0x6d, 0x31,
+    0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x07, 0x61, 0x72, 0x6d, 0x2e, 0x63, 0x6f,
+    0x6d, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08,
+    0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0x10, 0x68, 0x37, 0xed,
+    0x72, 0x4e, 0x16, 0x1d, 0xd1, 0x3e, 0x0a, 0x55, 0x4b, 0xf9, 0xfd, 0x7b, 0x6c, 0x78, 0x2c, 0x19,
+    0xbc, 0xec, 0xd5, 0x58, 0x16, 0x4e, 0x9a, 0xb2, 0xae, 0x1b, 0x26, 0x43, 0x54, 0xf3, 0x6d, 0x68,
+    0xaf, 0x1d, 0x9f, 0xde, 0xb9, 0x06, 0xbd, 0xb7, 0xc4, 0x16, 0xac, 0xf7, 0x62, 0x49, 0x40, 0x2f,
+    0xc1, 0xad, 0x39, 0xc0, 0xb5, 0x94, 0xc8, 0xd8, 0x4f, 0x89, 0xe1, 0x37, 0xa3, 0x23, 0x30, 0x21,
+    0x30, 0x1f, 0x06, 0x03, 0x55, 0x1d, 0x11, 0x04, 0x18, 0x30, 0x16, 0x82, 0x07, 0x61, 0x62, 0x63,
+    0x66, 0x64, 0x34, 0x62, 0x82, 0x0b, 0x77, 0x77, 0x77, 0x2e, 0x61, 0x62, 0x63, 0x66, 0x64, 0x34,
+    0x62, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x03, 0x49, 0x00,
+    0x30, 0x46, 0x02, 0x21, 0x00, 0x30, 0x45, 0x02, 0x21, 0x00, 0xca, 0x59, 0xa4, 0x52, 0x46, 0x6c,
+    0x7d, 0xe7, 0x7a, 0x1f, 0xe0, 0xa3, 0x9b, 0xb4, 0x79, 0x64, 0x44, 0x97, 0x53, 0x29, 0x79, 0x36,
+    0xac, 0x65, 0xa2, 0x66, 0x33, 0x02, 0x21, 0x00, 0x12, 0xc2, 0xd2, 0x08, 0x65, 0x02, 0x20, 0x18,
+    0x7d, 0x2d, 0x36, 0xe1, 0x68, 0x6a, 0x39, 0x65, 0xc8, 0x86, 0x94, 0xf3, 0xd1, 0x14, 0x16, 0xf7,
+    0xa1, 0xdb, 0x6e, 0x10, 0x33, 0x91, 0x91, 0x8f,
+];
+
+/// The
+const FIXED_SERVER_NAME: &str = "ac40a0c";
+
+/// The byte range in the certificate template where the issuer common name is
+/// found.  Lower limit is inclusive, upper limit exclusive.
+const ISSUER_COMMON_NAME_LOCATION: (usize, usize) = (161, 168);
+/// The byte range in the certificate template where the valid from date is
+/// found.  Lower limit is inclusive, upper limit exclusive.
+const VALIDITY_VALID_FROM_LOCATION: (usize, usize) = (172, 185);
+/// The byte range in the certificate template where the valid to date is
+/// found.  Lower limit is inclusive, upper limit exclusive.
+const VALIDITY_VALID_TO_LOCATION: (usize, usize) = (187, 200);
+/// The byte range in the certificate template where the subject common name is
+/// found.  Lower limit is inclusive, upper limit exclusive.
+const SUBJECT_COMMON_NAME_LOCATION: (usize, usize) = (314, 321);
+/// The byte range in the certificate template where the public key is
+/// found.  Lower limit is inclusive, upper limit exclusive.
+const PUBLIC_KEY_LOCATION: (usize, usize) = (344, 412);
+/// The byte range in the certificate template where the subject alternative
+/// first name is found.  Lower limit is inclusive, upper limit exclusive.
+const SUBJECT_ALT_NAME_FIRST_LOCATION: (usize, usize) = (429, 436);
+/// The byte range in the certificate template where the subject alternative
+/// second name is found.  Lower limit is inclusive, upper limit exclusive.
+const SUBJECT_ALT_NAME_SECOND_LOCATION: (usize, usize) = (442, 449);
+/// The byte range in the certificate template where the first part of the
+/// signature is found.  Lower limit is inclusive, upper limit exclusive.
+const SIGNATURE_PART_1_LOCATION: (usize, usize) = (469, 501);
+/// The byte range in the certificate template where the second part of the
+/// signature is found.  Lower limit is inclusive, upper limit exclusive.
+const SIGNATURE_PART_2_LOCATION: (usize, usize) = (504, 536);
+
+////////////////////////////////////////////////////////////////////////////////
+// Miscellaneous certificate-related material.
+////////////////////////////////////////////////////////////////////////////////
+
+/// Generates a cryptographic certificate using the template at the top of the
+/// file, filling in names, validity dates, and similar metadata by explicit
+/// splicing.
 fn generate_certificate(
-    common_name: &String,
-    private_key: &rustls::PrivateKey,
-    public_key: &Vec<u8>,
+    common_name_bytes: Vec<u8>,
+    private_key: rustls::PrivateKey,
+    public_key: Vec<u8>,
     policy: &veracruz_utils::VeracruzPolicy,
 ) -> Result<Vec<u8>, BajaError> {
-    let common_name_bytes = common_name.as_bytes();
-
-    let ring_private_key = ring::signature::EcdsaKeyPair::from_pkcs8(
+    let ring_private_key = EcdsaKeyPair::from_pkcs8(
         &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
         &private_key.0[..],
     )?;
 
-    let cert_template = vec![
-        0x30, 0x82, 0x02, 0x14, 0x30, 0x82, 0x01, 0xb9, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x14,
-        0x44, 0x82, 0x4b, 0x6c, 0x8d, 0xb7, 0x8c, 0x7d, 0x94, 0xd9, 0x56, 0x8f, 0x1e, 0xd2, 0x42,
-        0xc1, 0xd2, 0x3a, 0x5e, 0xc9, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04,
-        0x03, 0x02, 0x30, 0x77, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03, 0x55, 0x04, 0x06, 0x13, 0x02,
-        0x55, 0x53, 0x31, 0x0e, 0x30, 0x0c, 0x06, 0x03, 0x55, 0x04, 0x08, 0x0c, 0x05, 0x54, 0x65,
-        0x78, 0x61, 0x73, 0x31, 0x0f, 0x30, 0x0d, 0x06, 0x03, 0x55, 0x04, 0x07, 0x0c, 0x06, 0x41,
-        0x75, 0x73, 0x74, 0x69, 0x6e, 0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x0a, 0x0c,
-        0x07, 0x41, 0x72, 0x6d, 0x20, 0x4c, 0x74, 0x64, 0x31, 0x23, 0x30, 0x21, 0x06, 0x09, 0x2a,
-        0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01, 0x16, 0x14, 0x64, 0x65, 0x72, 0x65, 0x6b,
-        0x2e, 0x6d, 0x69, 0x6c, 0x6c, 0x65, 0x72, 0x40, 0x61, 0x72, 0x6d, 0x2e, 0x63, 0x6f, 0x6d,
-        0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x07, 0x61, 0x62, 0x63, 0x66,
-        0x64, 0x34, 0x62, 0x30, 0x1e, 0x17, 0x0d, 0x31, 0x39, 0x30, 0x37, 0x30, 0x38, 0x32, 0x31,
-        0x35, 0x33, 0x35, 0x31, 0x5a, 0x17, 0x0d, 0x31, 0x39, 0x30, 0x37, 0x30, 0x39, 0x32, 0x31,
-        0x35, 0x33, 0x35, 0x31, 0x5a, 0x30, 0x77, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03, 0x55, 0x04,
-        0x06, 0x13, 0x02, 0x55, 0x53, 0x31, 0x0e, 0x30, 0x0c, 0x06, 0x03, 0x55, 0x04, 0x08, 0x0c,
-        0x05, 0x54, 0x65, 0x78, 0x61, 0x73, 0x31, 0x0f, 0x30, 0x0d, 0x06, 0x03, 0x55, 0x04, 0x07,
-        0x0c, 0x06, 0x41, 0x75, 0x73, 0x74, 0x69, 0x6e, 0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55,
-        0x04, 0x0a, 0x0c, 0x07, 0x41, 0x72, 0x6d, 0x20, 0x4c, 0x74, 0x64, 0x31, 0x23, 0x30, 0x21,
-        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01, 0x16, 0x14, 0x64, 0x65,
-        0x72, 0x65, 0x6b, 0x2e, 0x6d, 0x69, 0x6c, 0x6c, 0x65, 0x72, 0x40, 0x61, 0x72, 0x6d, 0x2e,
-        0x63, 0x6f, 0x6d, 0x31, 0x10, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x07, 0x61,
-        0x72, 0x6d, 0x2e, 0x63, 0x6f, 0x6d, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48,
-        0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03,
-        0x42, 0x00, 0x04, 0x10, 0x68, 0x37, 0xed, 0x72, 0x4e, 0x16, 0x1d, 0xd1, 0x3e, 0x0a, 0x55,
-        0x4b, 0xf9, 0xfd, 0x7b, 0x6c, 0x78, 0x2c, 0x19, 0xbc, 0xec, 0xd5, 0x58, 0x16, 0x4e, 0x9a,
-        0xb2, 0xae, 0x1b, 0x26, 0x43, 0x54, 0xf3, 0x6d, 0x68, 0xaf, 0x1d, 0x9f, 0xde, 0xb9, 0x06,
-        0xbd, 0xb7, 0xc4, 0x16, 0xac, 0xf7, 0x62, 0x49, 0x40, 0x2f, 0xc1, 0xad, 0x39, 0xc0, 0xb5,
-        0x94, 0xc8, 0xd8, 0x4f, 0x89, 0xe1, 0x37, 0xa3, 0x23, 0x30, 0x21, 0x30, 0x1f, 0x06, 0x03,
-        0x55, 0x1d, 0x11, 0x04, 0x18, 0x30, 0x16, 0x82, 0x07, 0x61, 0x62, 0x63, 0x66, 0x64, 0x34,
-        0x62, 0x82, 0x0b, 0x77, 0x77, 0x77, 0x2e, 0x61, 0x62, 0x63, 0x66, 0x64, 0x34, 0x62, 0x30,
-        0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x03, 0x49, 0x00, 0x30,
-        0x46, 0x02, 0x21, 0x00, 0x30, 0x45, 0x02, 0x21, 0x00, 0xca, 0x59, 0xa4, 0x52, 0x46, 0x6c,
-        0x7d, 0xe7, 0x7a, 0x1f, 0xe0, 0xa3, 0x9b, 0xb4, 0x79, 0x64, 0x44, 0x97, 0x53, 0x29, 0x79,
-        0x36, 0xac, 0x65, 0xa2, 0x66, 0x33, 0x02, 0x21, 0x00, 0x12, 0xc2, 0xd2, 0x08, 0x65, 0x02,
-        0x20, 0x18, 0x7d, 0x2d, 0x36, 0xe1, 0x68, 0x6a, 0x39, 0x65, 0xc8, 0x86, 0x94, 0xf3, 0xd1,
-        0x14, 0x16, 0xf7, 0xa1, 0xdb, 0x6e, 0x10, 0x33, 0x91, 0x91, 0x8f,
-    ];
+    let mut constructed_cert = CERTIFICATE_TEMPLATE.to_vec();
 
-    // The following locations follow Rust's Range symantics. Lower bound is inclusive, upper bound is exclusive
-    let issuer_common_name_location = (161, 168);
-    let validity_valid_from_location = (172, 185);
-    let validity_valid_to_location = (187, 200);
-    let subject_common_name_location = (314, 321);
-    let public_key_location = (344, 412);
-    let subject_alt_name_first_location = (429, 436);
-    let subject_alt_name_second_location = (442, 449);
-    let signature_part_1_location = (469, 501);
-    let signature_part_2_location = (504, 536);
-
-    let mut constructed_cert = cert_template.clone();
-
-    if common_name_bytes.len() != (issuer_common_name_location.1 - issuer_common_name_location.0) {
+    if common_name_bytes.len() != (ISSUER_COMMON_NAME_LOCATION.1 - ISSUER_COMMON_NAME_LOCATION.0) {
         return Err(BajaError::InvalidLengthError(
             "common_name",
-            issuer_common_name_location.1 - issuer_common_name_location.0,
+            ISSUER_COMMON_NAME_LOCATION.1 - ISSUER_COMMON_NAME_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        issuer_common_name_location.0..issuer_common_name_location.1,
+        ISSUER_COMMON_NAME_LOCATION.0..ISSUER_COMMON_NAME_LOCATION.1,
         common_name_bytes.iter().cloned(),
     );
 
@@ -114,18 +143,18 @@ fn generate_certificate(
             "{:02}{:02}{:02}{:02}{:02}{:02}Z",
             year, month, day, hour, minute, second
         );
-        let valid_from_bytes = valid_from.as_bytes();
+        let valid_from_bytes = valid_from.as_bytes().to_vec();
         if valid_from_bytes.len()
-            != (validity_valid_from_location.1 - validity_valid_from_location.0)
+            != (VALIDITY_VALID_FROM_LOCATION.1 - VALIDITY_VALID_FROM_LOCATION.0)
         {
             return Err(BajaError::InvalidLengthError(
                 "valid_from_bytes",
-                validity_valid_from_location.1 - validity_valid_from_location.0,
+                VALIDITY_VALID_FROM_LOCATION.1 - VALIDITY_VALID_FROM_LOCATION.0,
             ));
         }
         constructed_cert.splice(
-            validity_valid_from_location.0..validity_valid_from_location.1,
-            valid_from_bytes.iter().cloned(),
+            VALIDITY_VALID_FROM_LOCATION.0..VALIDITY_VALID_FROM_LOCATION.1,
+            valid_from_bytes.iter(),
         );
     }
 
@@ -137,95 +166,95 @@ fn generate_certificate(
             "{:02}{:02}{:02}{:02}{:02}{:02}Z",
             year, month, day, hour, minute, second
         );
-        let valid_to_bytes = valid_to.as_bytes();
-        if valid_to_bytes.len() != (validity_valid_to_location.1 - validity_valid_to_location.0) {
+        let valid_to_bytes = valid_to.as_bytes().to_vec();
+        if valid_to_bytes.len() != (VALIDITY_VALID_TO_LOCATION.1 - VALIDITY_VALID_TO_LOCATION.0) {
             return Err(BajaError::InvalidLengthError(
                 "valid_to_bytes",
-                validity_valid_to_location.1 - validity_valid_to_location.0,
+                VALIDITY_VALID_TO_LOCATION.1 - VALIDITY_VALID_TO_LOCATION.0,
             ));
         }
         constructed_cert.splice(
-            validity_valid_to_location.0..validity_valid_to_location.1,
-            valid_to_bytes.iter().cloned(),
+            VALIDITY_VALID_TO_LOCATION.0..VALIDITY_VALID_TO_LOCATION.1,
+            valid_to_bytes.iter(),
         );
     };
 
-    if common_name_bytes.len() != (subject_common_name_location.1 - subject_common_name_location.0)
+    if common_name_bytes.len() != (SUBJECT_COMMON_NAME_LOCATION.1 - SUBJECT_COMMON_NAME_LOCATION.0)
     {
         return Err(BajaError::InvalidLengthError(
             "common_name_bytes",
-            subject_common_name_location.1 - subject_common_name_location.0,
+            SUBJECT_COMMON_NAME_LOCATION.1 - SUBJECT_COMMON_NAME_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        subject_common_name_location.0..subject_common_name_location.1,
+        SUBJECT_COMMON_NAME_LOCATION.0..SUBJECT_COMMON_NAME_LOCATION.1,
         common_name_bytes.iter().cloned(),
     );
 
-    if public_key.len() != (public_key_location.1 - public_key_location.0) {
+    if public_key.len() != (PUBLIC_KEY_LOCATION.1 - PUBLIC_KEY_LOCATION.0) {
         return Err(BajaError::InvalidLengthError(
             "public_key",
-            public_key_location.1 - public_key_location.0,
+            PUBLIC_KEY_LOCATION.1 - PUBLIC_KEY_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        public_key_location.0..public_key_location.1,
+        PUBLIC_KEY_LOCATION.0..PUBLIC_KEY_LOCATION.1,
         public_key.iter().cloned(),
     );
 
     if common_name_bytes.len()
-        != (subject_alt_name_first_location.1 - subject_alt_name_first_location.0)
+        != (SUBJECT_ALT_NAME_FIRST_LOCATION.1 - SUBJECT_ALT_NAME_FIRST_LOCATION.0)
     {
         return Err(BajaError::InvalidLengthError(
             "common_name_bytes",
-            subject_alt_name_first_location.1 - subject_alt_name_first_location.0,
+            SUBJECT_ALT_NAME_FIRST_LOCATION.1 - SUBJECT_ALT_NAME_FIRST_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        subject_alt_name_first_location.0..subject_alt_name_first_location.1,
+        SUBJECT_ALT_NAME_FIRST_LOCATION.0..SUBJECT_ALT_NAME_FIRST_LOCATION.1,
         common_name_bytes.iter().cloned(),
     );
     if common_name_bytes.len()
-        != (subject_alt_name_second_location.1 - subject_alt_name_second_location.0)
+        != (SUBJECT_ALT_NAME_SECOND_LOCATION.1 - SUBJECT_ALT_NAME_SECOND_LOCATION.0)
     {
         return Err(BajaError::InvalidLengthError(
             "common_name_bytes",
-            subject_alt_name_second_location.1 - subject_alt_name_second_location.0,
+            SUBJECT_ALT_NAME_SECOND_LOCATION.1 - SUBJECT_ALT_NAME_SECOND_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        subject_alt_name_second_location.0..subject_alt_name_second_location.1,
+        SUBJECT_ALT_NAME_SECOND_LOCATION.0..SUBJECT_ALT_NAME_SECOND_LOCATION.1,
         common_name_bytes.iter().cloned(),
     );
 
-    let rng = ring::rand::SystemRandom::new();
+    let rng = SystemRandom::new();
     let signature = ring_private_key.sign(&rng, &constructed_cert[..])?;
 
     let signature_vec = signature.as_ref();
 
     let mut signature_first_vec = vec![0; 32];
     signature_first_vec[..].clone_from_slice(&signature_vec[0..32]);
-    if signature_first_vec.len() != (signature_part_1_location.1 - signature_part_1_location.0) {
+    if signature_first_vec.len() != (SIGNATURE_PART_1_LOCATION.1 - SIGNATURE_PART_1_LOCATION.0) {
         return Err(BajaError::InvalidLengthError(
             "signature_first_vec",
-            signature_part_1_location.1 - signature_part_1_location.0,
+            SIGNATURE_PART_1_LOCATION.1 - SIGNATURE_PART_1_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        signature_part_1_location.0..signature_part_1_location.1,
+        SIGNATURE_PART_1_LOCATION.0..SIGNATURE_PART_1_LOCATION.1,
         signature_first_vec.iter().cloned(),
     );
 
     let mut signature_second_vec = vec![0; 32];
     signature_second_vec[..].clone_from_slice(&signature_vec[32..64]);
-    if signature_second_vec.len() != (signature_part_2_location.1 - signature_part_2_location.0) {
+    if signature_second_vec.len() != (SIGNATURE_PART_2_LOCATION.1 - SIGNATURE_PART_2_LOCATION.0) {
         return Err(BajaError::InvalidLengthError(
             "signature_second_vec",
-            signature_part_2_location.1 - signature_part_2_location.0,
+            SIGNATURE_PART_2_LOCATION.1 - SIGNATURE_PART_2_LOCATION.0,
         ));
     }
     constructed_cert.splice(
-        signature_part_2_location.0..signature_part_2_location.1,
+        SIGNATURE_PART_2_LOCATION.0..SIGNATURE_PART_2_LOCATION.1,
         signature_second_vec.iter().cloned(),
     );
 
@@ -239,41 +268,69 @@ fn generate_certificate(
     }
 }
 
-fn convert_cert_buffer(cert_string: &String) -> Result<rustls::Certificate, BajaError> {
-    let mut cursor = std::io::Cursor::new(cert_string);
+/// Converts a string into a parsed X509 cryptographic certificate.
+fn convert_cert_buffer<'a, U>(cert_string: U) -> Result<Certificate, BajaError>
+where
+    U: Into<&'a String>,
+{
+    let mut cursor = Cursor::new(cert_string.into());
     rustls::internal::pemfile::certs(&mut cursor)
         .map_err(|_| BajaError::TLSUnspecifiedError)
         .and_then(|certs| {
-            if certs.len() > 0 {
-                Ok(certs[0].clone())
-            } else {
+            if certs.is_empty() {
                 Err(BajaError::NoCertificateError)
+            } else {
+                Ok(certs[0].clone())
             }
         })
 }
 
-//fn search_client_id()
+////////////////////////////////////////////////////////////////////////////////
+// The Baja context.
+////////////////////////////////////////////////////////////////////////////////
+
+/// A Baja context contains various bits of meta-data, such as certificates and
+/// server configuration options, for managing a Baja server session.
+pub struct Baja {
+    /// A buffer for storing an unparsed PEM certificate for the server.
+    server_certificate_buffer: Vec<u8>,
+    /// The parsed PEM certificate for the server.
+    server_certificate: Certificate,
+    /// The configuration options for the server.
+    server_config: ServerConfig,
+    /// The global policy associated with the Veracruz computation, detailing
+    /// identities and roles for all principals, amongst other things.
+    policy: VeracruzPolicy,
+    /// A randomly generated name for the server.
+    name: String,
+    /// The set of principals, as specified in the Veracruz global policy, with
+    /// their identifying certificates and roles.
+    principals: Vec<Principal>,
+}
 
 impl Baja {
-    pub fn new(policy: veracruz_utils::VeracruzPolicy) -> Result<Self, BajaError> {
+    /// Creates a new Baja context using the global Veracruz policy, `policy`.
+    pub fn new(policy: VeracruzPolicy) -> Result<Self, BajaError> {
         // create the root_cert_store that contains all of the certs of the clients that can connect
         // Note: We are not using a CA here, so each client that needs to connect must have it's
         // cert directly in the RootCertStore
-        let mut root_cert_store = rustls::RootCertStore::empty();
-        let mut client_identities = Vec::new();
-        for this_identity in policy.identities().iter() {
-            let cert = convert_cert_buffer(&this_identity.certificate())?;
-            let _ = root_cert_store.add(&cert)?;
-            client_identities.push((
-                this_identity.id().clone(),
-                cert,
-                this_identity.roles().clone(),
-            ));
+        let mut root_cert_store = RootCertStore::empty();
+        let mut principals = Vec::new();
+
+        for identity in policy.identities().iter() {
+            let cert = convert_cert_buffer(&identity.certificate())?;
+            let mut principal = Principal::new(*identity.id(), cert);
+
+            principal.add_roles(identity.roles().iter());
+            root_cert_store.add(&cert)?;
+
+            principals.push(principal);
         }
+
         let (server_private_key, server_public_key) = {
-            let rng = ring::rand::SystemRandom::new();
+            let rng = SystemRandom::new();
             // ECDSA prime256r1 generation.
-            let pkcs8_bytes = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            let pkcs8_bytes = EcdsaKeyPair::generate_pkcs8(
                 &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
                 &rng,
             )?;
@@ -283,48 +340,53 @@ impl Baja {
             )
         };
 
-        let common_name = {
-            // This should be randomly generated as below. But this is causing
-            // temporary problems on Trustzone, so instead of randomly generating
-            // it, we're using a static value for now.
-            // This does not compromise the security of the system
-            //let mut temp = vec![0; 3];
-
-            //let rng = ring::rand::SystemRandom::new();
-            //rng.fill(&mut temp)
-            //.map_err(|_| "Error generating random bytes")?;
+        // NOTE: this should be randomly generated as below. But this is causing
+        // temporary problems on TrustZone, so instead of randomly generating
+        // it, we're using a fixed value for now.  This **does not** compromise
+        // the security of the system in any way.
+        let name = {
+            // let mut temp = vec![0; 3];
+            // let rng = SystemRandom::new();
+            // rng.fill(&mut temp).map_err(|_| "Error generating random bytes")?;
             // It must be a valid DNS name, which must not be all numeric
             // so we add an a at the beginning to be sure
-            //let full_string = format!("a{:02x}{:02x}{:02x}", temp[0], temp[1], temp[2]);
-            //full_string[..7].to_string()
-            "ac40a0c".to_string()
+            // let full_string =
+            //   format!("a{:02x}{:02x}{:02x}", temp[0], temp[1], temp[2]);
+            // full_string[..7].to_string()
+            FIXED_SERVER_NAME.to_string()
         };
-        let server_cert_buffer = generate_certificate(
-            &common_name,
-            &server_private_key,
-            &server_public_key,
+
+        let server_certificate_buffer = generate_certificate(
+            name.into_bytes(),
+            server_private_key.clone(),
+            server_public_key.clone(),
             &policy,
         )?;
 
-        let server_cert = rustls::Certificate(server_cert_buffer.clone());
+        let server_certificate = Certificate(server_certificate_buffer.clone());
         // create the configuration
         let mut server_config =
-            rustls::ServerConfig::new(rustls::AllowAnyAuthenticatedClient::new(root_cert_store));
+            ServerConfig::new(AllowAnyAuthenticatedClient::new(root_cert_store));
 
         // specialize the configuration
-        server_config.set_single_cert(vec![server_cert.clone()], server_private_key.clone())?;
+        server_config
+            .set_single_cert(vec![server_certificate.clone()], server_private_key.clone())?;
 
-        // set the supported ciphersuites in the server to the one specified in the policy
-        // This is a dumb way to do this, but I leave it up to the student to find a better way
-        // (The ALL_CIPHERSUITES array is not very long, anyway)
-        let policy_ciphersuite = rustls::CipherSuite::lookup_value(policy.ciphersuite())
+        // Set the supported ciphersuites in the server to the one specified in
+        // the policy.  This is a dumb way to do this, but I leave it up to the
+        // student to find a better way (the ALL_CIPHERSUITES array is not very
+        // long, anyway).
+
+        let policy_ciphersuite = CipherSuite::lookup_value(policy.ciphersuite())
             .map_err(|_| BajaError::TLSInvalidCyphersuiteError(policy.ciphersuite().to_string()))?;
         let mut supported_ciphersuite = None;
+
         for this_supported_cs in rustls::ALL_CIPHERSUITES.iter() {
             if this_supported_cs.suite == policy_ciphersuite {
                 supported_ciphersuite = Some(this_supported_cs);
             }
         }
+
         let supported_ciphersuite = supported_ciphersuite.ok_or(
             BajaError::TLSUnsupportedCyphersuiteError(policy_ciphersuite),
         )?;
@@ -332,31 +394,49 @@ impl Baja {
         server_config.ciphersuites = vec![supported_ciphersuite];
         server_config.versions = vec![rustls::ProtocolVersion::TLSv1_2];
 
-        let baja = Baja {
-            server_cert_buffer: server_cert_buffer,
-            server_cert: server_cert.clone(),
-            server_config: server_config,
-            policy: policy,
-            name: common_name,
-            client_identities: client_identities,
-        };
-        Ok(baja)
+        Ok(Self {
+            server_certificate_buffer,
+            server_certificate,
+            server_config,
+            policy,
+            name,
+            principals,
+        })
     }
 
-    pub fn get_name(&self) -> String {
-        self.name.clone()
+    /// Returns the randomly-generated name associated with the Baja context.
+    #[inline]
+    pub fn name(&self) -> &String {
+        &self.name
     }
 
-    pub fn get_server_cert_pem(&self) -> Vec<u8> {
-        self.server_cert_buffer.clone()
+    /// Returns the buffer associated with the unparsed PEM certificate of the
+    /// server.
+    #[inline]
+    pub fn server_certificate_buffer(&self) -> &Vec<u8> {
+        &self.server_certificate_buffer
     }
 
-    pub fn get_server_cert(&self) -> rustls::Certificate {
-        self.server_cert.clone()
+    /// Returns the parsed PEM certificate associated with the server.
+    #[inline]
+    pub fn server_certificate(&self) -> &Certificate {
+        &self.server_certificate
     }
 
-    pub fn new_session(&self) -> Result<BajaSession, BajaError> {
-        let session = BajaSession::new(&self.server_config.clone(), &self.client_identities)?;
-        Ok(session)
+    /// Returns the configuration associated with the server.
+    #[inline]
+    pub fn server_config(&self) -> &ServerConfig {
+        &self.server_config
+    }
+
+    /// Creates a new Baja session, using server configuration and information
+    /// about the principals that are stored in this Baja context.  Fails iff
+    /// the creation of the new Baja session fails.
+    #[inline]
+    pub fn create_session(&self) -> Result<BajaSession, BajaError> {
+        Ok(BajaSession::new(
+            self.server_config().clone(),
+            self.principals().clone(),
+        )?)
     }
 }

--- a/baja/src/baja.rs
+++ b/baja/src/baja.rs
@@ -69,7 +69,11 @@ const CERTIFICATE_TEMPLATE: [u8; 536] = [
     0xa1, 0xdb, 0x6e, 0x10, 0x33, 0x91, 0x91, 0x8f,
 ];
 
-/// The
+/// The fixed server name.  Note that, strictly speaking, this should be
+/// randomly generated, however there is currently a problem on the TrustZone
+/// platform where this is impossible.  As a result, we use a fixed arbitrary
+/// value for our server name.  Note that this **does not** have any security
+/// implications.
 const FIXED_SERVER_NAME: &str = "ac40a0c";
 
 /// The byte range in the certificate template where the issuer common name is

--- a/baja/src/baja.rs
+++ b/baja/src/baja.rs
@@ -324,7 +324,7 @@ impl Baja {
 
         for identity in policy.identities().iter() {
             let cert = convert_cert_buffer(identity.certificate())?;
-            let mut principal = Principal::new(cert, *identity.id());
+            let mut principal = Principal::new(cert.clone(), *identity.id());
 
             principal.add_roles(identity.roles().iter().cloned());
             root_cert_store.add(&cert)?;
@@ -362,7 +362,7 @@ impl Baja {
         };
 
         let server_certificate_buffer = generate_certificate(
-            name.into_bytes(),
+            name.clone().into_bytes(),
             server_private_key.clone(),
             server_public_key.clone(),
             &policy,

--- a/baja/src/baja_session.rs
+++ b/baja/src/baja_session.rs
@@ -1,6 +1,8 @@
 //! Baja sessions
 //!
-//! ## Authors
+//! Management and abstraction of TLS server sessions.
+//!
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!
@@ -9,38 +11,136 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use super::BajaError;
-use rustls::Session;
-use std::io::{Read, Write};
-use std::vec::Vec;
-use veracruz_utils;
+use crate::error::BajaError;
+use veracruz_utils::VeracruzRole;
 
+use std::{
+    io::{Read, Write},
+    vec::Vec,
+};
+
+use rustls::{Certificate, ServerSession, Session};
+
+////////////////////////////////////////////////////////////////////////////////
+// Principals.
+////////////////////////////////////////////////////////////////////////////////
+
+/// A principal is an individual identified with a cryptographic certificate,
+/// and assigned a set of roles that dictate what that principal can and cannot
+/// do in a Veracruz computation.
+pub struct Principal {
+    /// The unique client ID of the principal.
+    client_id: u32,
+    /// The identifying cryptographic certificate associated with the principal.
+    certificate: Certificate,
+    /// The set of roles that the principal possesses.
+    roles: Vec<VeracruzRole>,
+}
+
+impl Principal {
+    /// Creates a new principal from a client ID and a certificate.  Assigns the
+    /// principal an empty set of roles.
+    #[inline]
+    pub fn new(client_id: u32, certificate: rustls::Certificate) -> Self {
+        Self {
+            client_id,
+            certificate,
+            roles: Vec::new(),
+        }
+    }
+
+    /// Adds a new role to the principal's set of assigned roles.
+    #[inline]
+    pub fn add_role(&mut self, role: VeracruzRole) -> &mut Self {
+        self.roles.push(role);
+        self
+    }
+
+    /// Adds multiple new roles to the principal's set of assigned roles,
+    /// reading them from an iterator.
+    pub fn add_roles<T>(&mut self, roles: T) -> &mut Self
+    where
+        T: IntoIterator<Item = VeracruzRole>,
+    {
+        for role in roles {
+            self.add_role(role);
+        }
+        self
+    }
+
+    /// Returns `true` iff the principal has the role, `role`.
+    #[inline]
+    pub fn has_role(&self, role: &VeracruzRole) -> bool {
+        self.roles.iter().any(|r| r == role)
+    }
+
+    /// Returns the unique client ID associated with this principal.
+    #[inline]
+    pub fn client_id(&self) -> u32 {
+        self.client_id
+    }
+
+    /// Returns the cryptographic certificate associated with this principal.
+    #[inline]
+    pub fn certificate(&self) -> &Certificate {
+        &self.certificate
+    }
+
+    /// Returns the set of roles associated with this principal.
+    #[inline]
+    pub fn roles(&self) -> &Vec<VeracruzRole> {
+        &self.roles
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Baja sessions.
+////////////////////////////////////////////////////////////////////////////////
+
+/// A Baja session consists of a TLS server session with a list of principals
+/// and their identifying information.
 pub struct BajaSession {
-    tls_session: rustls::ServerSession,
-    pub client_identities: Vec<(u32, rustls::Certificate, Vec<veracruz_utils::VeracruzRole>)>,
+    /// The TLS server session.
+    tls_session: ServerSession,
+    /// The list of principals, their identities, and roles in the Veracruz
+    /// computation.
+    principals: Vec<Principal>,
 }
 
 impl BajaSession {
+    /// Creates a new Baja session from a server configuration and a list of
+    /// principals.
     pub fn new(
-        config: &rustls::ServerConfig,
-        client_identities: &Vec<(u32, rustls::Certificate, Vec<veracruz_utils::VeracruzRole>)>,
-    ) -> Result<BajaSession, BajaError> {
-        let tls_session = rustls::ServerSession::new(&std::sync::Arc::new(config.clone()));
+        config: rustls::ServerConfig,
+        principals: Vec<Principal>,
+    ) -> Self {
+        let tls_session = ServerSession::new(&std::sync::Arc::new(config));
 
-        let session = BajaSession {
-            tls_session: tls_session,
-            client_identities: client_identities.clone(),
-        };
-        Ok(session)
+        BajaSession {
+            tls_session,
+            principals,
+        }
     }
 
+    /// Writes the contents of `input` over the Baja session's TLS server session.
     pub fn send_tls_data(&mut self, input: &mut Vec<u8>) -> Result<(), BajaError> {
-        let mut slice = &input[..];
+        let mut slice = input.as_slice();
         self.tls_session.read_tls(&mut slice)?;
         self.tls_session.process_new_packets()?;
         Ok(())
     }
 
+    /// Writes the entirety of the `input` buffer over the TLS connection.
+    #[inline]
+    pub fn return_data(&mut self, input: &[u8]) -> Result<(), BajaError> {
+        self.tls_session.write_all(input)?;
+        Ok(())
+    }
+
+    /// Reads TLS data from the Baja session's TLS server session.  If the TLS
+    /// session has no data to read, returns `Ok(None)`.  If data is available
+    /// for reading, returns `Ok(Some(buffer))` for some byte buffer, `buffer`.
+    /// If reading fails, then an error is returned.
     pub fn read_tls_data(&mut self) -> Result<Option<Vec<u8>>, BajaError> {
         if self.tls_session.wants_write() {
             let mut output = Vec::new();
@@ -51,46 +151,55 @@ impl BajaSession {
         }
     }
 
+    /// Reads data via the established TLS session, returning the unique client
+    /// ID and the set of roles associated with the principal that sent the
+    /// data.
     pub fn read_plaintext_data(
         &mut self,
-    ) -> Result<Option<(u32, Vec<veracruz_utils::VeracruzRole>, Vec<u8>)>, BajaError> {
-        let mut received_buffer: std::vec::Vec<u8> = std::vec::Vec::new();
-
+    ) -> Result<Option<(u32, Vec<VeracruzRole>, Vec<u8>)>, BajaError> {
+        let mut received_buffer: Vec<u8> = Vec::new();
         let num_bytes = self.tls_session.read_to_end(&mut received_buffer)?;
+
         if num_bytes > 0 {
             let peer_certs = self
                 .tls_session
                 .get_peer_certificates()
                 .ok_or(BajaError::PeerCertificateError)?;
+
             if peer_certs.len() != 1 {
                 return Err(BajaError::InvalidLengthError("peer_certs", 1));
             }
-            let mut roles: Vec<veracruz_utils::VeracruzRole> = Vec::new();
+
+            let mut roles = Vec::new();
             let mut client_id = 0;
-            for this_identity in self.client_identities.iter() {
-                if this_identity.1 == peer_certs[0] {
-                    roles = this_identity.2.clone();
-                    client_id = this_identity.0;
+
+            for principal in self.principals.iter() {
+                if principal.certificate() == peer_certs[0] {
+                    roles = principal.roles().clone();
+                    client_id = principal.client_id();
                 }
             }
+
             if roles.is_empty() {
                 return Err(BajaError::EmptyRoleError(client_id.into()));
             }
+
             Ok(Some((client_id, roles, received_buffer)))
         } else {
             Ok(None)
         }
     }
 
+    /// Returns `true` iff the Baja session's TLS server session has data to be
+    /// read.
+    #[inline]
     pub fn read_tls_needed(&self) -> bool {
         self.tls_session.wants_write()
     }
 
-    pub fn return_data(&mut self, input: Vec<u8>) -> Result<(), BajaError> {
-        self.tls_session.write_all(&input[..])?;
-        Ok(())
-    }
-
+    /// Returns `true` iff the Baja session's TLS server session has finished
+    /// handshaking and therefore authentication has been completed.
+    #[inline]
     pub fn is_authenticated(&self) -> bool {
         !self.tls_session.is_handshaking()
     }

--- a/baja/src/baja_session.rs
+++ b/baja/src/baja_session.rs
@@ -43,10 +43,7 @@ pub struct BajaSession {
 impl BajaSession {
     /// Creates a new Baja session from a server configuration and a list of
     /// principals.
-    pub fn new(
-        config: rustls::ServerConfig,
-        principals: Vec<Principal>,
-    ) -> Self {
+    pub fn new(config: rustls::ServerConfig, principals: Vec<Principal>) -> Self {
         let tls_session = ServerSession::new(&std::sync::Arc::new(config));
 
         BajaSession {
@@ -107,9 +104,9 @@ impl BajaSession {
             let mut client_id = 0;
 
             for principal in self.principals.iter() {
-                if principal.certificate() == peer_certs[0] {
+                if principal.certificate() == &peer_certs[0] {
                     roles = principal.roles().clone();
-                    client_id = principal.client_id();
+                    client_id = principal.id().clone();
                 }
             }
 

--- a/baja/src/baja_session.rs
+++ b/baja/src/baja_session.rs
@@ -12,7 +12,7 @@
 //! information on licensing and copyright.
 
 use crate::error::BajaError;
-use veracruz_utils::VeracruzRole;
+use veracruz_utils::{VeracruzIdentity, VeracruzRole};
 
 use std::{
     io::{Read, Write},
@@ -22,80 +22,13 @@ use std::{
 use rustls::{Certificate, ServerSession, Session};
 
 ////////////////////////////////////////////////////////////////////////////////
-// Principals.
+// Baja sessions.
 ////////////////////////////////////////////////////////////////////////////////
 
 /// A principal is an individual identified with a cryptographic certificate,
 /// and assigned a set of roles that dictate what that principal can and cannot
 /// do in a Veracruz computation.
-pub struct Principal {
-    /// The unique client ID of the principal.
-    client_id: u32,
-    /// The identifying cryptographic certificate associated with the principal.
-    certificate: Certificate,
-    /// The set of roles that the principal possesses.
-    roles: Vec<VeracruzRole>,
-}
-
-impl Principal {
-    /// Creates a new principal from a client ID and a certificate.  Assigns the
-    /// principal an empty set of roles.
-    #[inline]
-    pub fn new(client_id: u32, certificate: rustls::Certificate) -> Self {
-        Self {
-            client_id,
-            certificate,
-            roles: Vec::new(),
-        }
-    }
-
-    /// Adds a new role to the principal's set of assigned roles.
-    #[inline]
-    pub fn add_role(&mut self, role: VeracruzRole) -> &mut Self {
-        self.roles.push(role);
-        self
-    }
-
-    /// Adds multiple new roles to the principal's set of assigned roles,
-    /// reading them from an iterator.
-    pub fn add_roles<T>(&mut self, roles: T) -> &mut Self
-    where
-        T: IntoIterator<Item = VeracruzRole>,
-    {
-        for role in roles {
-            self.add_role(role);
-        }
-        self
-    }
-
-    /// Returns `true` iff the principal has the role, `role`.
-    #[inline]
-    pub fn has_role(&self, role: &VeracruzRole) -> bool {
-        self.roles.iter().any(|r| r == role)
-    }
-
-    /// Returns the unique client ID associated with this principal.
-    #[inline]
-    pub fn client_id(&self) -> u32 {
-        self.client_id
-    }
-
-    /// Returns the cryptographic certificate associated with this principal.
-    #[inline]
-    pub fn certificate(&self) -> &Certificate {
-        &self.certificate
-    }
-
-    /// Returns the set of roles associated with this principal.
-    #[inline]
-    pub fn roles(&self) -> &Vec<VeracruzRole> {
-        &self.roles
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Baja sessions.
-////////////////////////////////////////////////////////////////////////////////
+pub type Principal = VeracruzIdentity<Certificate>;
 
 /// A Baja session consists of a TLS server session with a list of principals
 /// and their identifying information.

--- a/baja/src/error.rs
+++ b/baja/src/error.rs
@@ -1,6 +1,9 @@
 //! Baja error
 //!
-//! ## Authors
+//! Various Baja-specific errors produced by the Baja session and Baja contexts,
+//! and operations on them.
+//!
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!
@@ -11,31 +14,48 @@
 
 use err_derive::Error;
 
+/// The various different error modes associated with the Baja module.
+///
+/// NOTE: `protobuf` does not implement `Clone`, so deriving `Clone` for this
+/// type is impossible.
 #[derive(Debug, Error)]
 pub enum BajaError {
-    // NOTE: Protobuf does not implement clone, hence derive(clone) is impossible.
-    #[error(display = "Baja: TLSError: {:?}.", _0)]
+    /// A TLS error originating in the `RusTLS` library occurred, with an
+    /// accompanying error code.
+    #[error(display = "Baja: a TLS error occurred: {:?}.", _0)]
     TLSError(#[error(source)] rustls::TLSError),
-    #[error(display = "Baja: TLSError: unspecified.")]
+    /// A generic, unspecified TLS error occurred.
+    #[error(display = "Baja: an unspecified or unknown TLS error occurred.")]
     TLSUnspecifiedError,
-    #[error(display = "Baja: TLSError: invalid cyphersuite {:?}.", _0)]
+    /// An invalid, or unknown, ciphersuite was requested.
+    #[error(display = "Baja: an invalid cyphersuite was requested in the TLS handshake: {:?}.", _0)]
     TLSInvalidCyphersuiteError(std::string::String),
-    #[error(display = "Baja: TLSError: unsupported cyphersuite {:?}.", _0)]
+    /// An unsupported ciphersuite was requested.
+    #[error(display = "Baja: an unsupported cyphersuite was requested in the TLS handshake: {:?}.", _0)]
     TLSUnsupportedCyphersuiteError(rustls::CipherSuite),
-    #[error(display = "Baja: IOError: {:?}.", _0)]
+    /// An IO error occurred, with an accompanying error code.
+    #[error(display = "Baja: an IO error occurred: {:?}.", _0)]
     IOError(#[error(source)] std::io::Error),
-    #[error(display = "Baja: RingUnspecifiedError: {:?}.", _0)]
+    /// A generic error occurred in the Ring library.
+    #[error(display = "Baja: an unspecified error occurred in the Ring library: {:?}.", _0)]
     RingUnspecifiedError(#[error(source)] ring::error::Unspecified),
-    #[error(display = "Baja: RingKeyRejectedError: {:?}.", _0)]
+    /// A cryptographic key was rejected by the Ring library.
+    #[error(display = "Baja: the Ring library rejected a cryptographic key: {:?}.", _0)]
     RingKeyRejectedError(#[error(source)] ring::error::KeyRejected),
-    #[error(display = "Baja: Webpki: {:?}.", _0)]
+    /// A WebPKI error occurred with an accompanying error code.
+    #[error(display = "Baja: a WebPKI error occurred: {:?}.", _0)]
     WebpkiError(#[error(source)] webpki::Error),
-    #[error(display = "Baja: Failed to retrieve peer certificates.")]
+    /// The runtime failed to obtain the peer certificates from the TLS session.
+    #[error(display = "Baja: failed to retrieve peer certificates.")]
     PeerCertificateError,
-    #[error(display = "Baja: Invalid length of variable `{}`, expected {}", _0, _1)]
+    /// The length of a variable (e.g. the number of expected peer certificates)
+    /// did not match expectations.
+    #[error(display = "Baja: invalid length of variable `{}`, expected {}", _0, _1)]
     InvalidLengthError(&'static str, usize),
-    #[error(display = "Baja: Client {} has no role.", _0)]
+    /// A principal has not been assigned any roles in the Veracruz computation.
+    #[error(display = "Baja: principal {} has not been assigned any role in the computation.", _0)]
     EmptyRoleError(u64),
-    #[error(display = "Baja: No certificate")]
+    /// A cryptographic certificate was missing.
+    #[error(display = "Baja: no certificate was found.")]
     NoCertificateError,
 }

--- a/baja/src/error.rs
+++ b/baja/src/error.rs
@@ -28,19 +28,31 @@ pub enum BajaError {
     #[error(display = "Baja: an unspecified or unknown TLS error occurred.")]
     TLSUnspecifiedError,
     /// An invalid, or unknown, ciphersuite was requested.
-    #[error(display = "Baja: an invalid cyphersuite was requested in the TLS handshake: {:?}.", _0)]
+    #[error(
+        display = "Baja: an invalid cyphersuite was requested in the TLS handshake: {:?}.",
+        _0
+    )]
     TLSInvalidCyphersuiteError(std::string::String),
     /// An unsupported ciphersuite was requested.
-    #[error(display = "Baja: an unsupported cyphersuite was requested in the TLS handshake: {:?}.", _0)]
+    #[error(
+        display = "Baja: an unsupported cyphersuite was requested in the TLS handshake: {:?}.",
+        _0
+    )]
     TLSUnsupportedCyphersuiteError(rustls::CipherSuite),
     /// An IO error occurred, with an accompanying error code.
     #[error(display = "Baja: an IO error occurred: {:?}.", _0)]
     IOError(#[error(source)] std::io::Error),
     /// A generic error occurred in the Ring library.
-    #[error(display = "Baja: an unspecified error occurred in the Ring library: {:?}.", _0)]
+    #[error(
+        display = "Baja: an unspecified error occurred in the Ring library: {:?}.",
+        _0
+    )]
     RingUnspecifiedError(#[error(source)] ring::error::Unspecified),
     /// A cryptographic key was rejected by the Ring library.
-    #[error(display = "Baja: the Ring library rejected a cryptographic key: {:?}.", _0)]
+    #[error(
+        display = "Baja: the Ring library rejected a cryptographic key: {:?}.",
+        _0
+    )]
     RingKeyRejectedError(#[error(source)] ring::error::KeyRejected),
     /// A WebPKI error occurred with an accompanying error code.
     #[error(display = "Baja: a WebPKI error occurred: {:?}.", _0)]
@@ -53,7 +65,10 @@ pub enum BajaError {
     #[error(display = "Baja: invalid length of variable `{}`, expected {}", _0, _1)]
     InvalidLengthError(&'static str, usize),
     /// A principal has not been assigned any roles in the Veracruz computation.
-    #[error(display = "Baja: principal {} has not been assigned any role in the computation.", _0)]
+    #[error(
+        display = "Baja: principal {} has not been assigned any role in the computation.",
+        _0
+    )]
     EmptyRoleError(u64),
     /// A cryptographic certificate was missing.
     #[error(display = "Baja: no certificate was found.")]

--- a/baja/src/lib.rs
+++ b/baja/src/lib.rs
@@ -1,6 +1,9 @@
 //! The Baja library
 //!
-//! ## Authors
+//! Code for sending and receiving data over a TLS-encrypted link, inside the
+//! Veracruz runtime.
+//!
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/chihuahua/src/error/common.rs
+++ b/chihuahua/src/error/common.rs
@@ -1,5 +1,6 @@
 //! Common error handling code for all Chihuahua execution engines.
-//! ## Authors
+//!
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/chihuahua/src/hcall/wasmtime.rs
+++ b/chihuahua/src/hcall/wasmtime.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 #[cfg(feature = "sgx")]
 use std::sync::SgxMutex as Mutex;
 
-use std::vec::Vec;
+use std::{time::Instant, vec::Vec};
 
 use byteorder::{ByteOrder, LittleEndian};
 use wasmtime::{Caller, Extern, ExternType, Func, Instance, Module, Store, Trap, ValType};
@@ -30,7 +30,6 @@ use crate::{
         HCALL_WRITE_OUTPUT_NAME,
     },
 };
-use std::time::Instant;
 
 ////////////////////////////////////////////////////////////////////////////////
 // The Wasmtime host provisioning state.

--- a/colima/src/custom.rs
+++ b/colima/src/custom.rs
@@ -1,6 +1,6 @@
 //! Custom and derived functionality relating to Colima.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/durango/src/attestation.rs
+++ b/durango/src/attestation.rs
@@ -1,6 +1,6 @@
 //! Remote attestation functionality
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/durango/src/durango.rs
+++ b/durango/src/durango.rs
@@ -1,6 +1,6 @@
 //! The Durango library
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/durango/src/error.rs
+++ b/durango/src/error.rs
@@ -1,6 +1,6 @@
 //! The Durango error
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/durango/src/lib.rs
+++ b/durango/src/lib.rs
@@ -1,6 +1,6 @@
 //! The Durango library
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/durango/src/tests.rs
+++ b/durango/src/tests.rs
@@ -8,7 +8,7 @@
 //!
 //! when invoking these tests with Cargo.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/jalisco/src/main.rs
+++ b/jalisco/src/main.rs
@@ -1,6 +1,6 @@
 //! Jalisco
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/mexico-city/src/managers/baja_manager.rs
+++ b/mexico-city/src/managers/baja_manager.rs
@@ -30,7 +30,7 @@ pub fn init_baja(policy_json: &str) -> Result<(), MexicoCityError> {
     }
 
     //TODO: change the error type
-    let new_baja = Baja::new(policy.clone())?;
+    let new_baja = Baja::new(policy)?;
 
     {
         let mut baja_state = super::MY_BAJA.lock()?;
@@ -48,7 +48,7 @@ pub fn new_session() -> Result<u32, MexicoCityError> {
     };
 
     let session = match &*super::MY_BAJA.lock()? {
-        Some(my_baja) => my_baja.new_session()?,
+        Some(my_baja) => my_baja.create_session()?,
         None => {
             return Err(MexicoCityError::UninitializedBajaSessionError(
                 "new_session",
@@ -92,11 +92,11 @@ pub fn send_data(session_id: u32, input_data: &[u8]) -> Result<(), MexicoCityErr
 
     match proc_ret {
         super::ProvisioningResponse::ProtocolError { response } => {
-            Ok(this_session.return_data(response)?)
+            Ok(this_session.return_data(&response)?)
         }
         super::ProvisioningResponse::WaitForMoreData => Ok(()),
         super::ProvisioningResponse::Success { response } => {
-            Ok(this_session.return_data(response)?)
+            Ok(this_session.return_data(&response)?)
         }
     }
 }
@@ -135,7 +135,7 @@ pub fn get_data_needed(session_id: u32) -> Result<bool, MexicoCityError> {
 
 pub fn get_enclave_cert_pem() -> Result<Vec<u8>, MexicoCityError> {
     match &*super::MY_BAJA.lock()? {
-        Some(my_baja) => Ok(my_baja.get_server_cert_pem()),
+        Some(my_baja) => Ok(my_baja.server_certificate_buffer().clone()),
         None => Err(MexicoCityError::UninitializedBajaSessionError(
             "get_enclave_cert_pem",
         )),
@@ -144,7 +144,7 @@ pub fn get_enclave_cert_pem() -> Result<Vec<u8>, MexicoCityError> {
 
 pub fn get_enclave_cert() -> Result<rustls::Certificate, MexicoCityError> {
     match &*super::MY_BAJA.lock()? {
-        Some(my_baja) => Ok(my_baja.get_server_cert()),
+        Some(my_baja) => Ok(my_baja.server_certificate().clone()),
         None => Err(MexicoCityError::UninitializedBajaSessionError(
             "get_enclave_cert",
         )),
@@ -153,7 +153,7 @@ pub fn get_enclave_cert() -> Result<rustls::Certificate, MexicoCityError> {
 
 pub fn get_enclave_name() -> Result<std::string::String, MexicoCityError> {
     match &*super::MY_BAJA.lock()? {
-        Some(my_baja) => Ok(my_baja.get_name()),
+        Some(my_baja) => Ok(my_baja.name().clone()),
         None => Err(MexicoCityError::UninitializedBajaSessionError(
             "get_enclave_name",
         )),

--- a/mexico-city/src/managers/baja_manager.rs
+++ b/mexico-city/src/managers/baja_manager.rs
@@ -48,7 +48,7 @@ pub fn new_session() -> Result<u32, MexicoCityError> {
     };
 
     let session = match &*super::MY_BAJA.lock()? {
-        Some(my_baja) => my_baja.create_session()?,
+        Some(my_baja) => my_baja.create_session(),
         None => {
             return Err(MexicoCityError::UninitializedBajaSessionError(
                 "new_session",

--- a/veracruz-utils/src/lib.rs
+++ b/veracruz-utils/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Material that doesn't fit anywhere else, or is common across many modules.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!

--- a/veracruz-utils/src/policy.rs
+++ b/veracruz-utils/src/policy.rs
@@ -571,7 +571,7 @@ impl VeracruzPolicy {
     /// TODO: where is this used, and why is it needed if we have access to
     /// the identities through `self.identities()`?
     #[inline]
-    pub fn iter_on_client<'a>(&'a self) -> Iter<'a, VeracruzIdentity> {
+    pub fn iter_on_client<'a>(&'a self) -> Iter<'a, VeracruzIdentity<String>> {
         self.identities().iter()
     }
 

--- a/veracruz-utils/src/policy.rs
+++ b/veracruz-utils/src/policy.rs
@@ -33,8 +33,8 @@ use err_derive::Error;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{
-    string::{String, ToString},
     slice::Iter,
+    string::{String, ToString},
     vec::Vec,
 };
 
@@ -167,8 +167,8 @@ impl<U> VeracruzIdentity<U> {
     /// Adds multiple new roles to the principal's set of assigned roles,
     /// reading them from an iterator.
     pub fn add_roles<T>(&mut self, roles: T) -> &mut Self
-        where
-            T: IntoIterator<Item = VeracruzRole>,
+    where
+        T: IntoIterator<Item = VeracruzRole>,
     {
         for role in roles {
             self.add_role(role);
@@ -217,18 +217,18 @@ impl VeracruzIdentity<String> {
         }
 
         #[cfg(features = "std")]
-            {
-                let parsed_cert =
-                    x509_parser::pem::Pem::read(std::io::Cursor::new(self.certificate().as_bytes()))?;
+        {
+            let parsed_cert =
+                x509_parser::pem::Pem::read(std::io::Cursor::new(self.certificate().as_bytes()))?;
 
-                let parsed_cert = parsed_cert.0.parse_x509()?.tbs_certificate;
+            let parsed_cert = parsed_cert.0.parse_x509()?.tbs_certificate;
 
-                if parsed_cert.validity.time_to_expiration().is_none() {
-                    return Err(VeracruzUtilError::CertificateExpireError(
-                        self.certificate().clone(),
-                    ));
-                }
+            if parsed_cert.validity.time_to_expiration().is_none() {
+                return Err(VeracruzUtilError::CertificateExpireError(
+                    self.certificate().clone(),
+                ));
             }
+        }
 
         Ok(())
     }

--- a/veracruz-utils/src/policy.rs
+++ b/veracruz-utils/src/policy.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{
     string::{String, ToString},
+    slice::Iter,
     vec::Vec,
 };
 
@@ -124,11 +125,18 @@ pub enum VeracruzRole {
     StreamProvider,
 }
 
-/// A notion of identitity for Veracruz principals.
+/// A notion of identitity for Veracruz principals.  Note that in different
+/// contexts we require different representations from our cryptographic
+/// certificates: in some contexts these should be unparsed text representations
+/// of the certificates (e.g. in the material below), and in other circumstances
+/// a parsed format is more appropriate, e.g. the `Certificate` type from the
+/// `RusTLS` library, as used in Baja.  We therefore abstract over the concrete
+/// types of certificates to obtain a single type that suits both contexts.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct VeracruzIdentity {
-    /// The cryptographic (X509) certificate associated with this identity.
-    certificate: String,
+pub struct VeracruzIdentity<U> {
+    /// The cryptographic certificate associated with this identity.  Note that
+    /// the actual implementation of this is kept abstract.
+    certificate: U,
     /// The ID associated with this identity.
     /// TODO: what is this?  Explain it properly.
     id: u32,
@@ -137,21 +145,46 @@ pub struct VeracruzIdentity {
     roles: Vec<VeracruzRole>,
 }
 
-impl VeracruzIdentity {
-    /// Creates a new identity from a certificate, and identifier, and a mix
-    /// of Veracruz roles.
+impl<U> VeracruzIdentity<U> {
+    /// Creates a new identity from a certificate, and identifier.  Initially,
+    /// we keep the set of roles empty.
     #[inline]
-    pub fn new(certificate: String, id: u32, roles: Vec<VeracruzRole>) -> Self {
+    pub fn new(certificate: U, id: u32) -> Self {
         Self {
             certificate,
             id,
-            roles,
+            roles: Vec::new(),
         }
+    }
+
+    /// Adds a new role to the principal's set of assigned roles.
+    #[inline]
+    pub fn add_role(&mut self, role: VeracruzRole) -> &mut Self {
+        self.roles.push(role);
+        self
+    }
+
+    /// Adds multiple new roles to the principal's set of assigned roles,
+    /// reading them from an iterator.
+    pub fn add_roles<T>(&mut self, roles: T) -> &mut Self
+        where
+            T: IntoIterator<Item = VeracruzRole>,
+    {
+        for role in roles {
+            self.add_role(role);
+        }
+        self
+    }
+
+    /// Returns `true` iff the principal has the role, `role`.
+    #[inline]
+    pub fn has_role(&self, role: &VeracruzRole) -> bool {
+        self.roles.iter().any(|r| r == role)
     }
 
     /// Returns the certificate associated with this identity.
     #[inline]
-    pub fn certificate(&self) -> &String {
+    pub fn certificate(&self) -> &U {
         &self.certificate
     }
 
@@ -166,7 +199,9 @@ impl VeracruzIdentity {
     pub fn roles(&self) -> &Vec<VeracruzRole> {
         &self.roles
     }
+}
 
+impl VeracruzIdentity<String> {
     /// Checks the validity of the identity, including well-formedness checks on
     /// the structure of the X509 certificate.  Returns `Err(reason)` iff the
     /// identity is malformed.  Returns `Ok(())` in all other cases.
@@ -182,18 +217,18 @@ impl VeracruzIdentity {
         }
 
         #[cfg(features = "std")]
-        {
-            let parsed_cert =
-                x509_parser::pem::Pem::read(std::io::Cursor::new(self.certificate().as_bytes()))?;
+            {
+                let parsed_cert =
+                    x509_parser::pem::Pem::read(std::io::Cursor::new(self.certificate().as_bytes()))?;
 
-            let parsed_cert = parsed_cert.0.parse_x509()?.tbs_certificate;
+                let parsed_cert = parsed_cert.0.parse_x509()?.tbs_certificate;
 
-            if parsed_cert.validity.time_to_expiration().is_none() {
-                return Err(VeracruzUtilError::CertificateExpireError(
-                    self.certificate().clone(),
-                ));
+                if parsed_cert.validity.time_to_expiration().is_none() {
+                    return Err(VeracruzUtilError::CertificateExpireError(
+                        self.certificate().clone(),
+                    ));
+                }
             }
-        }
 
         Ok(())
     }
@@ -295,7 +330,7 @@ impl VeracruzExpiry {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VeracruzPolicy {
     /// The identities of every principal involved in a computation.
-    identities: std::vec::Vec<VeracruzIdentity>,
+    identities: Vec<VeracruzIdentity<String>>,
     /// The URL of the Sinaloa server.
     sinaloa_url: String,
     /// The expiry of the enclave's self-signed certificate, which will be
@@ -313,7 +348,7 @@ pub struct VeracruzPolicy {
     /// all are provisioned, however, we reorder these inputs into this fixed
     /// declared order so that the Veracruz host ABI, which allows access to
     /// inputs via an index, remains well-defined.
-    data_provision_order: std::vec::Vec<u64>,
+    data_provision_order: Vec<u64>,
     /// The URL of the Tabasco attestation service.
     tabasco_url: String,
     /// The hash of the program which will be provisioned into Veracruz by the
@@ -331,7 +366,7 @@ pub struct VeracruzPolicy {
     /// all are provisioned, however, we reorder these inputs into this fixed
     /// declared order so that the Veracruz host ABI, which allows access to
     /// inputs via an index, remains well-defined.
-    streaming_order: std::vec::Vec<u64>,
+    streaming_order: Vec<u64>,
 }
 
 impl VeracruzPolicy {
@@ -339,7 +374,7 @@ impl VeracruzPolicy {
     /// the resulting policy in the process.  Returns `Ok(policy)` iff these
     /// well-formedness checks pass.
     pub fn new(
-        identities: Vec<VeracruzIdentity>,
+        identities: Vec<VeracruzIdentity<String>>,
         sinaloa_url: String,
         enclave_cert_expiry: VeracruzExpiry,
         ciphersuite: String,
@@ -381,7 +416,7 @@ impl VeracruzPolicy {
 
     /// Returns the identities associated with this policy.
     #[inline]
-    pub fn identities(&self) -> &Vec<VeracruzIdentity> {
+    pub fn identities(&self) -> &Vec<VeracruzIdentity<String>> {
         &self.identities
     }
 
@@ -536,7 +571,7 @@ impl VeracruzPolicy {
     /// TODO: where is this used, and why is it needed if we have access to
     /// the identities through `self.identities()`?
     #[inline]
-    pub fn iter_on_client<'a>(&'a self) -> std::slice::Iter<'a, VeracruzIdentity> {
+    pub fn iter_on_client<'a>(&'a self) -> Iter<'a, VeracruzIdentity> {
         self.identities().iter()
     }
 


### PR DESCRIPTION
1. Added inline Rustdoc comments everywhere, throughout the library.
2. Factored out important constants (e.g. the cryptographic certificate template into explicit constants declared in the source file.
3. Generalized the `VeracruzIdentity` type in `veracruz-utils` and used this type in `Baja` in place of an explicit triple of `u32`, `Certificate`, and `Vec<VeracruzRole>` values.
4. Removed uneccessary allocations/clones throughout the codebase, and other bits of Rust cleanup preferring reference passing rather than value passing where we can get away with it.
5. Added `inline` hints for small functions.
6. Removed unnecessary error type on the creation of Baja sessions, and propagated this change onwards.
7. (Trivial) removed non-breaking space characters in various RustDoc comments (across the Veracruz codebase) which cause RustDoc to not render correctly in favour of a proper space character.
8. Generalized some functions taking Strings as inputs to functions that take generic arguments that can be converted into Strings.

Various other small improvements throughout.