### PR TITLE
Add `make quick-clean` rule to clean everything but LLVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,31 @@ clean:
 	$(MAKE) clean -C linux-root-enclave
 	rm -rf bin
 
+# clean-quick cleans everything but LLVM (in wasm-checker)
+quick-clean:
+	# remove databases since these can easily fall out of date
+	rm -f proxy-attestation-server/proxy-attestation-server.db
+	rm -f veracruz-server-test/proxy-attestation-server.db
+	rm -f veracruz-test/proxy-attestation-server.db
+	# clean code
+	cd runtime-manager-bind && cargo clean 
+	cd sgx-root-enclave-bind && cargo clean
+	cd psa-attestation && cargo clean
+	cd proxy-attestation-server && cargo clean
+	cd session-manager && cargo clean
+	cd veracruz-utils && cargo clean
+	cd veracruz-server-test && cargo clean
+	cd veracruz-test && cargo clean && rm -f proxy-attestation-server.db
+	cd nitro-root-enclave-server && cargo clean
+	$(MAKE) clean -C runtime-manager
+	$(MAKE) clean -C sgx-root-enclave
+	$(MAKE) clean -C veracruz-server
+	$(MAKE) clean -C test-collateral 
+	$(MAKE) clean -C trustzone-root-enclave
+	$(MAKE) quick-clean -C sdk
+	$(MAKE) clean -C nitro-root-enclave
+	rm -rf bin
+
 # NOTE: this target deletes ALL cargo.lock.
 clean-cargo-lock:
 	$(MAKE) -C sdk clean

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -132,3 +132,14 @@ clean:
 	done
 	$(MAKE) -C freestanding-execution-engine/ clean
 	$(MAKE) -C wasm-checker/ clean
+
+quick-clean:
+	for data in $(RELATIVE_DATA_GEN); do \
+		$(MAKE) -C $$data clean; \
+	done
+	rm -rf datasets
+	for example in $(addprefix $(RUST_EXAMPLE_DIR),$(basename $(notdir $(RELATIVE_RUST_EXAMPLES)))); do \
+		$(MAKE) -C $$example clean; \
+	done
+	$(MAKE) -C freestanding-execution-engine/ clean
+	#$(MAKE) -C wasm-checker/ clean


### PR DESCRIPTION
Consider adding a rule that cleans everything but LLVM.

This build rule cleans everything but wasm-checker, which seems to be the only library dependent on LLVM. It vastly dominates the build time but is rarely the source of compilation issues.

This could isolate the LLVM build itself and avoid compiling that, but I didn't dig deep enough into wasm-checker to know where this occurs.

Alternatively this could be inverted, making this the behavior of `make clean`, and keeping the existing clean behavior as `make slow-clean`.