### PR TITLE
Add pgen to .PHONY rule in test-collateral Makefile

### DIFF
--- a/test-collateral/Makefile
+++ b/test-collateral/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
 
-.PHONY: all policy-files clean
+.PHONY: all policy-files clean pgen
 
 
 WARNING_COLOR := "\e[1;33m"


### PR DESCRIPTION
Since we copy pgen in to the test-collateral dir later, this does actually create a dependency conflict. Was causing generate-policy
to not be rebuilt.