### PR TITLE
Fix sundry bugs in the Veracruz virtual filesystem

### DIFF
--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -294,6 +294,10 @@ impl FileSystem {
     fn new_fd(&self) -> FileSystemResult<Fd> {
         loop {
             let new_fd = self.random_u32()?.into();
+
+            // Set upper limit to 2**31 - 1 (WASI requirement)
+            let new_fd = Fd(new_fd.0 >> 1);
+
             if !self.fd_table.contains_key(&new_fd) {
                 return Ok(new_fd);
             }

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -293,7 +293,7 @@ impl FileSystem {
     /// Pick a new fd randomly.
     fn new_fd(&self) -> FileSystemResult<Fd> {
         loop {
-            let new_fd = self.random_u32()?.into();
+            let new_fd: Fd = self.random_u32()?.into();
 
             // Set upper limit to 2**31 - 1 (WASI requirement)
             let new_fd = Fd(new_fd.0 >> 1);

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -293,10 +293,10 @@ impl FileSystem {
     /// Pick a new fd randomly.
     fn new_fd(&self) -> FileSystemResult<Fd> {
         loop {
-            let new_fd: Fd = self.random_u32()?.into();
+            let new_fd = self.random_u32()?;
 
             // Set upper limit to 2**31 - 1 (WASI requirement)
-            let new_fd = Fd(new_fd.0 >> 1);
+            let new_fd = (new_fd >> 1).into();
 
             if !self.fd_table.contains_key(&new_fd) {
                 return Ok(new_fd);

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -129,7 +129,7 @@ impl FileSystem {
             rights_table,
             prestat_table: HashMap::new(),
         };
-        rst.install_prestat(&vec![""], std_streams_table);
+        rst.install_prestat::<&Path>(&Vec::new(), std_streams_table);
         rst
     }
 


### PR DESCRIPTION
This fixes various bugs in the VFS that came to light in recent work on further Veracruz examples.

Bugs:
* wasm32 program fails when file descriptor returned by `path_open()` is bigger than 2**31
  * Fix: enforce upper bound of 2**31 to the result of `new_fd()`
* empty directory ("") conflicts with the root directory ("/") because forward slashes are stripped from the path prefix by `wasi-libc`
  * In WASI, directories are discovered (preopened) at startup, starting from file descriptor fd=3 and incrementing fd until until failure (cf. `__wasilibc_populate_preopens()` in wasi-libc).
An internal register indexes those file descriptors associated with their path.
This register is checked before calling `path_open()`, which requires the parent directory's file descriptor of the path to open.
Because any forward flash prefixing the path is stripped away when a directory is saved to the registry, the root directory ("/") ends up with the same prefix as the empty directory ("").
And since the most recent entries take precedence over the least recent ones, the result of determining the parent directory of a file under the root directory always defaults to the empty directory, which is not currently supported in our implementation of `path_open()`
  * Fix: remove empty directory from the VFS to avoid conflicts with the root directory