### PR TITLE
Added "std" feature for session-manager

### DIFF
--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -10,6 +10,7 @@ sgx = ["veracruz-utils/sgx", "sgx_tstd", "sgx_types", "rustls/mesalock_sgx", "we
 # NOTE: turn on the `std` on ring for Error trait
 tz = ["veracruz-utils/tz", "webpki/default", "webpki-roots/default", "ring/std", "ring/non_sgx", "optee-utee", "rustls/default"]
 nitro = ["ring/std", "ring/non_sgx"]
+std = ["veracruz-utils/std", "ring/std"]
 
 [dependencies]
 rustls = { git = "https://github.com/veracruz-project/rustls.git", branch = "veracruz" }


### PR DESCRIPTION
Added "std" feature for `session-manager` which links the `session-manager` crate against `veracruz-utils/std` and `ring/std`.  This is part of the porting process for Veracruz on Linux.