### PR TITLE
Changes to allow Nitro to be integrated into the CI system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ nitro: sdk
 	pwd
 	RUSTFLAGS=$(NITRO_RUST_FLAG) $(MAKE) -C runtime-manager nitro
 	RUSTFLAGS=$(NITRO_RUST_FLAG) $(MAKE) -C nitro-root-enclave
-	RUSTFLAGS=$(NITRO_RUST_FLAG) $(MAKE) -C nitro-root-enclave-server
+	RUSTFLAGS=$(NITRO_RUST_FLAG) cd nitro-root-enclave-server && cargo build
 
 # Compile for trustzone, note: source the rust-optee-trustzone-sdk/environment first, however assume `unset CC`.
 trustzone: sdk trustzone-env

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
  
-.PHONY: all sdk test_cases sgx-veracruz-client-test trustzone-veracruz-client-test sgx trustzone sgx-veracruz-server-test sgx-veracruz-server-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-veracruz-server-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env trustzone-test-env clean clean-cargo-lock fmt 
+.PHONY: all sdk test_cases sgx-veracruz-client-test trustzone-veracruz-client-test sgx trustzone sgx-veracruz-server-test sgx-veracruz-server-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-veracruz-server-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env nitro-env trustzone-test-env clean clean-cargo-lock fmt 
 
  
 WARNING_COLOR := "\e[1;33m"
@@ -47,7 +47,7 @@ sgx: sdk sgx-env
 	cd sgx-root-enclave-bind && RUSTFLAGS=$(SGX_RUST_FLAG) cargo build
 	cd veracruz-client && RUSTFLAGS=$(SGX_RUST_FLAG) cargo build --lib --features sgx
 
-nitro: sdk
+nitro: sdk nitro-env
 	pwd
 	RUSTFLAGS=$(NITRO_RUST_FLAG) $(MAKE) -C runtime-manager nitro
 	RUSTFLAGS=$(NITRO_RUST_FLAG) $(MAKE) -C nitro-root-enclave
@@ -107,7 +107,7 @@ trustzone-test-env: tz_test.sh run_tz_test.sh
 
 nitro-veracruz-server-test: nitro test_cases
 	cd veracruz-server-test \
-		&& RUSTFLAGS=$(NITRO_RUST_FLAG) cargo test --features nitro \
+		&& RUSTFLAGS=$(NITRO_RUST_FLAG) cargo test --features nitro -- --test-threads=1 \
 		&& RUSTFLAGS=$(NITRO_RUST_FLAG) cargo test test_debug --features nitro,debug -- --ignored --test-threads=1
 	cd veracruz-server-test \
 		&& ./nitro-terminate.sh
@@ -149,6 +149,9 @@ trustzone-env:
 
 sgx-env:
 	unset CC
+
+nitro-env:
+	rustup target add x86_64-unknown-linux-musl
 
 clean:
 	cd runtime-manager-bind && cargo clean 

--- a/NITRO_INSTRUCTIONS.markdown
+++ b/NITRO_INSTRUCTIONS.markdown
@@ -1,8 +1,42 @@
 # Setting up an environment for Veracruz on AWS Nitro Enclaves
 
-Start a standard EC2 instance, with M5.large, x86_64, with a security group that allows port 22 from all IPs, ports 3010 and 9090 from the VPC IPs, with an EBS volume attached (I use 64 GB for that).
+Note that veracruz relies on an AMI available in us-east-1. We have not test other region.
 
-Log in to the instance.
+### VPC
+
+Create a VPC via [this link](https://console.aws.amazon.com/vpc/). 
+In the IPv4 CIDR blcok, we are using `192.168.0.0/16`. The rest remains as the default.
+
+### Internet Gateway
+
+Create an internet gateway via [this link](https://console.aws.amazon.com/vpc/). 
+Then select the new gateway and attach it to the new VPC in the action menu.
+
+### Subnet
+Create a subnet via [this link](https://console.aws.amazon.com/vpc/). 
+In the VPC ID, choose the VPC we just created. 
+In the available zone choose us-east-1f (we did not test other zone).
+In the IPv4 CIDR block, we are using `192.168.32.0/19`
+Once we have the new subnet, it is convenient to auto-assign public IPv4 in the action menu. 
+
+### Security Group
+Create a new security group attach to the VP we just created.
+In the inbound rules,  allows any ssh traffic to port 22 and any TCP to port 3030 and 9090. 
+For the latter, we need to pick custom TCP and type in the port number.
+
+
+### EC2 Instance
+Start an EC2 instance.
+- Step 1 Choose an Amazon Machine Image (AMI). Use any instance of Amazon Linux on x86.
+- Step 2: Choose an Instance Type. Pick M5.xlarge, 
+- Step 3: Configure Instance Details. In the network and subnet, choose the VPC and subnet we just created, respectively. Enable Auto-assign Public IP. In the Advanced Details by the end of this page, enable enclave.
+- Step 4: Add Storage. Attach an EBS volume (we are using 64GB due to m5.xlarge only have 8GB storage).
+- Step 5: Add Tags. Nothing to be done.
+- Step 6: Configure Security Group. Select the security group we just created.
+
+### Set up Veracruz in EC2 Instance
+
+Log in to the instance. We are using ssh.
 
 Mount the EBS volume (following these instructions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-using-volumes.html):
 ```bash
@@ -20,10 +54,12 @@ sudo yum install openssl11-devel
 sudo yum install openssl11
 ```
 
-Configure nitro enclaves (source: From <https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf> )
-Edit `/etc/nitro_enclaves/allocator.yaml` and set cpus = 2, memory to 256MB
+Configure nitro enclaves, and test the nitro enclave example application ([source](https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf) )
+Edit `/etc/nitro_enclaves/allocator.yaml` if necessary. We set cpus = 2, memory to 256MB.
 
-Following the directions here(https://www.crybit.com/change-default-data-image-directory-docker/), change the location where docker stores images (we do this because the default partition
+### Build or Fetch Veracruz Docker
+
+Following the directions [here](https://www.crybit.com/change-default-data-image-directory-docker/), change the location where docker stores images (we do this because the default partition
 is too small for the docker images, so we want them stored on the EBS volume):
 ```bash
 sudo systemctl stop docker
@@ -31,15 +67,20 @@ sudo mv /var/lib/docker /ebs_volume
 sudo ln -s /ebs_volume/docker /var/lib/docker
 sudo systemctl start docker
 ```
-Now, either build or download the docker image from our repo (https://github.com/veracruz-project/veracruz-docker-image)
+Now, either build or download the docker image from [our repo](https://github.com/veracruz-project/veracruz-docker-image).
 
-Set the environment variable `VERACRUZ_ROOT` to the absolute path to the veracruz source code.
+If building from the source, run `make nitro TEE=nitro`.
+It will start an container `veracruz_nitro`.
 
+If using an existing image,
+Set the environment variable `VERACRUZ_ROOT` to the absolute path to the veracruz source code and
 Set the environment variable `LOCALIP` to the private AWS IP address of the EC2 instance you are running on.
 Start the docker image:
 ```bash
 docker run --privileged -d -v $(abspath $(VERACRUZ_ROOT)):/work/veracruz -v $(HOME)/.cargo/registry/:/usr/local/cargo/registry/ -v /usr/bin:/host/bin -v /usr/share/nitro_enclaves:/usr/share/nitro_enclaves -v /run/nitro_enclaves:/run/nitro_enclaves -v /etc/nitro_enclaves:/etc/nitro_enclaves --device=/dev/vsock:/dev/vsock -v /var/run/docker.sock:/var/run/docker.sock --device=/dev/nitro_enclaves:/dev/nitro_enclaves --env TABASCO_IP_ADDRESS=$(LOCALIP) -p $(LOCALIP):3010:3010/tcp --name veracruz_nitro veracruz_image_nitro
 ```
+
+### Start Veracruz Docker
 
 Start a shell on the newly launch container:
 ```bash
@@ -52,23 +93,13 @@ aws configure
 ```
 
 Veracruz needs the ability to start another EC2 instance from your initial EC2 instance. The following instructions set up this ability.
-
 You need to get the subnet that your initial EC2 instance is on.
-
 The id of this subnet should be set in the environment varialbe AWS_SUBNET.
-
 You need to create a security group that allows ports 3010, 9090 for private IP addresses within the subnet.
-
-You probably also want to allow port 22 form all IPs to enable you to SSH into the instance (if you think you'll want to)
-
 The name of this security group should be set in the environment variable AWS_SECURITY_GROUP_ID
-
 You also need to set up an AWSK public/private key pair. You need the private key in a file on your initial EC2 instance. The path to this private key should be set in the environment variable AWS_PRIVATE_KEY_FILENAME.
-
 The name of this key pair (as known by AWS) should be set in the environment variable AWS_KEY_NAME.
-
 The AWS region that you are running on should be set in the environment variable AWS_REGION.
-
 To do this, it is recommended to set the variables in a file called nitro.env as follows:
 ```bash
 export AWS_KEY_NAME="<VALUE>"
@@ -81,6 +112,6 @@ export AWS_SECURITY_GROUP_ID="<VALUE>"
 Now, inside the shell running on the container, execute the following:
 ```bash
 cd /work/veracruz
-make nitro-sinaloa-test
+make nitro-veracruz-server-test
 ```
 You should see 22 tests pass.

--- a/test-collateral/Makefile
+++ b/test-collateral/Makefile
@@ -88,48 +88,48 @@ css.bin: $(RUNTIME_MANAGER_CSS_BIN)
 	$(MAKE) css.bin -C ../runtime-manager
 	cp $< $@
 
-get_random_policy.json: pgen pgen css.bin client_rsa_cert.pem random-source.wasm
+get_random_policy.json: pgen pgen $(wildcard css.bin) client_rsa_cert.pem random-source.wasm
 	./pgen --certificate client_rsa_cert.pem --roles ProgramProvider,ResultReader \
                 --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary random-source.wasm --enclave-debug-mode true --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-one_data_source_policy.json: pgen css.bin client_rsa_cert.pem linear-regression.wasm
+one_data_source_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem linear-regression.wasm
 	./pgen --data-provision-order 0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary linear-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-test_multiple_key_policy.json: pgen css.bin client_rsa_cert.pem moving-average-convergence-divergence.wasm
+test_multiple_key_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem moving-average-convergence-divergence.wasm
 	./pgen --data-provision-order 0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary moving-average-convergence-divergence.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-two_data_source_string_edit_distance_policy.json: pgen css.bin client_rsa_cert.pem string-edit-distance.wasm
+two_data_source_string_edit_distance_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem string-edit-distance.wasm
 	./pgen --data-provision-order 0,0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3013 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary string-edit-distance.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-two_data_source_intersection_set_policy.json: pgen css.bin client_rsa_cert.pem intersection-set-sum.wasm
+two_data_source_intersection_set_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem intersection-set-sum.wasm
 	./pgen --data-provision-order 0,0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3022 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary intersection-set-sum.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-two_data_source_private_set_intersection_policy.json: pgen css.bin client_rsa_cert.pem private-set-intersection.wasm
+two_data_source_private_set_intersection_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem private-set-intersection.wasm
 	./pgen --data-provision-order 0,0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3026 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary private-set-intersection.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-dual_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem linear-regression.wasm
+dual_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem linear-regression.wasm
 	./pgen --data-provision-order 1 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider,ResultReader \
@@ -137,7 +137,7 @@ dual_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem line
 		--binary linear-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-dual_parallel_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem linear-regression.wasm
+dual_parallel_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem linear-regression.wasm
 	./pgen --data-provision-order 1 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider,ResultReader \
@@ -145,7 +145,7 @@ dual_parallel_policy.json: pgen css.bin program_client_cert.pem data_client_cert
 		--binary linear-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-triple_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem linear-regression.wasm
+triple_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem linear-regression.wasm
 	./pgen --data-provision-order 1 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider,ResultReader \
@@ -154,7 +154,7 @@ triple_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem re
 		--binary linear-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-triple_parties_two_data_sources_sum_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
+triple_parties_two_data_sources_sum_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
 	./pgen --data-provision-order 1,2 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider \
@@ -163,7 +163,7 @@ triple_parties_two_data_sources_sum_policy.json: pgen css.bin program_client_cer
 		--binary intersection-set-sum.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-permuted_triple_parties_two_data_sources_sum_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
+permuted_triple_parties_two_data_sources_sum_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
 	./pgen --data-provision-order 1,2 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider \
@@ -172,7 +172,7 @@ permuted_triple_parties_two_data_sources_sum_policy.json: pgen css.bin program_c
 		--binary intersection-set-sum.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-triple_parties_two_data_sources_string_edit_distance_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
+triple_parties_two_data_sources_string_edit_distance_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
 	./pgen --data-provision-order 1,2 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider \
@@ -181,7 +181,7 @@ triple_parties_two_data_sources_string_edit_distance_policy.json: pgen css.bin p
 		--binary string-edit-distance.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-quadruple_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
+quadruple_policy.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
 	./pgen --data-provision-order 1,2 \
 		--certificate program_client_cert.pem --roles ProgramProvider \
 		--certificate data_client_cert.pem --roles DataProvider \
@@ -191,35 +191,35 @@ quadruple_policy.json: pgen css.bin program_client_cert.pem data_client_cert.pem
 		--binary string-edit-distance.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-invalid_policy/one_expired_data_source_policy.json: pgen css.bin expired_cert.pem linear-regression.wasm
+invalid_policy/one_expired_data_source_policy.json: pgen $(wildcard css.bin) expired_cert.pem linear-regression.wasm
 	./pgen --data-provision-order 0 \
 		--certificate expired_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3021 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary linear-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-idash2017_logistic_regression_policy.json: pgen css.bin client_rsa_cert.pem idash2017-logistic-regression.wasm
+idash2017_logistic_regression_policy.json: pgen $(wildcard css.bin) client_rsa_cert.pem idash2017-logistic-regression.wasm
 	./pgen --data-provision-order 0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3023 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary idash2017-logistic-regression.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-moving_average_convergence_divergence.json: pgen css.bin client_rsa_cert.pem moving-average-convergence-divergence.wasm
+moving_average_convergence_divergence.json: pgen $(wildcard css.bin) client_rsa_cert.pem moving-average-convergence-divergence.wasm
 	./pgen --data-provision-order 0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3024 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary moving-average-convergence-divergence.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-private_set_intersection_sum.json: pgen css.bin client_rsa_cert.pem private-set-intersection-sum.wasm
+private_set_intersection_sum.json: pgen $(wildcard css.bin) client_rsa_cert.pem private-set-intersection-sum.wasm
 	./pgen --data-provision-order 0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3025 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--binary private-set-intersection-sum.wasm --execution-strategy Interpretation \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
-number-stream-accumulation.json: pgen css.bin program_client_cert.pem data_client_cert.pem result_client_cert.pem number-stream-accumulation.wasm
+number-stream-accumulation.json: pgen $(wildcard css.bin) program_client_cert.pem data_client_cert.pem result_client_cert.pem number-stream-accumulation.wasm
 	./pgen --data-provision-order 0  --stream-provision-order 0,0 \
 		--certificate client_rsa_cert.pem --roles ProgramProvider,DataProvider,ResultReader \
 		--veracruz-server-ip 127.0.0.1:3026 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -155,9 +155,9 @@ mod tests {
                     proxy_attestation_server_url
                 };
                 #[cfg(feature="debug")]
-                let server = tabasco::server::server(ip_addr, true).unwrap();
+                let server = proxy_attestation_server::server::server(ip_addr, true).unwrap();
                 #[cfg(not(feature="debug"))]
-                let server = tabasco::server::server(ip_addr, false).unwrap();
+                let server = proxy_attestation_server::server::server(ip_addr, false).unwrap();
                 sys.block_on(server).unwrap();
             });
         });


### PR DESCRIPTION
These changes are required to allow veracruz to run inside a docker container for the Nitro environment. This is a partner to the PR (https://github.com/veracruz-project/veracruz-docker-image/pull/10) in the veracruz-docker-image repo. They should be merged at the same time.