### PR TITLE
Liberalized mutability constraints of methods of VeracruzServer trait

### DIFF
--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -217,25 +217,25 @@ pub trait VeracruzServer {
         Self: Sized;
 
     fn proxy_psa_attestation_get_token(
-        &self,
+        &mut self,
         challenge: Vec<u8>,
     ) -> Result<(Vec<u8>, Vec<u8>, i32), VeracruzServerError>;
 
-    fn plaintext_data(&self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError>;
+    fn plaintext_data(&mut self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError>;
 
     // Note: this function will go away
-    fn get_enclave_cert(&self) -> Result<Vec<u8>, VeracruzServerError>;
+    fn get_enclave_cert(&mut self) -> Result<Vec<u8>, VeracruzServerError>;
 
     // Note: This function will go away
-    fn get_enclave_name(&self) -> Result<String, VeracruzServerError>;
+    fn get_enclave_name(&mut self) -> Result<String, VeracruzServerError>;
 
-    fn new_tls_session(&self) -> Result<u32, VeracruzServerError>;
+    fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError>;
 
-    fn close_tls_session(&self, session_id: u32) -> Result<(), VeracruzServerError>;
+    fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError>;
 
     // The first bool indicates if the enclave is active, and the second vec contains the response
     fn tls_data(
-        &self,
+        &mut self,
         session_id: u32,
         input: Vec<u8>,
     ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError>;

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -104,7 +104,7 @@ pub mod veracruz_server_nitro {
             return Ok(meta);
         }
 
-        fn plaintext_data(&self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+        fn plaintext_data(&mut self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
             let parsed = transport_protocol::parse_runtime_manager_request(&data)?;
 
             if parsed.has_request_proxy_psa_attestation_token() {
@@ -124,7 +124,7 @@ pub mod veracruz_server_nitro {
         }
 
         // Note: this function will go away
-        fn get_enclave_cert(&self) -> Result<Vec<u8>, VeracruzServerError> {
+        fn get_enclave_cert(&mut self) -> Result<Vec<u8>, VeracruzServerError> {
             let certificate = {
                 let message = RuntimeManagerMessage::GetEnclaveCert;
                 let message_buffer = bincode::serialize(&message)?;
@@ -141,7 +141,7 @@ pub mod veracruz_server_nitro {
         }
 
         // Note: This function will go away
-        fn get_enclave_name(&self) -> Result<String, VeracruzServerError> {
+        fn get_enclave_name(&mut self) -> Result<String, VeracruzServerError> {
             let name: String = {
                 let message = RuntimeManagerMessage::GetEnclaveName;
                 let message_buffer = bincode::serialize(&message)?;
@@ -158,7 +158,7 @@ pub mod veracruz_server_nitro {
         }
 
         fn proxy_psa_attestation_get_token(
-            &self,
+            &mut self,
             challenge: Vec<u8>,
         ) -> Result<(Vec<u8>, Vec<u8>, i32), VeracruzServerError> {
             let message = RuntimeManagerMessage::GetPSAAttestationToken(challenge);
@@ -176,7 +176,7 @@ pub mod veracruz_server_nitro {
             return Ok((token, public_key, device_id));
         }
 
-        fn new_tls_session(&self) -> Result<u32, VeracruzServerError> {
+        fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
             let nls_message = RuntimeManagerMessage::NewTLSSession;
             let nls_buffer = bincode::serialize(&nls_message)?;
             self.enclave.send_buffer(&nls_buffer)?;
@@ -191,7 +191,7 @@ pub mod veracruz_server_nitro {
             return Ok(session_id);
         }
 
-        fn close_tls_session(&self, session_id: u32) -> Result<(), VeracruzServerError> {
+        fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
             let cts_message = RuntimeManagerMessage::CloseTLSSession(session_id);
             let cts_buffer = bincode::serialize(&cts_message)?;
 
@@ -207,7 +207,7 @@ pub mod veracruz_server_nitro {
         }
 
         fn tls_data(
-            &self,
+            &mut self,
             session_id: u32,
             input: Vec<u8>,
         ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError> {

--- a/veracruz-server/src/veracruz_server_sgx.rs
+++ b/veracruz-server/src/veracruz_server_sgx.rs
@@ -517,7 +517,7 @@ pub mod veracruz_server_sgx {
             }
         }
 
-        fn plaintext_data(&self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+        fn plaintext_data(&mut self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
             let parsed = transport_protocol::parse_runtime_manager_request(&data)?;
 
             if parsed.has_request_proxy_psa_attestation_token() {
@@ -537,7 +537,7 @@ pub mod veracruz_server_sgx {
         }
 
         fn proxy_psa_attestation_get_token(
-            &self,
+            &mut self,
             challenge: Vec<u8>,
         ) -> Result<(Vec<u8>, Vec<u8>, i32), VeracruzServerError> {
             let mut pagt_result: u32 = 0;
@@ -573,7 +573,7 @@ pub mod veracruz_server_sgx {
         }
 
         // TODO: This function will go away when we use attestation
-        fn get_enclave_cert(&self) -> Result<Vec<u8>, VeracruzServerError> {
+        fn get_enclave_cert(&mut self) -> Result<Vec<u8>, VeracruzServerError> {
             let mut len_result: u32 = 0;
             let mut cert_len: u64 = 0;
             let len_ret = unsafe {
@@ -613,7 +613,7 @@ pub mod veracruz_server_sgx {
         }
 
         // TODO: This function will go away when we use attestation
-        fn get_enclave_name(&self) -> Result<String, VeracruzServerError> {
+        fn get_enclave_name(&mut self) -> Result<String, VeracruzServerError> {
             let mut len_result: u32 = 0;
             let mut name_len: u64 = 0;
             let len_ret = unsafe {
@@ -651,7 +651,7 @@ pub mod veracruz_server_sgx {
             }
         }
 
-        fn new_tls_session(&self) -> Result<u32, VeracruzServerError> {
+        fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
             let mut session_id: u32 = 0;
             let mut result: u32 = 0;
             let ret = unsafe {
@@ -666,7 +666,7 @@ pub mod veracruz_server_sgx {
             }
         }
 
-        fn close_tls_session(&self, session_id: u32) -> Result<(), VeracruzServerError> {
+        fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
             let mut result: u32 = 0;
             let ret = unsafe {
                 runtime_manager_close_session_enc(self.runtime_manager_enclave.geteid(), &mut result, session_id)
@@ -681,7 +681,7 @@ pub mod veracruz_server_sgx {
         }
 
         fn tls_data(
-            &self,
+            &mut self,
             session_id: u32,
             input: Vec<u8>,
         ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError> {

--- a/veracruz-server/src/veracruz_server_tz.rs
+++ b/veracruz-server/src/veracruz_server_tz.rs
@@ -77,7 +77,7 @@ pub mod veracruz_server_tz {
             })
         }
 
-        fn plaintext_data(&self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+        fn plaintext_data(&mut self, data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
             let parsed = transport_protocol::parse_runtime_manager_request(&data)?;
 
             if parsed.has_request_proxy_psa_attestation_token() {
@@ -99,7 +99,7 @@ pub mod veracruz_server_tz {
         }
 
         // Note: this function will go away
-        fn get_enclave_cert(&self) -> Result<Vec<u8>, VeracruzServerError> {
+        fn get_enclave_cert(&mut self) -> Result<Vec<u8>, VeracruzServerError> {
             let mut context_opt = CONTEXT.lock()?;
             let context = context_opt
                 .as_mut()
@@ -127,7 +127,7 @@ pub mod veracruz_server_tz {
         }
 
         // Note: This function will go away
-        fn get_enclave_name(&self) -> Result<String, VeracruzServerError> {
+        fn get_enclave_name(&mut self) -> Result<String, VeracruzServerError> {
             let mut context_opt = CONTEXT.lock()?;
             let context = context_opt
                 .as_mut()
@@ -155,7 +155,7 @@ pub mod veracruz_server_tz {
         }
 
         fn proxy_psa_attestation_get_token(
-            &self,
+            &mut self,
             challenge: Vec<u8>,
         ) -> Result<(Vec<u8>, Vec<u8>, i32), VeracruzServerError> {
             let mut token: Vec<u8> = Vec::with_capacity(2 * 8192); // TODO: Don't do
@@ -197,7 +197,7 @@ pub mod veracruz_server_tz {
             Ok((token, pubkey, device_id))
         }
 
-        fn new_tls_session(&self) -> Result<u32, VeracruzServerError> {
+        fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
             let mut context_opt = CONTEXT.lock()?;
             let context = context_opt
                 .as_mut()
@@ -216,7 +216,7 @@ pub mod veracruz_server_tz {
             Ok(session_id)
         }
 
-        fn close_tls_session(&self, session_id: u32) -> Result<(), VeracruzServerError> {
+        fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
             let mut context_opt = CONTEXT.lock()?;
             let context = context_opt
                 .as_mut()
@@ -230,7 +230,7 @@ pub mod veracruz_server_tz {
         }
 
         fn tls_data(
-            &self,
+            &mut self,
             session_id: u32,
             input: Vec<u8>,
         ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError> {


### PR DESCRIPTION
Made some `VeracruzServer` trait methods take a mutable self reference instead of non-mutable.

Otherwise inner mutability would be needed to implement the trait for Linux using Rust's `TcpStream` type (see e.g. [here](https://github.com/veracruz-project/veracruz/compare/main...geky:linux-process#diff-a16b159351e8ce1db71d0f93953cc05d70765a84794237cf82b5fd5e3537549a) where a `Mutex<Refcell<TcpStream>>` is needed).