### PR TITLE
Change examples to return Result instead of using process::exit

### DIFF
--- a/sdk/rust-examples/idash2017-logistic-regression/Cargo.toml
+++ b/sdk/rust-examples/idash2017-logistic-regression/Cargo.toml
@@ -8,7 +8,8 @@ description = "A Rust reimplementation of the winning logistic regression entry 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
+anyhow = "1.0.14"
 
 [profile.release]
 opt-level = 3

--- a/sdk/rust-examples/intersection-set-sum/Cargo.toml
+++ b/sdk/rust-examples/intersection-set-sum/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the sum of values associated with keys k_i in set A wher
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", default-features = false, features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/linear-regression/Cargo.toml
+++ b/sdk/rust-examples/linear-regression/Cargo.toml
@@ -8,8 +8,9 @@ description = "Another pure-Rust implementation of logistic regression."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", default-features = false, features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/linear-regression/src/main.rs
+++ b/sdk/rust-examples/linear-regression/src/main.rs
@@ -26,16 +26,17 @@
 //! information on licensing and copyright.
 
 use serde::Serialize;
-use std::{fs, process::exit, vec::Vec};
+use std::fs;
+use anyhow;
 
 /// Reads the single input dataset, which is assumed to be a Bincode-encoded
 /// vector of 64-bit float pairs.  Fails with
 /// `return_code::ErrorCode::DataSourceCount` if there is not exactly one input,
 /// and fails with `return_code::ErrorCode::BadInput` if the input cannot be
 /// decoded from `pinecone` into a Rust vector of floating-point pairs.
-fn read_input() -> Result<Vec<(f64, f64)>, i32> {
-    let input = fs::read("/input-0").map_err(|_| 1)?;
-    pinecone::from_bytes(&input).map_err(|_| 1)
+fn read_input() -> anyhow::Result<Vec<(f64, f64)>> {
+    let input = fs::read("/input-0")?;
+    Ok(pinecone::from_bytes(&input)?)
 }
 
 /// The result of a linear regression is a line which is encoded as a gradient
@@ -88,19 +89,10 @@ fn linear_regression(data: &[(f64, f64)]) -> LinearRegression {
 /// be a Rust vector of pairs of `f64` values.  Writes back a Bincode-encoded
 /// `LinearRegression` struct as output.  Whoever receives the result is assumed
 /// to know how to decode the result.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let data = read_input()?;
     let result = linear_regression(&data);
-    let result_encode = match pinecone::to_vec(&result) {
-        Err(_err) => return Err(1),
-        Ok(s) => s,
-    };
-    fs::write("/output", result_encode).map_err(|_| 1)?;
+    let result_encode = pinecone::to_vec(&result)?;
+    fs::write("/output", result_encode)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit(e);
-    }
 }

--- a/sdk/rust-examples/logistic-regression/Cargo.toml
+++ b/sdk/rust-examples/logistic-regression/Cargo.toml
@@ -8,9 +8,10 @@ description = "Logistic regression example, using the Rust rusty-machine ML libr
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 rusty-machine = "0.5.4"
 serde = { version = "1.0.3", features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/moving-average-convergence-divergence/Cargo.toml
+++ b/sdk/rust-examples/moving-average-convergence-divergence/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the moving-average-convergence-divergence (MACD) metric 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/moving-average-convergence-divergence/src/main.rs
+++ b/sdk/rust-examples/moving-average-convergence-divergence/src/main.rs
@@ -24,7 +24,8 @@
 //! See the file `LICENSE.markdown` in the Veracruz root directory for licensing and
 //! copyright information.
 
-use std::{fs, process::exit};
+use std::fs;
+use anyhow;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Reading inputs.
@@ -32,9 +33,9 @@ use std::{fs, process::exit};
 
 /// Reads precisely one input, which is assumed to be a Pinecone-encoded vector of `f64`
 /// values.
-fn read_inputs() -> Result<Vec<f64>, i32> {
-    let input = fs::read("/input-0").map_err(|_| 1)?;
-    pinecone::from_bytes(&input).map_err(|_| 1)
+fn read_inputs() -> anyhow::Result<Vec<f64>> {
+    let input = fs::read("/input-0")?;
+    Ok(pinecone::from_bytes(&input)?)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -159,18 +160,11 @@ fn dec_approx(data: &[f64], norm: f64) -> Vec<f64> {
 
 /// Entry point: reads the vector of floats, processes them, and writes back a new vector of
 /// floats as output.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let dataset = read_inputs()?;
     let (_wma12, _wma26, _wma_diff, _wma9, _macd_wma, _decision_wma, decisions_wma_approx) =
         computation(dataset.as_slice());
-    let result_encode =
-        pinecone::to_vec::<Vec<f64>>(&decisions_wma_approx).map_err(|_| 1)?;
-    fs::write("/output", result_encode).map_err(|_| 1)?;
+    let result_encode = pinecone::to_vec::<Vec<f64>>(&decisions_wma_approx)?;
+    fs::write("/output", result_encode)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit(e);
-    }
 }

--- a/sdk/rust-examples/number-stream-accumulation/Cargo.toml
+++ b/sdk/rust-examples/number-stream-accumulation/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the sum of two values and an initial value if there is n
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/private-set-intersection-sum/Cargo.toml
+++ b/sdk/rust-examples/private-set-intersection-sum/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the sum of values associated with keys k_i appearing in 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/private-set-intersection-sum/src/main.rs
+++ b/sdk/rust-examples/private-set-intersection-sum/src/main.rs
@@ -16,7 +16,8 @@
 //! information on licensing and copyright.
 
 use serde::Deserialize;
-use std::{collections::HashSet, fs, process::exit};
+use std::{collections::HashSet, fs};
+use anyhow;
 
 /// The identifier of each customer, a pair of `u64` values.
 type Id = (u64, u64);
@@ -45,9 +46,9 @@ struct Input {
 
 /// Reads exactly one input, which is assumed to be a Pinecone-encoded `Input`
 /// struct, as above.
-fn read_inputs() -> Result<Input, i32> {
-    let input = fs::read("/input-0").map_err(|_| 1)?;
-    pinecone::from_bytes(input.as_slice()).map_err(|_| 1)
+fn read_inputs() -> anyhow::Result<Input> {
+    let input = fs::read("/input-0")?;
+    Ok(pinecone::from_bytes(input.as_slice())?)
 }
 
 /// Computes the set intersection-sum, returning the number of elements the sample and input
@@ -66,16 +67,10 @@ fn set_intersection_sum(data: Vec<((u64, u64), u32)>, sample: Vec<(u64, u64)>) -
 
 /// The program entry point: reads exactly one input, decodes it and computes the set
 /// intersection-sum before re-encoding it into Pinecone and returning.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let data = read_inputs()?;
     let result = set_intersection_sum(data.data, data.sample);
-    let result_encode = pinecone::to_vec::<(usize, u64)>(&result).map_err(|_| 1)?;
-    fs::write("/output", result_encode).map_err(|_| 1)?;
+    let result_encode = pinecone::to_vec::<(usize, u64)>(&result)?;
+    fs::write("/output", result_encode)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit((e as u16).into());
-    }
 }

--- a/sdk/rust-examples/private-set-intersection/Cargo.toml
+++ b/sdk/rust-examples/private-set-intersection/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the intersection of two input sets."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 serde = { version = "1.0.3", features = ["derive"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/private-set-intersection/src/main.rs
+++ b/sdk/rust-examples/private-set-intersection/src/main.rs
@@ -16,7 +16,8 @@
 //! copyright information.
 
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fs, process::exit, result::Result};
+use std::{collections::HashSet, fs};
+use anyhow;
 
 /// The format of the contents of the input sets, encoding meta-data about an employee.
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
@@ -34,11 +35,11 @@ struct Person {
 /// Reads all inputs: each input is assumed to be a Bincode-encoded `HashSet<Person>`.  Function
 /// returns a `Vec` of all hash-sets, one from each input provider.  Fails with
 /// `return_code::ErrorCode::BadInput` if any input cannot be deserialized from Bincode.
-fn read_inputs() -> Result<Vec<HashSet<Person>>, i32> {
-    let input0 = fs::read("/input-0").map_err(|_| 1)?;
-    let data0 = pinecone::from_bytes(&input0).map_err(|_| 1)?;
-    let input1 = fs::read("/input-1").map_err(|_| 1)?;
-    let data1 = pinecone::from_bytes(&input1).map_err(|_| 1)?;
+fn read_inputs() -> anyhow::Result<Vec<HashSet<Person>>> {
+    let input0 = fs::read("/input-0")?;
+    let data0 = pinecone::from_bytes(&input0)?;
+    let input1 = fs::read("/input-1")?;
+    let data1 = pinecone::from_bytes(&input1)?;
     Ok(vec![data0, data1])
 }
 
@@ -65,16 +66,10 @@ fn set_intersection(sets: &[HashSet<Person>]) -> HashSet<Person> {
 /// Entry point.  Reads an unbounded number of `HashSet<Person>` inputs and finds their
 /// intersection, returning the result (again, a `HashSet<Person>`).  Assumes inputs and output are
 /// encoded as Bincode.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let inputs = read_inputs()?;
     let result = set_intersection(&inputs);
-    let result_encode = pinecone::to_vec::<HashSet<Person>>(&result).map_err(|_| 1)?;
-    fs::write("/output", result_encode).map_err(|_| 1)?;
+    let result_encode = pinecone::to_vec::<HashSet<Person>>(&result)?;
+    fs::write("/output", result_encode)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit(e);
-    }
 }

--- a/sdk/rust-examples/random-source/Cargo.toml
+++ b/sdk/rust-examples/random-source/Cargo.toml
@@ -8,8 +8,9 @@ description = "Samples random data from the trusted Veracruz runtime.  Used to t
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 rand = "0.8.0"
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/random-source/src/main.rs
+++ b/sdk/rust-examples/random-source/src/main.rs
@@ -20,23 +20,14 @@
 //! and copyright information.
 
 use rand::Rng;
-use std::{fs, process::exit, result::Result};
-
-/// Entry point: generates a four-element long random vector of `u8` values and
-/// writes this back as the result.
-fn main() {
-    if let Err(e) = random() {
-        exit(e);
-    }
-    //NOTE: it is not necessary to explicitly call exit(0).
-    exit(0);
-}
+use std::fs;
+use anyhow;
 
 /// Write 32 random bytes to 'output'. The result is a Pinecone-encoded vector of u8.
-fn random() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let output = "/output";
     let bytes = rand::thread_rng().gen::<[u8; 32]>();
-    let rst = pinecone::to_vec(&bytes.to_vec()).map_err(|_| 1)?;
-    fs::write(output, rst).map_err(|_| 1)?;
+    let rst = pinecone::to_vec(&bytes.to_vec())?;
+    fs::write(output, rst)?;
     Ok(())
 }

--- a/sdk/rust-examples/read-file/Cargo.toml
+++ b/sdk/rust-examples/read-file/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
+anyhow = "1.0.14"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/read-file/src/main.rs
+++ b/sdk/rust-examples/read-file/src/main.rs
@@ -13,21 +13,16 @@
 //! See the `LICENSE.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use std::{fs, process::exit};
+use std::fs;
+use anyhow;
 
 /// Read from 'input.txt', encode then using pinecone and write to 'output'.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let input = "/input.txt";
     let output = "/output";
 
-    let f = fs::read(input).map_err(|_| 1)?;
-    let rst = pinecone::to_vec(&f).map_err(|_| 1)?;
-    fs::write(output, rst).map_err(|_| 1)?;
+    let f = fs::read(input)?;
+    let rst = pinecone::to_vec(&f)?;
+    fs::write(output, rst)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit(e);
-    }
 }

--- a/sdk/rust-examples/string-edit-distance/Cargo.toml
+++ b/sdk/rust-examples/string-edit-distance/Cargo.toml
@@ -8,8 +8,9 @@ description = "Computes the edit distance of two strings using the Rust `strsim`
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinecone = "0.2.3"
+pinecone = { version = "0.2.3", features = ["use-std"] }
 strsim = "0.10.0"
+anyhow = "1.0.14"
 
 [profile.release]
 opt-level = 3

--- a/sdk/rust-examples/string-edit-distance/src/main.rs
+++ b/sdk/rust-examples/string-edit-distance/src/main.rs
@@ -17,8 +17,9 @@
 //! See the file `LICENSING.markdown` in the Veracruz root directory for licensing
 //! and copyright information.
 
-use std::{fs, process::exit, result::Result};
+use std::fs;
 use strsim::jaro_winkler;
+use anyhow;
 
 /// Reads two input strings via the H-call mechanism.  Fails
 ///
@@ -27,9 +28,9 @@ use strsim::jaro_winkler;
 /// - with `return_code::ErrorCode::DataSourceCount` if the number of inputs
 ///   provided to the program is not exactly 2.
 ///
-fn read_inputs() -> Result<(String, String), i32> {
-    let this = String::from_utf8(fs::read("/input-0").map_err(|_| 1)?).map_err(|_| 1)?;
-    let that = String::from_utf8(fs::read("/input-1").map_err(|_| 1)?).map_err(|_| 1)?;
+fn read_inputs() -> anyhow::Result<(String, String)> {
+    let this = String::from_utf8(fs::read("/input-0")?)?;
+    let that = String::from_utf8(fs::read("/input-1")?)?;
 
     Ok((this, that))
 }
@@ -38,16 +39,10 @@ fn read_inputs() -> Result<(String, String), i32> {
 /// which are Rust strings encoded with Pinecone.  Fails if these assumptions
 /// are not met with an error code.  Writes a Pinecone-encoded `usize`, the
 /// distance between the two strings, back as output.
-fn compute() -> Result<(), i32> {
+fn main() -> anyhow::Result<()> {
     let (left, right) = read_inputs()?;
     let distance = jaro_winkler(&left, &right);
-    let result_encode = pinecone::to_vec::<f64>(&distance).map_err(|_| 1)?;
-    fs::write("/output", result_encode).map_err(|_| 1)?;
+    let result_encode = pinecone::to_vec::<f64>(&distance)?;
+    fs::write("/output", result_encode)?;
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = compute() {
-        exit(e);
-    }
 }


### PR DESCRIPTION
This is a follow up to a discussion in #57: https://github.com/veracruz-project/veracruz/pull/57#discussion_r646748586

Rust supports returning a Result from `main`, which returns a 0 for Ok and 1 for Error and writes errors to stderr:
https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html

Instead of carefully building a proper Rust error type for each example, I just used the [anyhow](https://docs.rs/anyhow/1.0.41/anyhow/index.html) crate to glob together the existing errors. This will also propagate up any low-level errors.

This results in easier to read examples that will also log errors to stderr, which should be nice to have with https://github.com/veracruz-project/veracruz/pull/157

---

Note one oddity: the feature "use-std" is required for pinecone to make pinecone::Error satisfy std::error::Error needed for implicit anyhow::Error casting.