### PR TITLE
Pinned Rouille to v3.2.1

### DIFF
--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -31,7 +31,7 @@ psa = ["psa-attestation/tz"]
 nitro = [ "serde_cbor", "nitro-enclave-attestation-document" ]
 
 [dependencies]
-rouille = "3.0"
+rouille = "=3.2.1"
 lazy_static = "1.3"
 base64 = "0.10"
 transport-protocol = { path = "../transport-protocol" }

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -24,7 +24,7 @@ dirs = "1.0.2"
 veracruz-utils = { path = "../veracruz-utils" }
 serde_json = { git = "https://github.com/veracruz-project/json.git", branch = "veracruz" }
 transport-protocol = { path = "../transport-protocol"}
-rouille = "3.0"
+rouille = "=3.2.1"
 base64 = "0.10.1"
 untrusted = "0.6.2"
 ring = "0.16"


### PR DESCRIPTION
New release of Rouille upgraded `time` dependency to a version that doesn't work with our pinned Rust version.