### PR TITLE
Pin the wasmtime version

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -21,7 +21,7 @@ ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracru
 serde = { git = "https://github.com/veracruz-project/serde.git", features=["derive"], branch = "veracruz" }
 typetag = { git = "https://github.com/veracruz-project/typetag.git", branch="veracruz" }
 wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch="veracruz" }
-wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", branch = "veracruz", optional = true }
+wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", rev = "cd67c9783600bc5437afaac088acde46ca48b650", optional = true }
 veracruz-utils = { path = "../veracruz-utils" }
 err-derive = "0.2"
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }


### PR DESCRIPTION
This is an intermediate PR to pin wasmtime to a particular commit to avoid a version synchronization error between the main veracruz repo and veracruz's wasmtime repo.