### PR TITLE
Add vehicle routing example

### DIFF
--- a/sdk/rust-language-support/examples/vehicle-routing/Makefile
+++ b/sdk/rust-language-support/examples/vehicle-routing/Makefile
@@ -1,0 +1,3 @@
+all: example.cpp RoutingKit/Makefile
+	$(MAKE) -C RoutingKit -f Makefile
+	g++ example.cpp -O0 -lroutingkit -lz -fopenmp -pthread -lm -o example -I RoutingKit/include -L RoutingKit/lib

--- a/sdk/rust-language-support/examples/vehicle-routing/Makefile_wasm
+++ b/sdk/rust-language-support/examples/vehicle-routing/Makefile_wasm
@@ -1,0 +1,3 @@
+all: example.cpp RoutingKit/Makefile_wasm
+	$(MAKE) -C RoutingKit -f Makefile_wasm
+	em++ example.cpp -fexceptions -O0 -s WASM=1 -s NO_DISABLE_EXCEPTION_CATCHING -lroutingkit -lz -o example.html -I RoutingKit/include -L RoutingKit/lib

--- a/sdk/rust-language-support/examples/vehicle-routing/example.cpp
+++ b/sdk/rust-language-support/examples/vehicle-routing/example.cpp
@@ -7,11 +7,16 @@
 using namespace RoutingKit;
 using namespace std;
 
+void log_message(std::string str)
+{
+	cout << str << endl;
+}
+
 int main (int argc, char *argv []) {
 	cout << "<<< entry point" << endl;
 
 	// Load a car routing graph from OpenStreetMap-based data
-	auto graph = simple_load_osm_car_routing_graph_from_pbf("cambridgeshire-latest.osm.pbf");
+	auto graph = simple_load_osm_car_routing_graph_from_pbf("cambridgeshire-latest.osm.pbf", log_message);
 	cout << "<<< graph: " << graph.node_count() << endl;
 	auto tail = invert_inverse_vector(graph.first_out);
 

--- a/sdk/rust-language-support/examples/vehicle-routing/example.cpp
+++ b/sdk/rust-language-support/examples/vehicle-routing/example.cpp
@@ -1,0 +1,63 @@
+#include <routingkit/osm_simple.h>
+#include <routingkit/contraction_hierarchy.h>
+#include <routingkit/inverse_vector.h>
+#include <routingkit/timer.h>
+#include <routingkit/geo_position_to_node.h>
+#include <iostream>
+using namespace RoutingKit;
+using namespace std;
+
+int main (int argc, char *argv []) {
+	cout << "<<< entry point" << endl;
+
+	// Load a car routing graph from OpenStreetMap-based data
+	auto graph = simple_load_osm_car_routing_graph_from_pbf("cambridgeshire-latest.osm.pbf");
+	cout << "<<< graph: " << graph.node_count() << endl;
+	auto tail = invert_inverse_vector(graph.first_out);
+
+	// Build the shortest path index
+	auto ch = ContractionHierarchy::build(
+		graph.node_count(), 
+		tail, graph.head, 
+		graph.travel_time
+	);
+
+	// Build the index to quickly map latitudes and longitudes
+	GeoPositionToNode map_geo_position(graph.latitude, graph.longitude);
+
+	// Besides the CH itself we need a query object. 
+	ContractionHierarchyQuery ch_query(ch);
+
+	// Use the query object to answer queries from stdin to stdout
+	float from_latitude = 52.18216, from_longitude = 0.17897, to_latitude = 52.25793, to_longitude = 0.00119;
+	unsigned from = map_geo_position.find_nearest_neighbor_within_radius(from_latitude, from_longitude, 1000).id;
+	if(from == invalid_id){
+		cout << "No node within 1000m from source position" << endl;
+		return 1;
+	}
+	unsigned to = map_geo_position.find_nearest_neighbor_within_radius(to_latitude, to_longitude, 1000).id;
+	if(to == invalid_id){
+		cout << "No node within 1000m from target position" << endl;
+		return 1;
+	}
+
+	long long start_time = get_micro_time();
+	ch_query.reset().add_source(from).add_target(to).run();
+	auto distance = ch_query.get_distance();
+	auto path = ch_query.get_node_path();
+	auto distances_to_t = ch_query.get_distances_to_targets();
+	long long end_time = get_micro_time();
+
+	cout << "To get from "<< from << " to "<< to << " one needs " << distance << " milliseconds." << endl;
+	cout << "This query was answered in " << (end_time - start_time) << " microseconds." << endl;
+	cout << "dtt is";
+	for(auto x:distances_to_t)
+		cout << " " << x;
+	cout << endl;
+	cout << "The path is";
+	for(auto x:path)
+		cout << " " << x;
+	cout << endl;
+
+	return 0;
+}


### PR DESCRIPTION
Adding vehicle routing to the examples.
WIP.

What works:
* RoutingKit successfully compiled to C++ and WASM (using Emscripten)
* example.cpp successfully compiled to C++ and WASM (using Emscripten)

What doesn't:
* The example throws errors when run by the Emscripten wrapper (WIP)
* RoutingKit can't be compiled to WASM using wasi-sdk because it doesn't support C++ exceptions like Emscripten. wasi-sdk doesn't support multithreading either.

TODO:
- [x] Write the example
- [ ] Remove exceptions from the RoutingKit library or add support for them (cf. Emscripten workaround)
- [ ] Add RoutingKit source code, or add it as a submodule