### PR TITLE
Pin bitflags to version 1.2.1

### DIFF
--- a/nitro-root-enclave-server/Cargo.toml
+++ b/nitro-root-enclave-server/Cargo.toml
@@ -18,5 +18,6 @@ transport-protocol = { path = "../transport-protocol"}
 stringreader = "0.1"
 curl = "=0.4.35"
 clap = "2.33"
+bitflags = "=1.2.1"
 local_ipaddress = "0.1.3"
 

--- a/runtime-manager-bind/Cargo.toml
+++ b/runtime-manager-bind/Cargo.toml
@@ -9,3 +9,4 @@ description = "Automatically-generated C bindings for the Runtime Manager enclav
 
 [build-dependencies]
 bindgen = "0.53.1"
+bitflags = "=1.2.1"

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -46,6 +46,7 @@ sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.g
 sgx_tcrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }
+bitflags = "=1.2.1"
 
 [build-dependencies]
 uuid = { version = "0.7", features = ["v4"] }

--- a/runtime-manager/Makefile
+++ b/runtime-manager/Makefile
@@ -152,7 +152,7 @@ $(OUT_DIR)/stripped_ta: $(OUT_DIR)/runtime_manager_enclave
 
 $(OUT_DIR)/runtime_manager_enclave: $(TZ_Src)
 	@echo $(INFO_COLOR)"CARGO <=  $(TZ_Src)" $(RESET_COLOR)
-	@OPTEE_OS_DIR=$(OPTEE_OS_DIR) xargo build --target $(TZ_TARGET) --features tz --release --verbose --out-dir $(OUT_DIR) -Z unstable-options
+	OPTEE_OS_DIR=$(OPTEE_OS_DIR) xargo build --target $(TZ_TARGET) --features tz --release --verbose --out-dir $(OUT_DIR) -Z unstable-options
 	@echo $(INFO_COLOR)"GEN   =>  runtime_manager_enclave" $(RESET_COLOR)
 
 

--- a/sdk/data-generators/csv-encoder/Cargo.toml
+++ b/sdk/data-generators/csv-encoder/Cargo.toml
@@ -8,6 +8,7 @@ description = "A utility for encoding CSV-structured data into the binary `pinec
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags   = "=1.2.1"
 clap       = "2.33.0"
 csv        = "1.0"
 env_logger = "0.7.1"

--- a/sdk/data-generators/idash2017-logistic-regression-generator/Cargo.toml
+++ b/sdk/data-generators/idash2017-logistic-regression-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/image-processing-generator/Cargo.toml
+++ b/sdk/data-generators/image-processing-generator/Cargo.toml
@@ -9,4 +9,5 @@ description = "A utility for generating synthetic images for use with the `image
 
 [dependencies]
 clap = "2.33"
+bitflags = "=1.2.1"
 image = "0.23.14"

--- a/sdk/data-generators/intersection-set-sum-generator/Cargo.toml
+++ b/sdk/data-generators/intersection-set-sum-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/linear-regression-generator/Cargo.toml
+++ b/sdk/data-generators/linear-regression-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/moving-average-convergence-divergence-generator/Cargo.toml
+++ b/sdk/data-generators/moving-average-convergence-divergence-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/number-stream-generator/Cargo.toml
+++ b/sdk/data-generators/number-stream-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/private-set-intersection-generator/Cargo.toml
+++ b/sdk/data-generators/private-set-intersection-generator/Cargo.toml
@@ -12,3 +12,4 @@ pinecone = "0.2"
 csv = "1.0"
 serde = { version = "1.0.103", features = ["derive"] }
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/private-set-intersection-sum-generator/Cargo.toml
+++ b/sdk/data-generators/private-set-intersection-sum-generator/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 rand = "0.7"
 rand_distr = "0.3"
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/shamir-secret-sharing/Cargo.toml
+++ b/sdk/data-generators/shamir-secret-sharing/Cargo.toml
@@ -14,3 +14,4 @@ codegen-units = 1
 structopt = { version="0.3", features=["wrap_help"] }
 rand = "0.8.3"
 hex = "0.4"
+bitflags = "=1.2.1"

--- a/sdk/data-generators/string-generator/Cargo.toml
+++ b/sdk/data-generators/string-generator/Cargo.toml
@@ -11,3 +11,4 @@ description = "A utility for generating synthetic strings for use with various e
 pinecone = "0.2"
 serde = { version = "1.0.103", features = ["derive"] }
 clap = "2.33"
+bitflags = "=1.2.1"

--- a/sdk/freestanding-execution-engine/Cargo.toml
+++ b/sdk/freestanding-execution-engine/Cargo.toml
@@ -11,6 +11,7 @@ description = "A freestanding WASM execution engine implementing the Veracruz AB
 execution-engine = { path = "../../execution-engine", features = ["std"] }
 veracruz-utils = { path = "../../veracruz-utils", features = ["std"] }
 clap = "2.33.3"
+bitflags = "=1.2.1"
 env_logger = "0.7.1"
 log = "0.4.8"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/sdk/rust-examples/image-processing/Cargo.toml
+++ b/sdk/rust-examples/image-processing/Cargo.toml
@@ -10,6 +10,7 @@ description = "Image processing example. Read an image from the virtual filesyst
 [dependencies]
 image = "0.23.14"
 anyhow = "1.0.14"
+bitflags = "=1.2.1"
 
 [profile.release]
 codegen-units = 1

--- a/sgx-root-enclave-bind/Cargo.toml
+++ b/sgx-root-enclave-bind/Cargo.toml
@@ -11,3 +11,4 @@ description = "Automatically-generated C bindings for the SGX root enclave image
 
 [build-dependencies]
 bindgen = "0.53.1"
+bitflags = "=1.2.1"

--- a/sgx-root-enclave/Cargo.toml
+++ b/sgx-root-enclave/Cargo.toml
@@ -19,6 +19,7 @@ veracruz-utils = { path = "../veracruz-utils", features = ["sgx"] }
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tdh = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+bitflags = "=1.2.1"
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_alloc = { git = "https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git", branch = "veracruz" }

--- a/test-collateral/generate-policy/Cargo.toml
+++ b/test-collateral/generate-policy/Cargo.toml
@@ -8,6 +8,7 @@ description = "Generates Veracruz policy files from a set of command line parame
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "=1.2.1"
 chrono = "0.4.19"
 clap = "2.33.3"
 data-encoding = "2.3.2"

--- a/trustzone-root-enclave/Cargo.toml
+++ b/trustzone-root-enclave/Cargo.toml
@@ -25,6 +25,7 @@ optee-utee = { git = "https://github.com/veracruz-project/rust-optee-trustzone-s
 veracruz-utils = { path = "../veracruz-utils", features = ["tz"] }
 lazy_static = {version = "1.4.0", features=["spin_no_std"] }
 ring = { git = "https://github.com/veracruz-project/ring.git", version = "=0.16.11", branch = "veracruz" }
+bitflags = "=1.2.1"
 
 [build-dependencies]
 uuid = { version = "=0.7.4", features = ["v4"] }

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -45,6 +45,7 @@ sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sd
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 env_logger = { version = "0.7", optional = true }
 log = { version = "0.4", optional = true }
+bitflags = "=1.2.1"
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_ucrypto = { branch="veracruz", git = 'https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git', optional = true }


### PR DESCRIPTION
`bitflags` version 1.3.1 came out and raised minimum supported Rust version to 1.46.