### PR TITLE
Fix mentions of source *cargo/env to use $CARGO_HOME

### DIFF
--- a/BUILD_INSTRUCTIONS.markdown
+++ b/BUILD_INSTRUCTIONS.markdown
@@ -93,7 +93,7 @@ Veracruz on SGX, first setup your local environment:
 ```
 cd /work/rust-optee-trustzone-sdk/
 source environment
-source ~/.cargo/env
+source $CARGO_HOME/env
 ```
 
 Now that your environment is set up, build the enclave binary by executing the

--- a/sgx_env.sh
+++ b/sgx_env.sh
@@ -1,4 +1,4 @@
 unset CC
 unset OPENSSL_DIR
 export SGX_SDK=/work/sgxsdk/
-source ~/.cargo/env
+source $CARGO_HOME/env

--- a/tz_env.sh
+++ b/tz_env.sh
@@ -1,4 +1,4 @@
 cd /work/rust-optee-trustzone-sdk/ && source environment
 unset CC
 export CC_aarch64_unknown_optee_trustzone=/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
-source ~/.cargo/env
+source $CARGO_HOME/env


### PR DESCRIPTION
Changed in https://github.com/veracruz-project/veracruz-docker-image/pull/2, Docker now uses `/usr/local/cargo/env`. Using $CARGO_HOME should make this future proof.

With help from @ShaleXIONG 