### PR TITLE
Replace mutexes around primitive types with atomics

### DIFF
--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -18,10 +18,10 @@ pub mod nitro;
 
 use crate::error::*;
 use lazy_static::lazy_static;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicI32, Ordering};
 
 lazy_static! {
-    static ref DEVICE_ID: Mutex<i32> = Mutex::new(0);
+    static ref DEVICE_ID: AtomicI32 = AtomicI32::new(0);
 }
 
 pub async fn start(body_string: String) -> ProxyAttestationServerResponder {
@@ -43,15 +43,7 @@ pub async fn start(body_string: String) -> ProxyAttestationServerResponder {
     }
     let (protocol, firmware_version) = transport_protocol::parse_start_msg(&parsed);
 
-    let device_id = {
-        let mut device_id_wrapper = DEVICE_ID.lock()
-            .map_err(|err| {
-                println!("proxy-attestation-server::attestation::start failed to obtain lock on DEVICE_ID:{:?}", err);
-                err
-            })?;
-        *device_id_wrapper = *device_id_wrapper + 1;
-        *device_id_wrapper
-    };
+    let device_id = DEVICE_ID.fetch_add(1, Ordering::SeqCst); 
 
     match protocol.as_str() {
         #[cfg(feature = "sgx")]

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -21,7 +21,7 @@ use lazy_static::lazy_static;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 lazy_static! {
-    static ref DEVICE_ID: AtomicI32 = AtomicI32::new(0);
+    static ref DEVICE_ID: AtomicI32 = AtomicI32::new(1);
 }
 
 pub async fn start(body_string: String) -> ProxyAttestationServerResponder {

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -19,7 +19,7 @@ use std::{
     collections::HashMap,
     string::String,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,
     },
     vec::Vec,
@@ -48,7 +48,7 @@ pub use error::RuntimeManagerError;
 
 lazy_static! {
     static ref MY_SESSION_MANAGER: Mutex<Option<::session_manager::SessionContext>> = Mutex::new(None);
-    static ref SESSION_COUNTER: Mutex<u32> = Mutex::new(0);
+    static ref SESSION_COUNTER: AtomicU32 = AtomicU32::new(0);
     static ref SESSIONS: Mutex<HashMap<u32, ::session_manager::Session>> = Mutex::new(HashMap::new());
     static ref PROTOCOL_STATE: Mutex<Option<ProtocolState>> = Mutex::new(None);
     static ref DEBUG_FLAG: AtomicBool = AtomicBool::new(false);

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -48,7 +48,7 @@ pub use error::RuntimeManagerError;
 
 lazy_static! {
     static ref MY_SESSION_MANAGER: Mutex<Option<::session_manager::SessionContext>> = Mutex::new(None);
-    static ref SESSION_COUNTER: AtomicU32 = AtomicU32::new(0);
+    static ref SESSION_COUNTER: AtomicU32 = AtomicU32::new(1);
     static ref SESSIONS: Mutex<HashMap<u32, ::session_manager::Session>> = Mutex::new(HashMap::new());
     static ref PROTOCOL_STATE: Mutex<Option<ProtocolState>> = Mutex::new(None);
     static ref DEBUG_FLAG: AtomicBool = AtomicBool::new(false);

--- a/runtime-manager/src/managers/session_manager.rs
+++ b/runtime-manager/src/managers/session_manager.rs
@@ -39,11 +39,8 @@ pub fn init_session_manager(policy_json: &str) -> Result<(), RuntimeManagerError
 }
 
 pub fn new_session() -> Result<u32, RuntimeManagerError> {
-    let local_session_id = {
-        let mut session_counter = super::SESSION_COUNTER.lock()?;
-        *session_counter += 1;
-        session_counter.clone()
-    };
+    
+    let local_session_id = super::SESSION_COUNTER.fetch_add(1, Ordering::SeqCst);
 
     let session = match &*super::MY_SESSION_MANAGER.lock()? {
         Some(my_session_manager) => my_session_manager.create_session(),

--- a/sgx-root-enclave/src/lib.rs
+++ b/sgx-root-enclave/src/lib.rs
@@ -25,10 +25,10 @@ use sgx_types::{
     sgx_dh_session_enclave_identity_t, sgx_ec256_public_t, sgx_key_128bit_t, sgx_ra_context_t,
     sgx_ra_init, sgx_status_t, sgx_target_info_t,
 };
-use std::{collections::HashMap, mem, string::ToString};
+use std::{collections::HashMap, mem, string::ToString, sync::atomic::{AtomicU64, Ordering}};
 
 lazy_static! {
-    static ref SESSION_ID: std::sync::SgxMutex<u64> = std::sync::SgxMutex::new(0);
+    static ref SESSION_ID: AtomicU64 = AtomuicU64::new(0);
     static ref DEVICE_ID: std::sync::SgxMutex<Option<i32>> = std::sync::SgxMutex::new(None);
     static ref INITIATOR_HASH: std::sync::SgxMutex<HashMap<u64, SgxDhInitiator>> =
         std::sync::SgxMutex::new(HashMap::new());
@@ -174,13 +174,7 @@ pub extern "C" fn start_local_attest_enc(
 
     let status = initiator.proc_msg1(msg1, msg2);
     assert!(!status.is_err());
-    let session_id = {
-        let mut sess_id_wrap = SESSION_ID
-            .lock()
-            .expect("Failed to obtain lock on SESSION_ID");
-        *sess_id_wrap = *sess_id_wrap + 1;
-        *sess_id_wrap
-    };
+    let session_id = SESSION_ID.fetch_add(1, Ordering::SeqCst);
 
     {
         let mut initiator_hash = INITIATOR_HASH

--- a/sgx-root-enclave/src/lib.rs
+++ b/sgx-root-enclave/src/lib.rs
@@ -28,7 +28,7 @@ use sgx_types::{
 use std::{collections::HashMap, mem, string::ToString, sync::atomic::{AtomicU64, Ordering}};
 
 lazy_static! {
-    static ref SESSION_ID: AtomicU64 = AtomuicU64::new(0);
+    static ref SESSION_ID: AtomicU64 = AtomicU64::new(1);
     static ref DEVICE_ID: std::sync::SgxMutex<Option<i32>> = std::sync::SgxMutex::new(None);
     static ref INITIATOR_HASH: std::sync::SgxMutex<HashMap<u64, SgxDhInitiator>> =
         std::sync::SgxMutex::new(HashMap::new());

--- a/trustzone-root-enclave/src/main.rs
+++ b/trustzone-root-enclave/src/main.rs
@@ -22,7 +22,7 @@ use optee_utee::{
 use psa_attestation::{
     psa_initial_attest_get_token, psa_initial_attest_load_key, t_cose_sign1_get_verification_pubkey,
 };
-use ring;;
+use ring;
 use std::{convert::TryInto, io::Write};
 use veracruz_utils::TrustZoneRootEnclaveOpcode;
 

--- a/trustzone-root-enclave/src/main.rs
+++ b/trustzone-root-enclave/src/main.rs
@@ -22,9 +22,8 @@ use optee_utee::{
 use psa_attestation::{
     psa_initial_attest_get_token, psa_initial_attest_load_key, t_cose_sign1_get_verification_pubkey,
 };
-use ring;
-use std::convert::TryInto;
-use std::io::Write;
+use ring;;
+use std::{convert::TryInto, io::Write};
 use veracruz_utils::TrustZoneRootEnclaveOpcode;
 
 lazy_static! {
@@ -54,7 +53,6 @@ lazy_static! {
         0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
         0xf0, 0x0d, 0xca, 0xfe, 0xf0, 0x0d, 0xca, 0xfe, 0xf0, 0x0d, 0xca, 0xfe, 0xf0, 0x0d, 0xca, 0xfe,
     ];
-    static ref NATIVE_ATTESTATION_DONE: std::sync::Mutex<bool> = std::sync::Mutex::new(false);
     static ref RUNTIME_MANAGER_HASH: std::sync::Mutex<Option<Vec<u8>>> = std::sync::Mutex::new(None);
 }
 

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -43,7 +43,7 @@ mod tests {
         io::{Read, Write},
         path::Path,
         sync::{
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, AtomicU32, Ordering},
             Mutex, Once,
         },
         thread,
@@ -126,17 +126,13 @@ mod tests {
         // If one of the two threads hits an Error, it sets the flag to `false` and
         // thus stops another thread. Without this hack, a failure can cause non-termination.
         static ref CONTINUE_FLAG_HASH: Mutex<HashMap<u32,bool>> = Mutex::new(HashMap::<u32,bool>::new());
-        static ref NEXT_TICKET: Mutex<u32> = Mutex::new(0);
+        static ref NEXT_TICKET: AtomicU32 = AtomicU32::new(0);
     }
 
     pub fn setup(proxy_attestation_server_url: String) -> u32 {
         #[allow(unused_assignments)]
-        let mut rst = 0;
-        {
-            let mut next = NEXT_TICKET.lock().unwrap();
-            rst = next.clone();
-            *next = *next + 1;
-        }
+        let mut rst = NEXT_TICKET.fetch_add(1, Ordering::SeqCst);
+	
         SETUP.call_once(|| {
             info!("SETUP.call_once called");
             std::env::set_var("RUST_LOG", "info,actix_server=debug,actix_web=debug");

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -131,7 +131,7 @@ mod tests {
 
     pub fn setup(proxy_attestation_server_url: String) -> u32 {
         #[allow(unused_assignments)]
-        let mut rst = NEXT_TICKET.fetch_add(1, Ordering::SeqCst);
+        let rst = NEXT_TICKET.fetch_add(1, Ordering::SeqCst);
 	
         SETUP.call_once(|| {
             info!("SETUP.call_once called");

--- a/veracruz-server/fuzz/fuzz_targets/provision_data.rs
+++ b/veracruz-server/fuzz/fuzz_targets/provision_data.rs
@@ -64,7 +64,7 @@ fuzz_target!(|buffer: &[u8]| {
         let rst = protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerResponse>(&rst);
         assert!(rst.is_ok());
 
-	flag_main.store(false, Ordering::SeqCst);
+        flag_main.store(false, Ordering::SeqCst);
 
         server_loop_handle.join().unwrap();
     }

--- a/veracruz-server/fuzz/fuzz_targets/provision_data.rs
+++ b/veracruz-server/fuzz/fuzz_targets/provision_data.rs
@@ -14,7 +14,7 @@ use transport_protocol;
 use libfuzzer_sys::fuzz_target;
 use std::io::prelude::*;
 use std::fs::File;
-use std::sync::{Arc, Mutex};
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
 
 const ENCLAVE_STATE_DATA_SOURCES_LOADING: u8 = 1;
 
@@ -52,7 +52,7 @@ fuzz_target!(|buffer: &[u8]| {
             std::sync::mpsc::Receiver<std::vec::Vec<u8>>,
         ) = std::sync::mpsc::channel();
         
-        let flag_main = Arc::new(Mutex::new(true));
+        let flag_main = Arc::new(AtomicBool::new(true));
         let flag_server = flag_main.clone();
 
         let server_loop_handle = std::thread::spawn(move || {
@@ -63,15 +63,9 @@ fuzz_target!(|buffer: &[u8]| {
         let rst = client_tls_send(&client_tls_tx, &client_tls_rx, &mut client_session, &request).unwrap();
         let rst = protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerResponse>(&rst);
         assert!(rst.is_ok());
-        //let response = rst.unwrap();
-        //assert!( response.get_status() == transport_protocol::ResponseStatus::SUCCESS );
-        //check_enclave_state(
-            //&mut client_session,
-            //&client_tls_tx,
-            //&client_tls_rx,
-            //ENCLAVE_STATE_DATA_SOURCES_LOADING,
-        //);
-        *flag_main.lock().unwrap() = false;
+
+	flag_main.store(false, Ordering::SeqCst);
+
         server_loop_handle.join().unwrap();
     }
 });
@@ -236,13 +230,13 @@ fn client_tls_send(
 }
 
 fn server_tls_loop(
-    flag : Arc<Mutex<bool>>,
+    flag : Arc<AtomicBool>,
     veracruz_server: &dyn veracruz_server::VeracruzServer,
     session_id: u32,
     tx: std::sync::mpsc::Sender<std::vec::Vec<u8>>,
     rx: std::sync::mpsc::Receiver<std::vec::Vec<u8>>,
 ) {
-     while *flag.lock().unwrap() {
+     while flag.load(Ordering::SeqCst) {
         let received = rx.try_recv();
         let received_buffer = received.unwrap_or_else(|_| std::vec::Vec::new());
 


### PR DESCRIPTION
Simplifies some code (e.g. using atomic fetch-add) and also reduces the number of points of failure, as atomic reads never fail.