### PR TITLE
WIP: port trusted Veracruz runtime to run as an unprotected AArch64 Linux process

### DIFF
--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 sgx = ["transport-protocol/sgx", "session-manager/sgx", "veracruz-utils/sgx", "wasmi/mesalock_sgx", "execution-engine/sgx", "rustls/mesalock_sgx", "protobuf/mesalock_sgx", "ring/mesalock_sgx", "sgx_types" , "sgx_tstd", "sgx_tcrypto", "sgx_tdh"]
 tz = ["wasmi/std", "session-manager/tz", "execution-engine/tz", "veracruz-utils/tz", "libc", "optee-utee-sys", "optee-utee", "serde_json/alloc"]
 nitro = [ "execution-engine/nitro", "wasmi/non_sgx", "session-manager/nitro", "veracruz-utils/nitro", "nsm_io", "nsm_lib", "ring/nitro", "nix", "byteorder", "bincode" ]
+linux = ["execution-engine/linux", "wasmi/non_sgx", "session-manager/linux", "veracruz-utils/linux"]
 
 [dependencies]
 session-manager = { path = "../session-manager"}
@@ -41,10 +42,10 @@ optee-utee-sys = { git = "https://github.com/veracruz-project/rust-optee-trustzo
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
 nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
-sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tcrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+[build-dependencies]
+uuid = { version = "0.7", features = ["v4"] }
+target_build_utils = "0.1"
 
 [build-dependencies]
 uuid = { version = "0.7", features = ["v4"] }

--- a/runtime-manager/Makefile
+++ b/runtime-manager/Makefile
@@ -12,7 +12,7 @@
 OUT_DIR?=.
 FINAL_DIR?=.
 
-.PHONY: all sgx trustzone clean deprecated nitro
+.PHONY: all sgx trustzone clean deprecated nitro aarch64-linux
 
 all: deprecated sgx
 
@@ -21,7 +21,7 @@ INFO_COLOR := "\e[1;32m"
 RESET_COLOR := "\e[0m"
 
 deprecated:
-	@echo $(WARNING_COLOR)"The default target, compiling sgx, is deprecated. Please explicitly choose target, sgx or trustzone." $(RESET_COLOR)
+	@echo $(WARNING_COLOR)"The default target, compiling sgx, is deprecated. Please explicitly choose target: sgx, trustzone, nitro, or aarch64-linux." $(RESET_COLOR)
 
 ############# SGX #################
 Signed_RustEnclave_RootName := runtime_manager.signed.so
@@ -156,6 +156,13 @@ runtime_manager.eif: target/x86_64-unknown-linux-musl/release/runtime_manager_en
 
 target/x86_64-unknown-linux-musl/release/runtime_manager_enclave: Cargo.toml $(Nitro_Src)
 	cargo build --target x86_64-unknown-linux-musl --release --features nitro
+
+############ AArch64 Linux processes ###############
+
+AArch64_Linux_Src := $(COMMON_Src) src/runtime_manager_linux.rs src/main.rs
+
+aarch64-linux: Cargo.toml $(AArch64_Linux_Src)
+	cargo build --target aarch64-unknown-linux-gnu --release --features aarch64-linux
 
 clean:
 	@cargo clean


### PR DESCRIPTION
- [ ] Port `execution-engine` to `aarch64-unknown-linux-gnu`, adding new `aarch64-linux` feature.
- [ ] Port `transport-protocol` to `aarch64-unknown-linux-gnu`, adding new `aarch64-linux` feature.
- [ ] Port `session-manager` to `aarch64-unknown-linux-gnu`, adding new `aarch64-linux` feature.
- [ ] Port `Veracruz-utils` to `aarch64-unknown-linux-gnu`, adding new `aarch64-linux` feature.
- [ ] Change `Cargo.toml` conditional compilation tests, removing check against target architecture (`aarch64`, `x86_64`) in favour of checks against target environments (`optee`, `sgx`), or similar, to make way for AArch64 Linux support (and eventually X64 Linux support).
- [ ] Add new unit and integration tests for AArch64 Linux.
- [ ] Update main project Makefile to add new `aarch64-linux` build target.
- [ ] Implement dummy attestation flow for Linux, similar to current situation for Optee.

Closes #107.