### PR TITLE
Embed enclave binaries into the Sinaloa binary directly

### DIFF
--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "An untrusted server/bridge that allows the outside world and the trusted Veracruz runtime to communicate with each other."
 
 [features]
-sgx = ["veracruz-utils/std","sgx_types", "sgx_urts", "transport-protocol/sgx_attestation", "runtime-manager-bind", "sgx-root-enclave-bind"]
+sgx = ["veracruz-utils/std","sgx_types", "sgx_urts", "transport-protocol/sgx_attestation", "runtime-manager-bind", "sgx-root-enclave-bind", "tempfile"]
 tz = ["veracruz-utils/std", "veracruz-utils/tz", "transport-protocol/tz", "optee-teec", "uuid"]
 nitro = ["veracruz-utils/nitro", "bincode", "serde/derive", "byteorder", "nix", "ssh2" ]
 debug = []
@@ -37,6 +37,7 @@ serde = { git = "https://github.com/veracruz-project/serde.git", default-feature
 byteorder = { version = "1.3.2", optional = true }
 nix = { version = "0.15", optional = true }
 ssh2 = {version = "0.8.3", optional = true }
+tempfile = { version = "3.2.0", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }


### PR DESCRIPTION
Embedded the enclave binaries into Sinaloa directly. This prevents Sinaloa from containing relative links to the build directory.

I'm not sure it's possible to pass the binary to SGX directly, so I am just writing to a temporary file in order to pass the binary to the SGX API.

Added the tempfile crate as a conditional dependency for sgx-sinaloa.

Cherry-picked from https://github.com/veracruz-project/veracruz/pull/75, which is currently dependent.

cc @dreemkiller 