### PR TITLE
Improve debugging of WASM programs

### DIFF
--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -644,17 +644,6 @@ impl FileSystem {
     /// A rust-style base implementation for `fd_write`. It directly calls `fd_pwrite` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
     pub(crate) fn fd_write(&mut self, fd: Fd, buf: &[u8]) -> FileSystemResult<Size> {
-        // Redirect writes to fd(0) and fd(1) to the host's stdout and stderr respectively
-        if fd.0 == 0 || fd.0 == 1 {
-            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-            print!("{}", s);
-            return Ok(buf.len() as u32)
-        } else if fd.0 == 2 {
-            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-            eprint!("{}", s);
-            return Ok(buf.len() as u32)
-        }
-
         self.check_right(&fd, Rights::FD_WRITE)?;
         let offset = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.offset;
 

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -644,6 +644,17 @@ impl FileSystem {
     /// A rust-style base implementation for `fd_write`. It directly calls `fd_pwrite` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
     pub(crate) fn fd_write(&mut self, fd: Fd, buf: &[u8]) -> FileSystemResult<Size> {
+        // Redirect writes to fd(0) and fd(1) to the host's stdout and stderr respectively
+        if fd.0 == 0 || fd.0 == 1 {
+            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+            print!("{}", s);
+            return Ok(buf.len() as u32)
+        } else if fd.0 == 2 {
+            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+            eprint!("{}", s);
+            return Ok(buf.len() as u32)
+        }
+
         self.check_right(&fd, Rights::FD_WRITE)?;
         let offset = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.offset;
 

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -137,12 +137,12 @@ impl FileSystem {
     /// and then pre-open them.
     fn install_prestat<T: AsRef<Path> + Sized>(&mut self, dir_paths: &[T]) {
         // Pre open the stdin stdout and stderr.
-        self.install_file("stderr", Inode(0), "".as_bytes());
-        self.install_fd(Fd(0), Inode(0), &Rights::FD_READ, &Rights::FD_READ);
-        self.install_file("stdin", Inode(1), "".as_bytes());
-        self.install_fd(Fd(1), Inode(1), &Rights::FD_READ, &Rights::FD_READ);
+        self.install_file("stdin", Inode(0), "".as_bytes());
+        self.install_fd(Fd(0), Inode(0), &Self::DEFAULT_RIGHTS, &Self::DEFAULT_RIGHTS);
+        self.install_file("stdout", Inode(1), "".as_bytes());
+        self.install_fd(Fd(1), Inode(1), &Self::DEFAULT_RIGHTS, &Self::DEFAULT_RIGHTS);
         self.install_file("stderr", Inode(2), "".as_bytes());
-        self.install_fd(Fd(2), Inode(2), &Rights::FD_READ, &Rights::FD_READ);
+        self.install_fd(Fd(2), Inode(2), &Self::DEFAULT_RIGHTS, &Self::DEFAULT_RIGHTS);
 
         // Install ROOT_DIRECTORY_FD is the first FD prestat will open.
         self.install_dir(Path::new(Self::ROOT_DIRECTORY), Self::ROOT_DIRECTORY_INODE);

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -29,6 +29,13 @@ use wasi_types::{
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// Standard channels.
+////////////////////////////////////////////////////////////////////////////////
+pub const STDIN: (&'static str, u32, u64) = ("stdin", 0, 0);
+pub const STDOUT: (&'static str, u32, u64) = ("stdout", 1, 1);
+pub const STDERR: (&'static str, u32, u64) = ("stderr", 2, 2);
+
+////////////////////////////////////////////////////////////////////////////////
 // Filesystem errors.
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -137,9 +144,7 @@ impl FileSystem {
     /// Install standard channels (`stdin`, `stdout`, `stderr`)
     fn install_standard_channel<T: AsRef<Path> + Sized>(
         &mut self,
-        path: T,
-        fd_number: u32,
-        inode_number: u64,
+        (path, fd_number, inode_number): (T, u32, u64),
         rights_base: &Rights,
     ) {
         self.install_file(&path, Inode(inode_number), "".as_bytes());
@@ -155,10 +160,9 @@ impl FileSystem {
     /// and then pre-open them.
     fn install_prestat<T: AsRef<Path> + Sized>(&mut self, dir_paths: &[T]) {
         // Pre open the standard channels.
-        // TODO: fix std channels' names and fd/inode numbers
-        self.install_standard_channel("stdin", 0, 0, &Rights::FD_READ);
-        self.install_standard_channel("stdout", 1, 1, &Rights::FD_WRITE);
-        self.install_standard_channel("stderr", 2, 2, &Rights::FD_WRITE);
+        self.install_standard_channel(STDIN, &Rights::FD_READ);
+        self.install_standard_channel(STDOUT, &Rights::FD_WRITE);
+        self.install_standard_channel(STDERR, &Rights::FD_WRITE);
 
         // Install ROOT_DIRECTORY_FD is the first FD prestat will open.
         self.install_dir(Path::new(Self::ROOT_DIRECTORY), Self::ROOT_DIRECTORY_INODE);

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -137,8 +137,7 @@ impl FileSystem {
     // Internal auxiliary methods
     ////////////////////////////////////////////////////////////////////////
 
-    #[inline]
-    /// Install standard streams (`stdin`, `stdout`, `stderr`)
+    /// Install standard streams (`stdin`, `stdout`, `stderr`).
     fn install_standard_streams(
         &mut self,
         std_streams_table: &Vec<StandardStream>,

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -105,7 +105,7 @@ impl FileSystem {
     /// The root directory name. It will be pre-opened for any wasm program.
     pub const ROOT_DIRECTORY: &'static str = "/";
     /// The root directory inode. It will be pre-opened for any wasm program.
-    pub const ROOT_DIRECTORY_INODE: Inode = Inode(2);
+    pub const ROOT_DIRECTORY_INODE: Inode = Inode(3);
     /// The root directory file descriptor. It will be pre-opened for any wasm program.
     pub const ROOT_DIRECTORY_FD: Fd = Fd(3);
     /// The default initial rights on a newly created file.
@@ -157,13 +157,14 @@ impl FileSystem {
 
         // Assume the ROOT_DIRECTORY_FD is the first FD prestat will open.
         let root_fd_number = Self::ROOT_DIRECTORY_FD.0;
+        let root_inode_number = Self::ROOT_DIRECTORY_INODE.0;
         for (index, path) in dir_paths.iter().enumerate() {
-            let index = index as u32;
-            let new_fd = Fd(index + root_fd_number + 1);
-            self.install_dir(path, Self::ROOT_DIRECTORY_INODE);
+            let new_inode = Inode(index as u64 + root_inode_number + 1);
+            let new_fd = Fd(index as u32 + root_fd_number + 1);
+            self.install_dir(path, new_inode);
             self.install_fd(
                 new_fd,
-                Self::ROOT_DIRECTORY_INODE,
+                new_inode,
                 &Self::DEFAULT_RIGHTS,
                 &Self::DEFAULT_RIGHTS,
             );

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -644,18 +644,15 @@ impl FileSystem {
     /// A rust-style base implementation for `fd_write`. It directly calls `fd_pwrite` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
     pub(crate) fn fd_write(&mut self, fd: Fd, buf: &[u8]) -> FileSystemResult<Size> {
-        #[cfg(debug_assertions)]
-        {
-            // Redirect writes to stdout and stderr to the host's stdout and stderr respectively
-            if fd.0 == 0 || fd.0 == 1 {
-                let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-                print!("{}", s);
-                return Ok(buf.len() as u32)
-            } else if fd.0 == 2 {
-                let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-                eprint!("{}", s);
-                return Ok(buf.len() as u32)
-            }
+        // Redirect writes to fd(0) and fd(1) to the host's stdout and stderr respectively
+        if fd.0 == 0 || fd.0 == 1 {
+            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+            print!("{}", s);
+            return Ok(buf.len() as u32)
+        } else if fd.0 == 2 {
+            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+            eprint!("{}", s);
+            return Ok(buf.len() as u32)
         }
 
         self.check_right(&fd, Rights::FD_WRITE)?;

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -644,15 +644,18 @@ impl FileSystem {
     /// A rust-style base implementation for `fd_write`. It directly calls `fd_pwrite` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
     pub(crate) fn fd_write(&mut self, fd: Fd, buf: &[u8]) -> FileSystemResult<Size> {
-        // Redirect writes to fd(0) and fd(1) to the host's stdout and stderr respectively
-        if fd.0 == 0 || fd.0 == 1 {
-            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-            print!("{}", s);
-            return Ok(buf.len() as u32)
-        } else if fd.0 == 2 {
-            let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
-            eprint!("{}", s);
-            return Ok(buf.len() as u32)
+        #[cfg(debug_assertions)]
+        {
+            // Redirect writes to stdout and stderr to the host's stdout and stderr respectively
+            if fd.0 == 0 || fd.0 == 1 {
+                let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+                print!("{}", s);
+                return Ok(buf.len() as u32)
+            } else if fd.0 == 2 {
+                let s = std::str::from_utf8(&buf).expect("Found invalid UTF-8");
+                eprint!("{}", s);
+                return Ok(buf.len() as u32)
+            }
         }
 
         self.check_right(&fd, Rights::FD_WRITE)?;

--- a/execution-engine/src/wasi/wasmtime.rs
+++ b/execution-engine/src/wasi/wasmtime.rs
@@ -29,7 +29,7 @@ use wasmtime::{Caller, Extern, ExternType, Func, Instance, Module, Store, Val, V
 
 lazy_static! {
     // The initial value has NO use.
-    static ref VFS_INSTANCE: Mutex<WasiWrapper> = Mutex::new(WasiWrapper::new(Arc::new(Mutex::new(FileSystem::new(HashMap::new()))), Principal::NoCap));
+    static ref VFS_INSTANCE: Mutex<WasiWrapper> = Mutex::new(WasiWrapper::new(Arc::new(Mutex::new(FileSystem::new(HashMap::new(), &vec![]))), Principal::NoCap));
 }
 
 /// A macro for lock the global VFS and store the result in the variable,

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -100,9 +100,9 @@ impl ProtocolState {
         let expected_shutdown_sources = global_policy.expected_shutdown_list();
 
         let rights_table = global_policy.get_rights_table();
-        let std_channels_table = global_policy.std_channels_table();
+        let std_streams_table = global_policy.std_streams_table();
         let digest_table = global_policy.get_digest_table()?;
-        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_channels_table)));
+        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_streams_table)));
 
         Ok(ProtocolState {
             global_policy,

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -100,8 +100,9 @@ impl ProtocolState {
         let expected_shutdown_sources = global_policy.expected_shutdown_list();
 
         let rights_table = global_policy.get_rights_table();
+        let std_channels_table = global_policy.std_channels_table();
         let digest_table = global_policy.get_digest_table()?;
-        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table)));
+        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_channels_table)));
 
         Ok(ProtocolState {
             global_policy,

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -81,7 +81,9 @@ struct CommandLineOptions {
     binary: String,
     /// The execution strategy to use when performing the computation.
     execution_strategy: ExecutionStrategy,
+    /// Whether the contents of `stdout` should be dumped before exiting
     dump_stdout: bool,
+    /// Whether the contents of `stderr` should be dumped before exiting
     dump_stderr: bool,
 }
 

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -38,7 +38,7 @@ use std::{
     vec::Vec,
     path::PathBuf,
 };
-use veracruz_utils::policy::principal::{ExecutionStrategy, FileRights, Principal, StandardChannel};
+use veracruz_utils::policy::principal::{ExecutionStrategy, FileRights, Principal, StandardStream};
 use wasi_types::Rights;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -228,11 +228,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         | Rights::PATH_CREATE_FILE
         | Rights::PATH_FILESTAT_SET_SIZE;
 
-    // Set up standard channels table
-    let std_channels_table = vec![
-        StandardChannel::Stdin(FileRights::new(String::from("stdin"), u64::from(read_right) as u32)),
-        StandardChannel::Stdout(FileRights::new(String::from("stdout"), u64::from(write_right) as u32)),
-        StandardChannel::Stderr(FileRights::new(String::from("stderr"), u64::from(write_right) as u32)),
+    // Set up standard streams table
+    let std_streams_table = vec![
+        StandardStream::Stdin(FileRights::new(String::from("stdin"), u64::from(read_right) as u32)),
+        StandardStream::Stdout(FileRights::new(String::from("stdout"), u64::from(write_right) as u32)),
+        StandardStream::Stderr(FileRights::new(String::from("stderr"), u64::from(write_right) as u32)),
     ];
 
     // Manually create the Right table for the VFS.
@@ -240,11 +240,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     for file_path in cmdline.data_sources.iter() {
         file_table.insert(PathBuf::from(file_path), read_right);
     }
-    for std_channel in &std_channels_table {
-        let (path, rights) = match std_channel {
-            StandardChannel::Stdin(file_rights) => (file_rights.file_name(), file_rights.rights()),
-            StandardChannel::Stdout(file_rights) => (file_rights.file_name(), file_rights.rights()),
-            StandardChannel::Stderr(file_rights) => (file_rights.file_name(), file_rights.rights()),
+    for std_stream in &std_streams_table {
+        let (path, rights) = match std_stream {
+            StandardStream::Stdin(file_rights) => (file_rights.file_name(), file_rights.rights()),
+            StandardStream::Stdout(file_rights) => (file_rights.file_name(), file_rights.rights()),
+            StandardStream::Stderr(file_rights) => (file_rights.file_name(), file_rights.rights()),
         };
         let rights = Rights::try_from(*rights as u64)
             .map_err(|e| format!("Failed to convert u64 to Rights: {:?}", e))?;
@@ -253,7 +253,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     file_table.insert(PathBuf::from(OUTPUT_FILE), write_right);
     right_table.insert(Principal::Program(prog_file_name.to_string()), file_table);
 
-    let vfs = Arc::new(Mutex::new(FileSystem::new(right_table, &std_channels_table)));
+    let vfs = Arc::new(Mutex::new(FileSystem::new(right_table, &std_streams_table)));
     vfs.lock()
         .map_err(|e| format!("Failed to lock vfs, error: {:?}", e))?
         .write_file_by_filename(

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -295,6 +295,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map_err(|e| format!("Failed to convert byte stream to UTF-8 string: {:?}", e))?;
     eprint!("{}", stderr_dump);
 
-    info!("WASM program {} loaded into VFS.", prog_file_name);
     Ok(())
 }

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -254,5 +254,29 @@ fn main() -> Result<(), Box<dyn Error>> {
     let return_code = execute(&cmdline.execution_strategy, vfs.clone(), &prog_file_name)?;
     info!("return code: {:?}", return_code);
     info!("time: {} micro seconds", main_time.elapsed().as_micros());
+
+    // Dump contents of stdout
+    let buf = vfs.lock()
+        .map_err(|e| format!("Failed to lock vfs, error: {:?}", e))?
+        .read_file_by_filename(
+            &Principal::InternalSuperUser,
+            "stdout",
+        )?;
+    let stdout_dump = std::str::from_utf8(&buf)
+        .map_err(|e| format!("Failed to convert byte stream to UTF-8 string: {:?}", e))?;
+    print!("{}", stdout_dump);
+
+    // Dump contents of stderr
+    let buf = vfs.lock()
+        .map_err(|e| format!("Failed to lock vfs, error: {:?}", e))?
+        .read_file_by_filename(
+            &Principal::InternalSuperUser,
+            "stderr",
+        )?;
+    let stderr_dump = std::str::from_utf8(&buf)
+        .map_err(|e| format!("Failed to convert byte stream to UTF-8 string: {:?}", e))?;
+    eprint!("{}", stderr_dump);
+
+    info!("WASM program {} loaded into VFS.", prog_file_name);
     Ok(())
 }

--- a/test-collateral/Makefile
+++ b/test-collateral/Makefile
@@ -127,6 +127,7 @@ get_random_policy.json: pgen pgen css-$(TEE).bin client_rsa_cert.pem random-sour
 		--binary random-source.wasm --capability "output : $(WRITE_RIGHT)" \
        --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--enclave-debug-mode true --execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 one_data_source_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem linear-regression.wasm
@@ -134,6 +135,7 @@ one_data_source_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem linear-regr
  		--binary linear-regression.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 test_multiple_key_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem moving-average-convergence-divergence.wasm
@@ -141,6 +143,7 @@ test_multiple_key_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem moving-av
  		--binary moving-average-convergence-divergence.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 two_data_source_string_edit_distance_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem string-edit-distance.wasm
@@ -148,6 +151,7 @@ two_data_source_string_edit_distance_policy.json: pgen css-$(TEE).bin client_rsa
  		--binary string-edit-distance.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3013 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 two_data_source_intersection_set_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem intersection-set-sum.wasm
@@ -155,6 +159,7 @@ two_data_source_intersection_set_policy.json: pgen css-$(TEE).bin client_rsa_cer
  		--binary intersection-set-sum.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3022 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 two_data_source_private_set_intersection_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem private-set-intersection.wasm
@@ -162,6 +167,7 @@ two_data_source_private_set_intersection_policy.json: pgen css-$(TEE).bin client
  		--binary private-set-intersection.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3026 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 dual_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem linear-regression.wasm
@@ -170,6 +176,7 @@ dual_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.p
 		--binary linear-regression.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3014 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 dual_parallel_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem linear-regression.wasm
@@ -178,6 +185,7 @@ dual_parallel_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_clie
  		--binary linear-regression.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 	--veracruz-server-ip 127.0.0.1:3015 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 triple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem linear-regression.wasm
@@ -186,7 +194,8 @@ triple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert
 		--certificate result_client_cert.pem --capability "output : $(READ_RIGHT), linear-regression.wasm : $(WRITE_RIGHT)" \
  		--binary linear-regression.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3016 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
-		 --execution-strategy Interpretation \
+		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
@@ -196,6 +205,7 @@ triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin program_cli
  		--binary intersection-set-sum.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3017 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 permuted_triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem intersection-set-sum.wasm
@@ -205,6 +215,7 @@ permuted_triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin pr
  		--binary intersection-set-sum.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3018 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 triple_parties_two_data_sources_string_edit_distance_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
@@ -214,6 +225,7 @@ triple_parties_two_data_sources_string_edit_distance_policy.json: pgen css-$(TEE
  		--binary string-edit-distance.wasm  --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3019 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 quadruple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem string-edit-distance.wasm
@@ -224,6 +236,7 @@ quadruple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_c
  		--binary string-edit-distance.wasm --capability "input-0 : $(READ_RIGHT), input-1 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3020 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 invalid_policy/one_expired_data_source_policy.json: pgen css-$(TEE).bin expired_cert.pem linear-regression.wasm
@@ -231,6 +244,7 @@ invalid_policy/one_expired_data_source_policy.json: pgen css-$(TEE).bin expired_
  		--binary linear-regression.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3021 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 idash2017_logistic_regression_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem idash2017-logistic-regression.wasm
@@ -238,6 +252,7 @@ idash2017_logistic_regression_policy.json: pgen css-$(TEE).bin client_rsa_cert.p
  		--binary idash2017-logistic-regression.wasm  --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3023 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 moving_average_convergence_divergence.json: pgen css-$(TEE).bin client_rsa_cert.pem moving-average-convergence-divergence.wasm
@@ -245,6 +260,7 @@ moving_average_convergence_divergence.json: pgen css-$(TEE).bin client_rsa_cert.
  		--binary moving-average-convergence-divergence.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3024 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 private_set_intersection_sum.json: pgen css-$(TEE).bin client_rsa_cert.pem private-set-intersection-sum.wasm
@@ -252,6 +268,7 @@ private_set_intersection_sum.json: pgen css-$(TEE).bin client_rsa_cert.pem priva
 		--binary private-set-intersection-sum.wasm --capability "input-0 : $(READ_RIGHT), output : $(WRITE_RIGHT)" \
 		--veracruz-server-ip 127.0.0.1:3025 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 number-stream-accumulation.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.pem result_client_cert.pem number-stream-accumulation.wasm
@@ -266,6 +283,7 @@ basic_file_read_write.json: pgen css-$(TEE).bin client_rsa_cert.pem read-file.wa
 		--binary read-file.wasm --capability "input.txt: $(READ_RIGHT), output : $(WRITE_RIGHT)" \
         --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--enclave-debug-mode true --execution-strategy Interpretation \
+		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0)
 
 .SECONDEXPANSION:

--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -27,7 +27,7 @@ use serde_json::{json, to_string_pretty, Value};
 use veracruz_utils::policy::{
     policy::Policy,
     expiry::Timepoint,
-    principal::{ExecutionStrategy, Identity, Program, FileRights, StandardChannel},
+    principal::{ExecutionStrategy, Identity, Program, FileRights, StandardStream},
 };
 use wasi_types::Rights;
 
@@ -711,23 +711,23 @@ fn serialize_execution_strategy(strategy: &str) -> ExecutionStrategy {
     }
 }
 
-/// Serializes the standard channels of all principals in the Veracruz computation into
-/// a vec of StandardChannel.
-fn serialize_std_channels(arguments: &Arguments) -> Vec<StandardChannel> {
-    info!("Serializing standard channels.");
+/// Serializes the standard streams of all principals in the Veracruz computation into
+/// a vec of StandardStream.
+fn serialize_std_streams(arguments: &Arguments) -> Vec<StandardStream> {
+    info!("Serializing standard streams.");
     
-    let mut std_channels_table = Vec::new();
+    let mut std_streams_table = Vec::new();
     if let Some(stdin) = &arguments.stdin {
-        std_channels_table.push(StandardChannel::Stdin(serialize_capability_entry(&stdin)));
+        std_streams_table.push(StandardStream::Stdin(serialize_capability_entry(&stdin)));
     }
     if let Some(stdout) = &arguments.stdout {
-        std_channels_table.push(StandardChannel::Stdout(serialize_capability_entry(&stdout)));
+        std_streams_table.push(StandardStream::Stdout(serialize_capability_entry(&stdout)));
     }
     if let Some(stderr) = &arguments.stderr {
-        std_channels_table.push(StandardChannel::Stderr(serialize_capability_entry(&stderr)));
+        std_streams_table.push(StandardStream::Stderr(serialize_capability_entry(&stderr)));
     }
 
-    std_channels_table
+    std_streams_table
 }
 
 /// Serializes the Veracruz policy file as a JSON value.
@@ -752,7 +752,7 @@ fn serialize_json(arguments: &Arguments) -> Value {
         format!("{}", &arguments.proxy_attestation_server_ip.as_ref().expect(&format!("Failed to get the proxy attestation server ip"))),
         arguments.enclave_debug_mode,
         serialize_execution_strategy(&arguments.execution_strategy),
-        serialize_std_channels(arguments),
+        serialize_std_streams(arguments),
     ).expect("Failed to instantiate a (struct) policy");
 
     json!(policy)

--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -27,7 +27,7 @@ use serde_json::{json, to_string_pretty, Value};
 use veracruz_utils::policy::{
     policy::Policy,
     expiry::Timepoint,
-    principal::{ExecutionStrategy, Identity, Program, FileRights},
+    principal::{ExecutionStrategy, Identity, Program, FileRights, StandardChannel},
 };
 use wasi_types::Rights;
 
@@ -139,6 +139,9 @@ struct Arguments {
     /// Describes the execution strategy (interpretation or JIT) that will be
     /// used for the computation.
     execution_strategy: String,
+    stdin: Option<String>,
+    stdout: Option<String>,
+    stderr: Option<String>,
 }
 
 impl Arguments {
@@ -160,6 +163,9 @@ impl Arguments {
             program_binaries: Vec::new(),
             enclave_debug_mode: false,
             execution_strategy: String::new(),
+            stdin: None,
+            stdout: None,
+            stderr: None,
         }
     }
 }
@@ -307,6 +313,30 @@ binary.",
                 .required(true)
                 .default_value(DEFAULT_EXECUTION_STRATEGY),
         )
+        .arg(
+            Arg::with_name("stdin")
+                .short("si")
+                .long("stdin")
+                .value_name("STDIN")
+                .help("The configuration of the standard input in the form 'path:rights'")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("stdout")
+                .short("so")
+                .long("stdout")
+                .value_name("STDOUT")
+                .help("The configuration of the standard output in the form 'path:rights'")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("stderr")
+                .short("se")
+                .long("stderr")
+                .value_name("STDERR")
+                .help("The configuration of the standard error in the form 'path:rights'")
+                .required(false),
+        )
         .get_matches();
 
     info!("Parsed command line.");
@@ -420,6 +450,32 @@ command-line parameter.",
         );
     }
 
+    if let Some(stdin) = matches.value_of("stdin") {
+        let stdin = String::from(stdin);
+        let stdin2 = stdin.clone();
+        check_capability(&[vec![stdin]]);
+        arguments.stdin = Some(stdin2);
+    } else {
+        info!("No stdin configuration was passed as command line parameters.");
+    }
+
+    if let Some(stdout) = matches.value_of("stdout") {
+        let stdout = String::from(stdout);
+        let stdout2 = stdout.clone();
+        check_capability(&[vec![stdout]]);
+        arguments.stdout = Some(stdout2);
+    } else {
+        info!("No stdout configuration was passed as command line parameters.");
+    }
+
+    if let Some(stderr) = matches.value_of("stderr") {
+        let stderr = String::from(stderr);
+        let stderr2 = stderr.clone();
+        check_capability(&[vec![stderr]]);
+        arguments.stderr = Some(stderr2);
+    } else {
+        info!("No stderr configuration was passed as command line parameters.");
+    }
     info!("Successfully extracted command line arguments.");
 
     arguments
@@ -655,6 +711,25 @@ fn serialize_execution_strategy(strategy: &str) -> ExecutionStrategy {
     }
 }
 
+/// Serializes the standard channels of all principals in the Veracruz computation into
+/// a vec of StandardChannel.
+fn serialize_std_channels(arguments: &Arguments) -> Vec<StandardChannel> {
+    info!("Serializing standard channels.");
+    
+    let mut std_channels_table = Vec::new();
+    if let Some(stdin) = &arguments.stdin {
+        std_channels_table.push(StandardChannel::Stdin(serialize_capability_entry(&stdin)));
+    }
+    if let Some(stdout) = &arguments.stdout {
+        std_channels_table.push(StandardChannel::Stdout(serialize_capability_entry(&stdout)));
+    }
+    if let Some(stderr) = &arguments.stderr {
+        std_channels_table.push(StandardChannel::Stderr(serialize_capability_entry(&stderr)));
+    }
+
+    std_channels_table
+}
+
 /// Serializes the Veracruz policy file as a JSON value.
 ///
 /// NOTE: we are glossing over TrustZone attestation for the moment, so we use
@@ -677,6 +752,7 @@ fn serialize_json(arguments: &Arguments) -> Value {
         format!("{}", &arguments.proxy_attestation_server_ip.as_ref().expect(&format!("Failed to get the proxy attestation server ip"))),
         arguments.enclave_debug_mode,
         serialize_execution_strategy(&arguments.execution_strategy),
+        serialize_std_channels(arguments),
     ).expect("Failed to instantiate a (struct) policy");
 
     json!(policy)

--- a/veracruz-utils/src/policy/policy.rs
+++ b/veracruz-utils/src/policy/policy.rs
@@ -35,7 +35,7 @@ use crate::{
         error::PolicyError,
         expiry::Timepoint,
         principal::{
-            RightsTable, ExecutionStrategy, Identity, Principal, StandardChannel,
+            RightsTable, ExecutionStrategy, Identity, Principal, StandardStream,
             Program,
         },
     },
@@ -88,8 +88,8 @@ pub struct Policy {
     debug: bool,
     /// The execution strategy that will be used to execute the WASM binary.
     execution_strategy: ExecutionStrategy,
-    /// The rights table of the standard channels.
-    std_channels_table: Vec<StandardChannel>,
+    /// The rights table of the standard streams.
+    std_streams_table: Vec<StandardStream>,
 }
 
 impl Policy {
@@ -108,7 +108,7 @@ impl Policy {
         proxy_attestation_server_url: String,
         debug: bool,
         execution_strategy: ExecutionStrategy,
-        std_channels_table: Vec<StandardChannel>,
+        std_streams_table: Vec<StandardStream>,
     ) -> Result<Self, PolicyError> {
         let policy = Self {
             identities,
@@ -122,7 +122,7 @@ impl Policy {
             proxy_attestation_server_url,
             debug,
             execution_strategy,
-            std_channels_table,
+            std_streams_table,
         };
 
         policy.assert_valid()?;
@@ -225,10 +225,10 @@ impl Policy {
         &self.execution_strategy
     }
 
-    /// Return the rights of the standard channels, associated with this policy.
+    /// Return the rights of the standard streams, associated with this policy.
     #[inline]
-    pub fn std_channels_table(&self) -> &Vec<StandardChannel> {
-        &self.std_channels_table
+    pub fn std_streams_table(&self) -> &Vec<StandardStream> {
+        &self.std_streams_table
     }
 
     /// Checks that the policy is valid, returning `Err(reason)` iff the policy

--- a/veracruz-utils/src/policy/policy.rs
+++ b/veracruz-utils/src/policy/policy.rs
@@ -35,7 +35,7 @@ use crate::{
         error::PolicyError,
         expiry::Timepoint,
         principal::{
-            RightsTable, ExecutionStrategy, Identity, Principal,
+            RightsTable, ExecutionStrategy, Identity, Principal, StandardChannel,
             Program,
         },
     },
@@ -88,6 +88,8 @@ pub struct Policy {
     debug: bool,
     /// The execution strategy that will be used to execute the WASM binary.
     execution_strategy: ExecutionStrategy,
+    /// The rights table of the standard channels.
+    std_channels_table: Vec<StandardChannel>,
 }
 
 impl Policy {
@@ -106,6 +108,7 @@ impl Policy {
         proxy_attestation_server_url: String,
         debug: bool,
         execution_strategy: ExecutionStrategy,
+        std_channels_table: Vec<StandardChannel>,
     ) -> Result<Self, PolicyError> {
         let policy = Self {
             identities,
@@ -119,6 +122,7 @@ impl Policy {
             proxy_attestation_server_url,
             debug,
             execution_strategy,
+            std_channels_table,
         };
 
         policy.assert_valid()?;
@@ -219,6 +223,12 @@ impl Policy {
     #[inline]
     pub fn execution_strategy(&self) -> &ExecutionStrategy {
         &self.execution_strategy
+    }
+
+    /// Return the rights of the standard channels, associated with this policy.
+    #[inline]
+    pub fn std_channels_table(&self) -> &Vec<StandardChannel> {
+        &self.std_channels_table
     }
 
     /// Checks that the policy is valid, returning `Err(reason)` iff the policy

--- a/veracruz-utils/src/policy/principal.rs
+++ b/veracruz-utils/src/policy/principal.rs
@@ -259,14 +259,14 @@ impl Identity<String> {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Standard channels.
+// Standard streams.
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Standard channels (`stdin`, `stdout`, `stderr`) are mapped to the VFS just like any other file, though
+/// Standard streams (`stdin`, `stdout`, `stderr`) are mapped to the VFS just like any other file, though
 /// associated with specific file descriptors and inodes.
 /// Their path (filename) and access rights are configured in the JSON policy file.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum StandardChannel {
+pub enum StandardStream {
     Stdin(FileRights),
     Stdout(FileRights),
     Stderr(FileRights),

--- a/veracruz-utils/src/policy/principal.rs
+++ b/veracruz-utils/src/policy/principal.rs
@@ -267,7 +267,10 @@ impl Identity<String> {
 /// Their path (filename) and access rights are configured in the JSON policy file.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum StandardStream {
+    /// Standard input stream with its rights
     Stdin(FileRights),
+    /// Standard output stream with its rights
     Stdout(FileRights),
+    /// Standard error stream with its rights
     Stderr(FileRights),
 }

--- a/veracruz-utils/src/policy/principal.rs
+++ b/veracruz-utils/src/policy/principal.rs
@@ -257,3 +257,17 @@ impl Identity<String> {
         Ok(())
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Standard channels.
+////////////////////////////////////////////////////////////////////////////////
+
+/// Standard channels (`stdin`, `stdout`, `stderr`) are mapped to the VFS just like any other file, though
+/// associated with specific file descriptors and inodes.
+/// Their path (filename) and access rights are configured in the JSON policy file.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum StandardChannel {
+    Stdin(FileRights),
+    Stdout(FileRights),
+    Stderr(FileRights),
+}


### PR DESCRIPTION
Improve debugging of WASM programs. Based on #155.

Done:
* ~~Redirect writes to stdout and stderr to the host's stdout and stderr~~
* Short-term solution: Change the freestanding execution engine to dump the content of stdout/stderr after computation
* Fixed bug in execution engine
* Longer-term solution: Map this feature to Veracruz capabilities, so that only allowed principals may use it

TODO:
* Even further:
  * Dump backtrace (cf. https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasmtime/src/trap.rs)
  * Interface Veracruz with debuggers?