### PR TITLE
use the renamed version of the Nitro Enclave attestation crate

### DIFF
--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -28,7 +28,7 @@ cli = ["structopt"]
 # Note: Final attestation is always PSA. This is just to enable platforms
 # that use PSA for their native attestation.
 psa = ["psa-attestation/tz"]
-nitro = [ "serde_cbor", "nitro-enclave-token" ]
+nitro = [ "serde_cbor", "nitro-enclave-attestation-document" ]
 
 [dependencies]
 rouille = "3.0"
@@ -58,7 +58,7 @@ env_logger = "0.7"
 log = "=0.4.13"
 err-derive = "0.2"
 serde_cbor = {version = "0.11", optional = true }
-nitro-enclave-token = { git = "https://github.com/veracruz-project/nitro-enclave-token.git", branch = "main", optional = true }
+nitro-enclave-attestation-document = { git = "https://github.com/veracruz-project/nitro-enclave-attestation-document.git", branch = "main", optional = true }
 nb-connect = "=1.0.3"
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_ucrypto = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/proxy-attestation-server/src/attestation/nitro.rs
+++ b/proxy-attestation-server/src/attestation/nitro.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Mutex};
 use std::io::Write;
 use std::sync::atomic::Ordering;
 
-use nitro_enclave_token::NitroToken;
+use nitro_enclave_attestation_document::AttestationDocument;
 
 /// The DER-encoded root certificate used to authenticate the certificate chain
 /// (which is used to authenticate the Nitro Enclave tokens).
@@ -122,10 +122,10 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
             "nitro_attestation_doc",
         ));
     }
-    let (att_doc, device_id) =
+    let (att_doc_data, device_id) =
         transport_protocol::parse_nitro_attestation_doc(&parsed.get_nitro_attestation_doc());
 
-    let attestation_document = NitroToken::authenticate_token(&att_doc, &AWS_NITRO_ROOT_CERTIFICATE).map_err(|err| {
+    let attestation_document = AttestationDocument::authenticate(&att_doc_data, &AWS_NITRO_ROOT_CERTIFICATE).map_err(|err| {
         println!("proxy-attestation-server::nitro::attestation_token authenticate_token failed:{:?}", err);
         let _ignore = std::io::stdout().flush();
         ProxyAttestationServerError::CborError(format!("parse_nitro_token failed to parse token data:{:?}", err))


### PR DESCRIPTION
I've renamed the Nitro Enclave Attestation Token crate to nitro-enclave-attestation-document. This change uses that new repo and it's updated components.