### PR TITLE
Fix Makefile clean-cargo-lock target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ clean:
 # NOTE: this target deletes ALL cargo.lock.
 clean-cargo-lock:
 	$(MAKE) clean -C sdk
-	rm -f $(addsuffix /Cargo.lock,session-manager execution-engine transport-protocol veracruz-client sgx-root-enclave runtime-manager-bind runtime-manager psa-attestation veracruz-server-test veracruz-server sgx-root-enclave-bind trustzone-root-enclave proxy-attestation-server veracruz-test veracruz-util)
+	rm -f $(addsuffix /Cargo.lock,session-manager execution-engine transport-protocol veracruz-client sgx-root-enclave runtime-manager-bind runtime-manager psa-attestation veracruz-server-test veracruz-server sgx-root-enclave-bind trustzone-root-enclave proxy-attestation-server veracruz-test veracruz-utils)
 
 # update dependencies, note does NOT change Cargo.toml, useful if
 # patched/github dependencies have changed without version bump

--- a/Makefile
+++ b/Makefile
@@ -273,8 +273,9 @@ clean:
 
 # NOTE: this target deletes ALL cargo.lock.
 clean-cargo-lock:
-	$(MAKE) clean -C sdk
-	rm -f $(addsuffix /Cargo.lock,session-manager execution-engine transport-protocol veracruz-client sgx-root-enclave runtime-manager-bind runtime-manager psa-attestation veracruz-server-test veracruz-server sgx-root-enclave-bind trustzone-root-enclave proxy-attestation-server veracruz-test veracruz-utils)
+	$(MAKE) -C sdk clean
+	$(MAKE) -C test-collateral clean
+	rm -f $(addsuffix /Cargo.lock,execution-engine nitro-root-enclave nitro-root-enclave-server platform-services proxy-attestation-server psa-attestation runtime-manager runtime-manager-bind session-manager sgx-root-enclave sgx-root-enclave-bind test-collateral transport-protocol trustzone-root-enclave veracruz-client veracruz-server veracruz-server-test veracruz-test veracruz-utils)
 
 # update dependencies, note does NOT change Cargo.toml, useful if
 # patched/github dependencies have changed without version bump

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ clean:
 clean-cargo-lock:
 	$(MAKE) -C sdk clean
 	$(MAKE) -C test-collateral clean
-	rm -f $(addsuffix /Cargo.lock,execution-engine nitro-root-enclave nitro-root-enclave-server platform-services proxy-attestation-server psa-attestation runtime-manager runtime-manager-bind session-manager sgx-root-enclave sgx-root-enclave-bind test-collateral transport-protocol trustzone-root-enclave veracruz-client veracruz-server veracruz-server-test veracruz-test veracruz-utils)
+	rm -f $(addsuffix /Cargo.lock,execution-engine nitro-root-enclave nitro-root-enclave-server platform-services proxy-attestation-server psa-attestation runtime-manager runtime-manager-bind session-manager sgx-root-enclave sgx-root-enclave-bind transport-protocol trustzone-root-enclave veracruz-client veracruz-server veracruz-server-test veracruz-test veracruz-utils)
 
 # update dependencies, note does NOT change Cargo.toml, useful if
 # patched/github dependencies have changed without version bump


### PR DESCRIPTION
The Makefile target `clean-cargo-lock` was not properly deleting all `Cargo.lock` files causing disbelief, anger, and grief when trying to understand why Veracruz was not compiling correctly:

- `veracruz-utils` was incorrectly rendered as `veracruz-util` in the existing list of directories, failing to remove the lock file from that directory, silently.
- The list of directories being cleaned had become out-of-date as a result of the growth of the project.  These have now been refreshed using `echo */ | xargs -n 1 | sed 's/.$//'`.