### PR TITLE
Fix Veracruz CI

### DIFF
--- a/sdk/freestanding-execution-engine/Cargo.toml
+++ b/sdk/freestanding-execution-engine/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.103", features = ["derive"] }
 toml = "0.5.5"
 wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch="veracruz", features = ["non_sgx"] }
 wast = "=35.0.0"
+wat = "<1.0.38"
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }
 
 [[bin]]


### PR DESCRIPTION
Sequel of https://github.com/veracruz-project/wasmtime/pull/1
Fixing the version of `wat` in `wasmtime` doesn't solve the issue.

This PR fixes the version of `wast` to `<1.0.38` in the freestanding execution engine.