### PR TITLE
Remove platform-specific conditional dependencies

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -29,7 +29,7 @@ pinecone = "0.2"
 name = "execution_engine"
 path = "./src/lib.rs"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [patch.crates-io]

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -24,13 +24,11 @@ wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch="veracru
 wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", branch = "veracruz", optional = true }
 err-derive = "0.2"
 pinecone = "0.2"
+sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [lib]
 name = "execution_engine"
 path = "./src/lib.rs"
-
-[target.'cfg(target_env = "sgx")'.dependencies]
-sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [patch.crates-io]
 serde = { git = "https://github.com/veracruz-project/serde.git", features=["derive"], branch = "veracruz" }

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -21,11 +21,7 @@ cfg-if = "0.1.10"
 getrandom = { version = "0.1.14", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
 nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_trts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
-[target.'cfg(target_os = "optee")'.dependencies]
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 
 [profile.release]

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -22,10 +22,10 @@ getrandom = { version = "0.1.14", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
 nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_trts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(target_os = "optee")'.dependencies]
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 
 [profile.release]

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -53,9 +53,6 @@ err-derive = "0.2"
 serde_cbor = {version = "0.11", optional = true }
 nitro-enclave-token = { git = "https://github.com/veracruz-project/nitro-enclave-token.git", branch = "main", optional = true }
 nb-connect = "=1.0.3"
-
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -55,7 +55,7 @@ nitro-enclave-token = { git = "https://github.com/veracruz-project/nitro-enclave
 nb-connect = "=1.0.3"
 
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -44,12 +44,12 @@ nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", bran
 uuid = { version = "0.7", features = ["v4"] }
 target_build_utils = "0.1"
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(target_os = "optee")'.dependencies]
 libc = { git = "https://github.com/veracruz-project/libc.git", branch = "veracruz", optional = true }
 optee-utee-sys = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tcrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -48,7 +48,6 @@ sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.gi
 
 [build-dependencies]
 uuid = { version = "0.7", features = ["v4"] }
-target_build_utils = "0.1"
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_alloc = { branch="veracruz", git = "https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git", optional = true }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -36,24 +36,19 @@ err-derive = "0.2"
 nix = { version = "0.15", optional = true}
 byteorder = { version = "1.3", optional = true }
 bincode = { git = "https://github.com/veracruz-project/bincode.git", branch = "veracruz", default-features = false, optional = true }
-
-nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
-nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
-
-[build-dependencies]
-uuid = { version = "0.7", features = ["v4"] }
-target_build_utils = "0.1"
-
-[target.'cfg(target_os = "optee")'.dependencies]
 libc = { git = "https://github.com/veracruz-project/libc.git", branch = "veracruz", optional = true }
 optee-utee-sys = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
-
-[target.'cfg(target_env = "sgx")'.dependencies]
+nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
+nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tcrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+[build-dependencies]
+uuid = { version = "0.7", features = ["v4"] }
+target_build_utils = "0.1"
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_alloc = { branch="veracruz", git = "https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git", optional = true }

--- a/runtime-manager/build.rs
+++ b/runtime-manager/build.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 fn main() -> std::io::Result<()> {
     let target = target_build_utils::TargetInfo::new().expect("could not get target info");
-    if target.target_arch() == "aarch64" {
+    if target.target_os() == "optee" {
         let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
         let runtime_manager_uuid: &str = &std::fs::read_to_string("../runtime-manager-uuid.txt").unwrap();
 

--- a/runtime-manager/build.rs
+++ b/runtime-manager/build.rs
@@ -9,7 +9,6 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-extern crate target_build_utils;
 use std::env;
 use std::fs::File;
 use std::io::Write;
@@ -17,8 +16,8 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 fn main() -> std::io::Result<()> {
-    let target = target_build_utils::TargetInfo::new().expect("could not get target info");
-    if target.target_os() == "optee" {
+    #[cfg(feature = "tz")]
+    {
         let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
         let runtime_manager_uuid: &str = &std::fs::read_to_string("../runtime-manager-uuid.txt").unwrap();
 

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -18,12 +18,8 @@ veracruz-utils = { path = "../veracruz-utils" }
 webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "veracruz" }
 webpki-roots = { git = "https://github.com/veracruz-project/webpki-roots.git" , branch = "veracruz"}
 err-derive = "0.2"
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
-[target.'cfg(target_os = "optee")'.dependencies]
 optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -19,7 +19,7 @@ webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "ver
 webpki-roots = { git = "https://github.com/veracruz-project/webpki-roots.git" , branch = "veracruz"}
 err-derive = "0.2"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/sgx-root-enclave/Cargo.toml
+++ b/sgx-root-enclave/Cargo.toml
@@ -18,7 +18,7 @@ ring = { git = "https://github.com/veracruz-project/ring.git", version = "=0.16.
 veracruz-utils = { path = "../veracruz-utils", features = ["sgx"] }
 psa-attestation = { path = "../psa-attestation", features = ["sgx"] }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/sgx-root-enclave/Cargo.toml
+++ b/sgx-root-enclave/Cargo.toml
@@ -17,8 +17,6 @@ transport-protocol = { path = "../transport-protocol", features=["sgx"] }
 ring = { git = "https://github.com/veracruz-project/ring.git", version = "=0.16.11", branch = "veracruz", features = ["mesalock_sgx"] }
 veracruz-utils = { path = "../veracruz-utils", features = ["sgx"] }
 psa-attestation = { path = "../psa-attestation", features = ["sgx"] }
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/transport-protocol/Cargo.toml
+++ b/transport-protocol/Cargo.toml
@@ -14,13 +14,11 @@ tz = []
 [dependencies]
 protobuf = { git = "https://github.com/veracruz-project/rust-protobuf.git", branch = "veracruz" }
 err-derive = "0.2"
+sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [build-dependencies]
 protoc-rust = { git = "https://github.com/veracruz-project/rust-protobuf.git", branch = "veracruz" }
-
-[target.'cfg(target_env = "sgx")'.dependencies]
-sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_alloc = { branch="veracruz", git = 'https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git', optional = true }

--- a/transport-protocol/Cargo.toml
+++ b/transport-protocol/Cargo.toml
@@ -18,7 +18,7 @@ err-derive = "0.2"
 [build-dependencies]
 protoc-rust = { git = "https://github.com/veracruz-project/rust-protobuf.git", branch = "veracruz" }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/transport-protocol/src/lib.rs
+++ b/transport-protocol/src/lib.rs
@@ -12,7 +12,7 @@
 #![crate_name = "transport_protocol"]
 #![crate_type = "staticlib"]
 #![cfg_attr(feature = "sgx", no_std)]
-#![cfg_attr(target_env = "sgx", feature(rustc_private))]
+#![cfg_attr(feature = "sgx", feature(rustc_private))]
 
 #[cfg(feature = "sgx")]
 #[macro_use]

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -15,7 +15,6 @@ mock = ["mockall", "mockito"]
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 rustls = { git = "https://github.com/veracruz-project/rustls.git", branch = "veracruz" }
 webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "veracruz" }
-
 webpki-roots = { git = "https://github.com/veracruz-project/webpki-roots.git", branch = "veracruz"}
 ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz"}
 reqwest = { version = "0.9", default-features=false }
@@ -30,12 +29,9 @@ percent-encoding = "2.1.0"
 serde_json = { git = "https://github.com/veracruz-project/json.git", branch = "veracruz" }
 stringreader = "0.1.1"
 err-derive = "0.2"
-
 # Used in unit tests. Mock all the network traffic
 mockall = { version = "0.5.0", optional = true }
 mockito = { version = "0.23.1", optional = true } 
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -35,7 +35,7 @@ err-derive = "0.2"
 mockall = { version = "0.5.0", optional = true }
 mockito = { version = "0.23.1", optional = true } 
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -46,8 +46,6 @@ log = "=0.4.13"
 lazy_static = "1.4"
 regex = "1.4"
 local_ipaddress = "0.1.3"
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -47,7 +47,7 @@ lazy_static = "1.4"
 regex = "1.4"
 local_ipaddress = "0.1.3"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -38,16 +38,11 @@ byteorder = { version = "1.3.2", optional = true }
 nix = { version = "0.15", optional = true }
 ssh2 = {version = "0.8.3", optional = true }
 tempfile = { version = "3.2.0", optional = true }
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 runtime-manager-bind = { path = "../runtime-manager-bind", optional = true }
 sgx-root-enclave-bind = { path = "../sgx-root-enclave-bind", optional = true }
-
-[target.'cfg(target_os = "optee")'.dependencies]
 optee-teec = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
-# for the error handling 
 uuid = { version = "0.7", optional = true }
 hex = {version = "=0.4.2", optional = true }
 

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -44,7 +44,6 @@ runtime-manager-bind = { path = "../runtime-manager-bind", optional = true }
 sgx-root-enclave-bind = { path = "../sgx-root-enclave-bind", optional = true }
 optee-teec = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 uuid = { version = "0.7", optional = true }
-hex = {version = "=0.4.2", optional = true }
 
 [build-dependencies]
 target_build_utils = "0.1"

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -39,13 +39,13 @@ nix = { version = "0.15", optional = true }
 ssh2 = {version = "0.8.3", optional = true }
 tempfile = { version = "3.2.0", optional = true }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 runtime-manager-bind = { path = "../runtime-manager-bind", optional = true }
 sgx-root-enclave-bind = { path = "../sgx-root-enclave-bind", optional = true }
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(target_os = "optee")'.dependencies]
 optee-teec = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 # for the error handling 
 uuid = { version = "0.7", optional = true }

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -44,6 +44,3 @@ runtime-manager-bind = { path = "../runtime-manager-bind", optional = true }
 sgx-root-enclave-bind = { path = "../sgx-root-enclave-bind", optional = true }
 optee-teec = { git = "https://github.com/veracruz-project/rust-optee-trustzone-sdk.git", branch = "veracruz", optional = true }
 uuid = { version = "0.7", optional = true }
-
-[build-dependencies]
-target_build_utils = "0.1"

--- a/veracruz-server/build.rs
+++ b/veracruz-server/build.rs
@@ -28,7 +28,7 @@ fn main() {
             "SW" => println!("cargo:rustc-link-lib=dylib=sgx_urts_sim"),
             "HW" => {
                 let target = target_build_utils::TargetInfo::new().unwrap();
-                if target.target_arch() == "x86_64" {
+                if target.target_env() == "sgx" {
                     println!("cargo:rustc-link-lib=dylib=sgx_urts");
                     println!("cargo:rustc-link-lib=dylib=sgx_tkey_exchange");
                     println!("cargo:rustc-link-lib=dylib=sgx_uae_service");

--- a/veracruz-server/build.rs
+++ b/veracruz-server/build.rs
@@ -13,13 +13,10 @@
 use std::env;
 #[cfg(feature = "tz")]
 use std::process::Command;
-#[cfg(feature = "sgx")]
-use target_build_utils;
 
 fn main() {
     #[cfg(feature = "sgx")]
     {
-        let target = target_build_utils::TargetInfo::new().expect("could not get target info");
         let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/work/sgxsdk".to_string());
         let is_sim = env::var("SGX_MODE").unwrap_or_else(|_| "HW".to_string());
 
@@ -27,13 +24,10 @@ fn main() {
         match is_sim.as_ref() {
             "SW" => println!("cargo:rustc-link-lib=dylib=sgx_urts_sim"),
             "HW" => {
-                let target = target_build_utils::TargetInfo::new().unwrap();
-                if target.target_env() == "sgx" {
-                    println!("cargo:rustc-link-lib=dylib=sgx_urts");
-                    println!("cargo:rustc-link-lib=dylib=sgx_tkey_exchange");
-                    println!("cargo:rustc-link-lib=dylib=sgx_uae_service");
-                    println!("cargo:rustc-link-lib=dylib=sgx_ukey_exchange");
-                }
+                println!("cargo:rustc-link-lib=dylib=sgx_urts");
+                println!("cargo:rustc-link-lib=dylib=sgx_tkey_exchange");
+                println!("cargo:rustc-link-lib=dylib=sgx_uae_service");
+                println!("cargo:rustc-link-lib=dylib=sgx_ukey_exchange");
             }
             _ => println!("cargo:rustc-link-lib=dylib=sgx_urts"), // Treat undefined as HW
         }
@@ -56,7 +50,7 @@ fn main() {
             .status()
             .unwrap();
         if !make_result.success() {
-            panic!("veracruz-server::build.rs: make sgx-root-enclave failed");
+            panic!("veracruz-server::build.rs: make trustzone-root-enclave failed");
         }
 
         let make_result = Command::new("make")

--- a/veracruz-test/Cargo.toml
+++ b/veracruz-test/Cargo.toml
@@ -30,8 +30,6 @@ env_logger = "0.7"
 log = "=0.4.13"
 lazy_static = "1.4"
 err-derive = "0.2"
-
-[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_alloc = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/veracruz-test/Cargo.toml
+++ b/veracruz-test/Cargo.toml
@@ -31,7 +31,7 @@ log = "=0.4.13"
 lazy_static = "1.4"
 err-derive = "0.2"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_env = "sgx")'.dependencies]
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_alloc = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }


### PR DESCRIPTION
Remove platform-specific conditional dependencies of the form

```
[target.'cfg(target_arch = "X")'.dependencies]
```

from various Cargo.toml files.  With the move to support AArch64 and X64 Linux processes as a backend these are no longer appropriate.  Instead, adopted optional dependencies selected by feature flags to select backend-specific dependencies.