### PR TITLE
Hoovering up various references to old component names in comments, documents, etc.

### DIFF
--- a/COMPONENTS.markdown
+++ b/COMPONENTS.markdown
@@ -105,6 +105,6 @@ of the `wasm32-unknown-unknown` build target, and makes the forking of
 existing Rust libraries (e.g. `getrandom` and `rand` above) easier, as the
 `wasm32-unknown-unknown` target is often interpreted as implying the WASI ABI
 in existing Rust code.
-- Tlaxcala: this is an ABI-validator for Veracruz binaries, which takes a
+- WASM Checker: this is an ABI-validator for Veracruz binaries, which takes a
 binary as input and certifies that it only assumes the presence of WASM host
 functions that are exposed by the Veracruz ABI.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
  
-.PHONY: all sdk test_cases sgx-veracruz-client-test trustzone-veracruz-client-test sgx trustzone sgx-sinaloa-test sgx-sinaloa-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-sinaloa-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env tlaxcala trustzone-test-env clean clean-cargo-lock fmt 
+.PHONY: all sdk test_cases sgx-veracruz-client-test trustzone-veracruz-client-test sgx trustzone sgx-sinaloa-test sgx-sinaloa-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-sinaloa-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env trustzone-test-env clean clean-cargo-lock fmt 
 
  
 WARNING_COLOR := "\e[1;33m"

--- a/runtime-manager/src/runtime_manager_trustzone.rs
+++ b/runtime-manager/src/runtime_manager_trustzone.rs
@@ -373,10 +373,6 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
         }
         RuntimeManagerOpcode::ResetEnclave => {
             debug_message("runtime_manager_trustzone::invoke_command::ResetEnclave".to_string());
-            //TODO: Check if this is necessary.
-            //      If so, implmenent as the follows:
-            //      let mut cs_guard = CHIHUAHUA_STATE.lock().unwrap();
-            //      *cs_guard = Some(ChihuahuaState::new())
         }
     }
     Ok(())

--- a/sdk/wasm-checker/Makefile
+++ b/sdk/wasm-checker/Makefile
@@ -1,6 +1,13 @@
-# Authors: Veracruz Team, Arm Research
-
-# This makefile is used to generate the Tlaxcala wasm binary analyzer
+# Makefile for the WASM Checker binary ABI validator.
+#
+# Authors
+#
+# The Veracruz Development Team.
+#
+# Copyright and Licensing
+#
+# See the `LICENSING.markdown` file in the Veracruz root directory for
+# copyright and licensing information.
 
 bin/wasm-checker: src/main.cc wabt json
 	mkdir -p bin/

--- a/sinaloa/src/sinaloa_tz.rs
+++ b/sinaloa/src/sinaloa_tz.rs
@@ -379,11 +379,11 @@ pub mod sinaloa_tz {
             return Ok(());
         }
 
-        fn fetch_firmware_version(jal_session: &mut Session) -> Result<String, SinaloaError> {
+        fn fetch_firmware_version(session: &mut Session) -> Result<String, SinaloaError> {
             let firmware_version_len = {
                 let p0 = ParamValue::new(0, 0, ParamType::ValueOutput);
                 let mut gfvl_op = Operation::new(0, p0, ParamNone, ParamNone, ParamNone);
-                jal_session
+                session
                     .invoke_command(SgxRootEnclaveOpcode::GetFirmwareVersionLen as u32, &mut gfvl_op)?;
                 gfvl_op.parameters().0.a()
             };
@@ -391,7 +391,7 @@ pub mod sinaloa_tz {
                 let mut fwv_vec = vec![0; firmware_version_len as usize];
                 let p0 = ParamTmpRef::new_output(&mut fwv_vec);
                 let mut gfv_op = Operation::new(0, p0, ParamNone, ParamNone, ParamNone);
-                jal_session
+                session
                     .invoke_command(SgxRootEnclaveOpcode::GetFirmwareVersion as u32, &mut gfv_op)?;
                 String::from_utf8(fwv_vec)?
             };

--- a/transport-protocol/protos/transport_protocol.proto
+++ b/transport-protocol/protos/transport_protocol.proto
@@ -1,4 +1,4 @@
-//! Colima, protocol buffer for Veracruz
+//! Protocol buffers for Veracruz transport protocol messages
 //!
 //! ## Authors
 //!


### PR DESCRIPTION
Rear-guard action after the great renaming.