### PR TITLE
Added pre-commit hook for code formatting checking

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -53,7 +53,11 @@ into the main Veracruz codebase by issuing a pull request through Github.
 Before submitting any pull request, please ensure that:
 1. You have run `cargo fmt` on any changes.  A project-wide `cargo fmt`
    can be executed by building the `fmt` target in the main project
-   Makefile.
+   Makefile.  A Git pre-commit hook is available in the `githooks`
+   directory can be used to automatically check Rust files are formatted
+   correctly before they are committed.  To enable this hook, run the
+   `make setup-githooks` command which will automatically install
+   `rustfmt`, if needed, and set the Git hooks directory to `githooks`.
 2. The new changes are clearly commented using `rustdoc` markup, for
    Rust code, or similar for whatever language your changes are written
    in.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
  
-.PHONY: all sdk sgx-veracruz-client-test trustzone-veracruz-client-test nitro-veracruz-client-test sgx trustzone sgx-veracruz-server-test sgx-veracruz-server-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-veracruz-server-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env trustzone-test-env clean clean-cargo-lock fmt 
+.PHONY: all sdk setup-githooks sgx-veracruz-client-test trustzone-veracruz-client-test nitro-veracruz-client-test sgx trustzone sgx-veracruz-server-test sgx-veracruz-server-performance sgx-veracruz-test sgx-psa-attestation tz-psa-attestationtrustzone-veracruz-server-test-setting  trustzone-veracruz-test-setting trustzone-env sgx-env trustzone-test-env clean clean-cargo-lock fmt 
 
  
 WARNING_COLOR := "\e[1;33m"
@@ -26,6 +26,10 @@ BIN_DIR ?= /usr/local/cargo/bin
  
 all:
 	@echo $(WARNING_COLOR)"Please explicitly choose a target."$(RESET_COLOR)
+
+setup-githooks:
+	rustup component add rustfmt
+	git config core.hooksPath githooks
 
 # Build all of the SDK and examples
 sdk:

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,39 @@
+#! /bin/bash
+#
+# A pre-commit Git hook.
+#
+# Currently checks the formatting of all Rust files staged for commit,
+# failing if any need to be reformatted using `rustfmt`.  Note that the
+# hook does not modify any file.
+#
+# Authors
+#
+# The Veracruz Development Team.
+#
+# Copyright and licensing
+#
+# See the `LICENSE_MIT.markdown` file in the Veracruz repository root
+# directory for copyright and licensing information.
+
+HAS_ISSUES=0
+
+echo "Checking code formatting of files staged for commit."
+
+for file in $(git diff --name-only --staged \*.rs); do
+    RUSTFMT="$(rustfmt --check --skip-children --unstable-features $file)"
+    if [ "$RUSTFMT" != "" ]; then
+        printf "[ERROR]: $file\n"
+        HAS_ISSUES=1
+    else
+        printf "[   OK]: $file\n"
+    fi
+done
+
+if [ $HAS_ISSUES -eq 0 ]; then
+    echo "Code formatting style is OK."
+    exit 0
+fi
+
+echo "There are formatting issues in all of the files marked with ERROR above (if any)."
+echo "First format your code with \`make fmt\` or call \`rustfmt\` manually before committing."
+exit 1


### PR DESCRIPTION
Add pre-commit hook for code formatting checking.  Changes include:

1. Added pre-commit Git hook for code-formatting checking in new `githooks` directory.  Note that Git prevents the local `.git/hooks/` directory from being put under source control, so if we want to track these project-wide hooks then we need to introduce another directory to contain them.
2. Added a new Makefile target `setup-githooks` which installs `rustfmt`, if not already installed, and points Git to the `githooks` directory.
3. Updated `CONTRIBUTING.markdown` to document this hook, and how to set it up, locally.