### PR TITLE
Fix type signature check of clock_time_get()

### DIFF
--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -189,7 +189,7 @@ impl TypeCheck {
             WasiAPIName::ENVIRON_GET => vec![Self::POINTER, Self::POINTER],
             WasiAPIName::ENVIRON_SIZES_GET => vec![Self::POINTER, Self::POINTER],
             WasiAPIName::CLOCK_RES_GET => vec![Self::CLOCKID, Self::POINTER],
-            WasiAPIName::CLOCK_TIME_GET => vec![Self::CLOCKID, Self::TIMESTAMP, Self::TIMESTAMP],
+            WasiAPIName::CLOCK_TIME_GET => vec![Self::CLOCKID, Self::TIMESTAMP, Self::POINTER],
             WasiAPIName::FD_ADVISE => vec![Self::FD, Self::FILESIZE, Self::FILESIZE, Self::ADVICE],
             WasiAPIName::FD_ALLOCATE => vec![Self::FD, Self::FILESIZE, Self::FILESIZE],
             WasiAPIName::FD_CLOSE => vec![Self::FD],


### PR DESCRIPTION
Fixed the implementation of the `clock_time_get()` signature, which was previously failing due to the function expecting a timestamp when it should have been expecting a pointer.