### PR TITLE
Fix a dependency issue

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -25,6 +25,7 @@ wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", branch = 
 err-derive = "0.2"
 pinecone = "0.2"
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+wast = "=35.0.0"
 
 [lib]
 name = "execution_engine"

--- a/sdk/freestanding-execution-engine/Cargo.toml
+++ b/sdk/freestanding-execution-engine/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.8"
 serde = { version = "1.0.103", features = ["derive"] }
 toml = "0.5.5"
 wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch="veracruz", features = ["non_sgx"] }
+wast = "=35.0.0"
 
 [[bin]]
 name = "freestanding-execution-engine"


### PR DESCRIPTION
Force the wast version. New wast uses a function converting char to string which is not supported in our current nightly rust version.