### PR TITLE
Add clock-related functions to platform-services, conditionally implement them in WASI ABI

### DIFF
--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -339,13 +339,14 @@ impl FileSystem {
     #[inline]
     pub(crate) fn clock_res_get(&self, clock_id: ClockId) -> FileSystemResult<Timestamp> {
         if !self.enable_clock {
-            return Err(ErrNo::NoSys);
+            return Err(ErrNo::Access);
         }
 
         let clock_id = u32::from(clock_id) as u8;
         match getclockres(clock_id) {
             result::Result::Success(resolution) => Ok(Timestamp::from_nanos(resolution)),
-            _ => Err(ErrNo::NoSys),
+            result::Result::Unavailable => Err(ErrNo::NoSys),
+            _ => Err(ErrNo::Inval),
         }
     }
 
@@ -357,13 +358,14 @@ impl FileSystem {
         _precision: Timestamp,
     ) -> FileSystemResult<Timestamp> {
         if !self.enable_clock {
-            return Err(ErrNo::NoSys);
+            return Err(ErrNo::Access);
         }
 
         let clock_id = u32::from(clock_id) as u8;
         match getclocktime(clock_id) {
             result::Result::Success(timespec) => Ok(Timestamp::from_nanos(timespec)),
-            _ => Err(ErrNo::NoSys),
+            result::Result::Unavailable => Err(ErrNo::NoSys),
+            _ => Err(ErrNo::Inval),
         }
     }
 

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -142,10 +142,7 @@ impl FileSystem {
     ////////////////////////////////////////////////////////////////////////
 
     /// Install standard streams (`stdin`, `stdout`, `stderr`).
-    fn install_standard_streams(
-        &mut self,
-        std_streams_table: &Vec<StandardStream>,
-    ) {
+    fn install_standard_streams(&mut self, std_streams_table: &Vec<StandardStream>) {
         for std_stream in std_streams_table {
             // Map each standard stream to an fd and inode.
             // Rights are assumed to be already configured by the execution engine in the rights table

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -920,7 +920,7 @@ impl FileSystem {
     #[inline]
     pub(crate) fn random_get(&self, buf_len: Size) -> FileSystemResult<Vec<u8>> {
         let mut buf = vec![0; buf_len as usize];
-        if let result::Result::Success(_) = getrandom(&mut buf) {
+        if getrandom(&mut buf).is_success() {
             Ok(buf)
         } else {
             Err(ErrNo::NoSys)

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -629,9 +629,7 @@ impl WASMIRuntimeState {
         ))
     }
 
-    /// The implementation of the WASI `clock_res_get` function.  This is not
-    /// supported by Veracruz.  We write `0` as the resolution and return
-    /// `ErrNo::NoSys`.
+    /// The implementation of the WASI `clock_res_get` function.
     fn wasi_clock_res_get(&mut self, args: RuntimeArgs) -> WasiResult {
         TypeCheck::check_args_number(&args, WasiAPIName::CLOCK_RES_GET)?;
         let clock_id = args.nth_checked::<u32>(0)?;

--- a/execution-engine/src/wasi/wasmtime.rs
+++ b/execution-engine/src/wasi/wasmtime.rs
@@ -29,7 +29,7 @@ use wasmtime::{Caller, Extern, ExternType, Func, Instance, Module, Store, Val, V
 
 lazy_static! {
     // The initial value has NO use.
-    static ref VFS_INSTANCE: Mutex<WasiWrapper> = Mutex::new(WasiWrapper::new(Arc::new(Mutex::new(FileSystem::new(HashMap::new(), &vec![]))), Principal::NoCap));
+    static ref VFS_INSTANCE: Mutex<WasiWrapper> = Mutex::new(WasiWrapper::new(Arc::new(Mutex::new(FileSystem::new(HashMap::new(), &vec![], false))), Principal::NoCap));
 }
 
 /// A macro for lock the global VFS and store the result in the variable,

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -7,7 +7,7 @@ description = "An abstraction layer for various isolation technologies.  Exposes
 
 [features]
 default = []
-std = ["getrandom"]
+std = ["getrandom", "nix"]
 sgx = ["sgx_trts"]
 tz = ["optee-utee"]
 nitro = ["nsm_io", "nsm_lib"]
@@ -19,7 +19,7 @@ path = "./src/lib.rs"
 [dependencies]
 cfg-if = "0.1.10"
 getrandom = { version = "0.1.14", optional = true }
-nix = "0.22"
+nix = { version = "0.22", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
 nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
 sgx_trts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -19,6 +19,7 @@ path = "./src/lib.rs"
 [dependencies]
 cfg-if = "0.1.10"
 getrandom = { version = "0.1.14", optional = true }
+nix = "0.22"
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
 nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
 sgx_trts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/platform-services/src/lib.rs
+++ b/platform-services/src/lib.rs
@@ -39,7 +39,7 @@ cfg_if! {
     } else if #[cfg(feature = "std")] {
         #[path="std_platform_services.rs"]
         mod imp;
-    
+
     } else {
         compile_error!(
             "Unrecognised feature: platforms supported are SGX, TZ, Nitro, and std.");

--- a/platform-services/src/lib.rs
+++ b/platform-services/src/lib.rs
@@ -78,6 +78,7 @@ pub fn getrandom(buffer: &mut [u8]) -> result::Result<()> {
 ///     - `result::Result::Unavailable` if the specified clock is not available
 ///       on this platform.
 ///     - `result::Result::UnknownError` if a runtime error occurred.
+#[inline]
 pub fn getclockres(clock_id: u8) -> result::Result<u64> {
     imp::platform_getclockres(clock_id)
 }
@@ -90,6 +91,7 @@ pub fn getclockres(clock_id: u8) -> result::Result<u64> {
 ///     - `result::Result::Unavailable` if the specified clock is not available
 ///       on this platform.
 ///     - `result::Result::UnknownError` if a runtime error occurred.
+#[inline]
 pub fn getclocktime(clock_id: u8) -> result::Result<u64> {
     imp::platform_getclocktime(clock_id)
 }

--- a/platform-services/src/lib.rs
+++ b/platform-services/src/lib.rs
@@ -62,10 +62,34 @@ cfg_if! {
 ///     - `result::Result::UnknownError` if a runtime error occurred during
 ///       generation of the random numbers.  In which case, the contents of
 ///       `buffer` are undefined.
-pub fn getrandom(buffer: &mut [u8]) -> result::Result {
+pub fn getrandom(buffer: &mut [u8]) -> result::Result<()> {
     if buffer.is_empty() {
-        return Result::Success;
+        return Result::Success(());
     } else {
         imp::platform_getrandom(buffer)
     }
+}
+
+/// Gets resolution from the specified clock.
+///
+/// Returns:
+///     - `result::Result::Success`, embedding the clock resolution in
+///       nanoseconds, if the operation successfully completed.
+///     - `result::Result::Unavailable` if the specified clock is not available
+///       on this platform.
+///     - `result::Result::UnknownError` if a runtime error occurred.
+pub fn getclockres(clock_id: u8) -> result::Result<u64> {
+    imp::platform_getclockres(clock_id)
+}
+
+/// Gets time from the specified clock.
+///
+/// Returns:
+///     - `result::Result::Success`, embedding the clock time in
+///       nanoseconds, if the operation successfully completed.
+///     - `result::Result::Unavailable` if the specified clock is not available
+///       on this platform.
+///     - `result::Result::UnknownError` if a runtime error occurred.
+pub fn getclocktime(clock_id: u8) -> result::Result<u64> {
+    imp::platform_getclocktime(clock_id)
 }

--- a/platform-services/src/nitro_platform_services.rs
+++ b/platform-services/src/nitro_platform_services.rs
@@ -18,7 +18,7 @@ use nsm_lib;
 
 /// Fills a buffer, `buffer`, with random bytes sampled from the thread-local
 /// random number source.  Uses the AWS Nitro RNG
-pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
+pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
     let nsm_fd = nsm_lib::nsm_lib_init();
     if nsm_fd < 0 {
         return result::Result::UnknownError;
@@ -29,7 +29,7 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
         nsm_lib::nsm_get_random(nsm_fd, buffer.as_mut_ptr(), &mut buffer_len)
     };
     return match status {
-        nsm_io::ErrorCode::Success => result::Result::Success,
+        nsm_io::ErrorCode::Success => result::Result::Success(()),
         _ => result::Result::UnknownError,
     };
 }

--- a/platform-services/src/nitro_platform_services.rs
+++ b/platform-services/src/nitro_platform_services.rs
@@ -34,4 +34,14 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
     };
 }
 
+/// Returns the clock resolution in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}
 
+/// Returns the clock time in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclocktime(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}

--- a/platform-services/src/nitro_platform_services.rs
+++ b/platform-services/src/nitro_platform_services.rs
@@ -25,9 +25,7 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
     }
     let mut buffer_len = buffer.len();
 
-    let status = unsafe {
-        nsm_lib::nsm_get_random(nsm_fd, buffer.as_mut_ptr(), &mut buffer_len)
-    };
+    let status = unsafe { nsm_lib::nsm_get_random(nsm_fd, buffer.as_mut_ptr(), &mut buffer_len) };
     return match status {
         nsm_io::ErrorCode::Success => result::Result::Success(()),
         _ => result::Result::UnknownError,

--- a/platform-services/src/result.rs
+++ b/platform-services/src/result.rs
@@ -20,9 +20,9 @@
 
 //! Error codes describing the result of a platform service function.
 #[derive(Debug)]
-pub enum Result {
+pub enum Result<T> {
     /// The operation completed successfully.
-    Success,
+    Success(T),
     /// The operation is unavailable on this platform.
     Unavailable,
     /// An unknown error occurred during the execution of the operation.

--- a/platform-services/src/result.rs
+++ b/platform-services/src/result.rs
@@ -28,3 +28,12 @@ pub enum Result<T> {
     /// An unknown error occurred during the execution of the operation.
     UnknownError,
 }
+
+impl<T> Result<T> {
+    pub fn is_success(&self) -> bool {
+        match self {
+            Self::Success(_) => true,
+            _ => false,
+        }
+    }
+}

--- a/platform-services/src/result.rs
+++ b/platform-services/src/result.rs
@@ -1,7 +1,7 @@
 //! Error codes for platform services
 //!
 //! A platform service can end in one of three ways:
-//! 
+//!
 //! 1. *Success*, in which the platform service successfully executed,
 //! 2. *Unavailable*, in which the service in question is not available on
 //!    the current platfrom.  For example: a trusted time source may not be

--- a/platform-services/src/result.rs
+++ b/platform-services/src/result.rs
@@ -29,6 +29,7 @@ pub enum Result<T> {
     UnknownError,
 }
 
+/// Returns whether the result is a success.
 impl<T> Result<T> {
     pub fn is_success(&self) -> bool {
         match self {

--- a/platform-services/src/sgx_platform_services.rs
+++ b/platform-services/src/sgx_platform_services.rs
@@ -25,3 +25,15 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
     }
     result::Result::UnknownError
 }
+
+/// Returns the clock resolution in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}
+
+/// Returns the clock time in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclocktime(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}

--- a/platform-services/src/sgx_platform_services.rs
+++ b/platform-services/src/sgx_platform_services.rs
@@ -19,9 +19,9 @@ use sgx_trts::trts;
 /// Fills a buffer, `buffer`, with random bytes sampled from the thread-local
 /// random number source.  Uses the SGX trusted RTS library from the Rust SGX
 /// SDK to implement this.
-pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
+pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
     if let Ok(_) = trts::rsgx_read_rand(buffer) {
-        return result::Result::Success;
+        return result::Result::Success(());
     }
     result::Result::UnknownError
 }

--- a/platform-services/src/std_platform_services.rs
+++ b/platform-services/src/std_platform_services.rs
@@ -17,10 +17,7 @@
 use super::result;
 
 use getrandom;
-use nix::{
-    time,
-    sys::time::TimeValLike,
-};
+use nix::{sys::time::TimeValLike, time};
 
 /// Fills a buffer, `buffer`, with random bytes sampled from the random number
 /// source provided by the host operating system, as provided by `getrandom`.

--- a/platform-services/src/std_platform_services.rs
+++ b/platform-services/src/std_platform_services.rs
@@ -38,13 +38,7 @@ pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
         Ok(t) => t,
         Err(_) => return result::Result::Unavailable,
     };
-
-    // Catch overflow
-    if timespec.tv_sec() == 0 {
-        result::Result::UnknownError
-    } else {
-        result::Result::Success(timespec.num_nanoseconds() as u64)
-    }
+    result::Result::Success(timespec.num_nanoseconds() as u64)
 }
 
 /// Returns the clock time in nanoseconds.

--- a/platform-services/src/std_platform_services.rs
+++ b/platform-services/src/std_platform_services.rs
@@ -2,6 +2,8 @@
 //!
 //! Implements the `getrandom` platform service using the Rust `getrandom::getrandom()`
 //! function.
+//! Implements the `getclockres` and `getclocktime` platform services using
+//! functions provided by `nix::time`.
 //!
 //! ## Authors
 //!

--- a/platform-services/src/std_platform_services.rs
+++ b/platform-services/src/std_platform_services.rs
@@ -24,8 +24,6 @@ use nix::{
 
 /// Fills a buffer, `buffer`, with random bytes sampled from the random number
 /// source provided by the host operating system, as provided by `getrandom`.
-///
-/// This is for use with "freestanding-execution-engine".
 pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
     if let Ok(_) = getrandom::getrandom(buffer) {
         return result::Result::Success(());
@@ -34,8 +32,6 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
 }
 
 /// Returns the clock resolution in nanoseconds.
-///
-/// This is for use with "freestanding-execution-engine".
 pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
     let clock_id = time::ClockId::from_raw(clock_id.into());
     let timespec = match time::clock_getres(clock_id) {
@@ -52,8 +48,6 @@ pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
 }
 
 /// Returns the clock time in nanoseconds.
-///
-/// This is for use with "freestanding-execution-engine".
 pub fn platform_getclocktime(clock_id: u8) -> result::Result<u64> {
     let clock_id = time::ClockId::from_raw(clock_id.into());
     let timespec = match time::clock_gettime(clock_id) {

--- a/platform-services/src/tz_platform_services.rs
+++ b/platform-services/src/tz_platform_services.rs
@@ -14,7 +14,7 @@
 
 use super::result;
 
-use optee_utee::{Random};
+use optee_utee::Random;
 
 /// Fills a buffer, `buffer`, with random bytes sampled from the thread-local
 /// random number source.  Uses the Optee trusted RTS library from the Rust TZ

--- a/platform-services/src/tz_platform_services.rs
+++ b/platform-services/src/tz_platform_services.rs
@@ -19,9 +19,9 @@ use optee_utee::{Random};
 /// Fills a buffer, `buffer`, with random bytes sampled from the thread-local
 /// random number source.  Uses the Optee trusted RTS library from the Rust TZ
 /// SDK to implement this.
-pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
+pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
     Random::generate(buffer);
-    result::Result::Success
+    result::Result::Success(())
 }
 
 /// Returns the clock resolution in nanoseconds.

--- a/platform-services/src/tz_platform_services.rs
+++ b/platform-services/src/tz_platform_services.rs
@@ -23,3 +23,15 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result {
     Random::generate(buffer);
     result::Result::Success
 }
+
+/// Returns the clock resolution in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclockres(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}
+
+/// Returns the clock time in nanoseconds.
+/// TODO: implement it
+pub fn platform_getclocktime(clock_id: u8) -> result::Result<u64> {
+    result::Result::Unavailable
+}

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -101,8 +101,9 @@ impl ProtocolState {
 
         let rights_table = global_policy.get_rights_table();
         let std_streams_table = global_policy.std_streams_table();
+        let enable_clock = global_policy.enable_clock();
         let digest_table = global_policy.get_digest_table()?;
-        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_streams_table)));
+        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_streams_table, enable_clock)));
 
         Ok(ProtocolState {
             global_policy,

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -101,7 +101,7 @@ impl ProtocolState {
 
         let rights_table = global_policy.get_rights_table();
         let std_streams_table = global_policy.std_streams_table();
-        let enable_clock = global_policy.enable_clock();
+        let enable_clock = *global_policy.enable_clock();
         let digest_table = global_policy.get_digest_table()?;
         let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_streams_table, enable_clock)));
 

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -9,13 +9,15 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+use execution_engine::{execute, fs::FileSystem};
+use lazy_static::lazy_static;
 #[cfg(feature = "tz")]
 use optee_utee::trace_println;
 #[cfg(feature = "sgx")]
 use sgx_types::sgx_status_t;
-use std::sync::Mutex;
 #[cfg(feature = "sgx")]
-use std::{ffi::CString};
+use std::ffi::CString;
+use std::sync::Mutex;
 use std::{
     collections::HashMap,
     string::String,
@@ -25,8 +27,6 @@ use std::{
     },
     vec::Vec,
 };
-use lazy_static::lazy_static;
-use execution_engine::{fs::FileSystem, execute};
 use veracruz_utils::policy::{
     policy::Policy,
     principal::{ExecutionStrategy, Principal},
@@ -103,7 +103,11 @@ impl ProtocolState {
         let std_streams_table = global_policy.std_streams_table();
         let enable_clock = *global_policy.enable_clock();
         let digest_table = global_policy.get_digest_table()?;
-        let vfs = Arc::new(Mutex::new(FileSystem::new(rights_table, std_streams_table, enable_clock)));
+        let vfs = Arc::new(Mutex::new(FileSystem::new(
+            rights_table,
+            std_streams_table,
+            enable_clock,
+        )));
 
         Ok(ProtocolState {
             global_policy,
@@ -145,7 +149,6 @@ impl ProtocolState {
         file_name: &str,
         data: &[u8],
     ) -> Result<(), RuntimeManagerError> {
-
         // Check the digest, if necessary
         if let Some(digest) = self.digest_table.get(file_name) {
             let incoming_digest = Self::sha_256_digest(data);
@@ -158,14 +161,11 @@ impl ProtocolState {
                 }
             }
         }
-        // Set the modified flag 
+        // Set the modified flag
         self.is_modified = true;
-        self.vfs.lock()?.write_file_by_filename(
-            client_id,
-            file_name,
-            data,
-            false,
-        )?;
+        self.vfs
+            .lock()?
+            .write_file_by_filename(client_id, file_name, data, false)?;
         Ok(())
     }
 
@@ -184,17 +184,14 @@ impl ProtocolState {
         file_name: &str,
         data: &[u8],
     ) -> Result<(), RuntimeManagerError> {
-        // If a file must match a digest, e.g. a program, 
+        // If a file must match a digest, e.g. a program,
         // it is not permitted to append the file.
         if self.digest_table.contains_key(file_name) {
             return Err(RuntimeManagerError::FileSystemError(ErrNo::Access));
         }
         self.is_modified = true;
         self.vfs.lock()?.write_file_by_filename(
-            client_id,
-            file_name,
-            data,
-            // set the append flag to true
+            client_id, file_name, data, // set the append flag to true
             true,
         )?;
         Ok(())
@@ -206,10 +203,10 @@ impl ProtocolState {
         client_id: &Principal,
         file_name: &str,
     ) -> Result<Option<Vec<u8>>, RuntimeManagerError> {
-        let rst = self.vfs.lock()?.read_file_by_filename(
-            client_id,
-            file_name,
-        )?;
+        let rst = self
+            .vfs
+            .lock()?
+            .read_file_by_filename(client_id, file_name)?;
         if rst.len() == 0 {
             return Ok(None);
         }

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -68,10 +68,9 @@ const DEFAULT_DUMP_STDOUT: &'static str = "false";
 /// The default dump status of `stderr`, if no alternative is provided on the
 /// command line.
 const DEFAULT_DUMP_STDERR: &'static str = "false";
-
 /// The default value of the clock flag, if no alternative is provided on the
 /// command line.
-const DEFAULT_ENABLE_CLOCK: bool = false;
+const DEFAULT_ENABLE_CLOCK: &'static str = "false";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Command line options and parsing.
@@ -216,7 +215,9 @@ fn parse_command_line() -> Result<CommandLineOptions, Box<dyn Error>> {
         }
     };
 
-    let enable_clock = if let Some(enable_clock) = matches.value_of("enable-clock") {
+    let enable_clock = {
+        let enable_clock = matches.value_of("enable-clock")
+            .unwrap_or(DEFAULT_ENABLE_CLOCK);
         if let Ok(enable_clock) = bool::from_str(enable_clock) {
             if enable_clock { info!("Clock functions are enabled."); }
             enable_clock
@@ -224,8 +225,6 @@ fn parse_command_line() -> Result<CommandLineOptions, Box<dyn Error>> {
             return Err(format!("Expecting a boolean, but found {}", enable_clock)
             .into());
         }
-    } else {
-        return Err("Default 'enable-clock' value is not loaded correctly".into());
     };
 
     Ok(CommandLineOptions {

--- a/test-collateral/Makefile
+++ b/test-collateral/Makefile
@@ -128,9 +128,10 @@ css-$(TEE).bin: $(RUNTIME_MANAGER_CSS_BIN)
 get_random_policy.json: pgen pgen css-$(TEE).bin client_rsa_cert.pem random-source.wasm
 	./pgen --certificate client_rsa_cert.pem --capability "output : $(READ_RIGHT), random-source.wasm : $(WRITE_RIGHT)" \
 		--binary random-source.wasm --capability "output : $(WRITE_RIGHT)" \
-       --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
+		--veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--enclave-debug-mode true --execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) --proxy-attestation-server-cert ../test-collateral/CACert.pem
 
 one_data_source_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem linear-regression.wasm
@@ -139,6 +140,7 @@ one_data_source_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem linear-regr
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -148,6 +150,7 @@ test_multiple_key_policy.json: pgen css-$(TEE).bin client_rsa_cert.pem moving-av
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -157,6 +160,7 @@ two_data_source_string_edit_distance_policy.json: pgen css-$(TEE).bin client_rsa
 		--veracruz-server-ip 127.0.0.1:3013 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -166,6 +170,7 @@ two_data_source_intersection_set_policy.json: pgen css-$(TEE).bin client_rsa_cer
 		--veracruz-server-ip 127.0.0.1:3022 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -175,6 +180,7 @@ two_data_source_private_set_intersection_policy.json: pgen css-$(TEE).bin client
 		--veracruz-server-ip 127.0.0.1:3026 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -185,6 +191,7 @@ dual_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert.p
 		--veracruz-server-ip 127.0.0.1:3014 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -195,6 +202,7 @@ dual_parallel_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_clie
 	--veracruz-server-ip 127.0.0.1:3015 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -206,6 +214,7 @@ triple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_cert
 		--veracruz-server-ip 127.0.0.1:3016 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		 --execution-strategy Interpretation \
 		 --stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -217,6 +226,7 @@ triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin program_cli
 		--veracruz-server-ip 127.0.0.1:3017 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -228,6 +238,7 @@ permuted_triple_parties_two_data_sources_sum_policy.json: pgen css-$(TEE).bin pr
 		--veracruz-server-ip 127.0.0.1:3018 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -239,6 +250,7 @@ triple_parties_two_data_sources_string_edit_distance_policy.json: pgen css-$(TEE
 		--veracruz-server-ip 127.0.0.1:3019 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -251,6 +263,7 @@ quadruple_policy.json: pgen css-$(TEE).bin program_client_cert.pem data_client_c
 		--veracruz-server-ip 127.0.0.1:3020 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -260,6 +273,7 @@ invalid_policy/one_expired_data_source_policy.json: pgen css-$(TEE).bin expired_
 		--veracruz-server-ip 127.0.0.1:3021 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -269,6 +283,7 @@ idash2017_logistic_regression_policy.json: pgen css-$(TEE).bin client_rsa_cert.p
 		--veracruz-server-ip 127.0.0.1:3023 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -278,6 +293,7 @@ moving_average_convergence_divergence.json: pgen css-$(TEE).bin client_rsa_cert.
 		--veracruz-server-ip 127.0.0.1:3024 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -287,6 +303,7 @@ private_set_intersection_sum.json: pgen css-$(TEE).bin client_rsa_cert.pem priva
 		--veracruz-server-ip 127.0.0.1:3025 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 
@@ -304,6 +321,7 @@ basic_file_read_write.json: pgen css-$(TEE).bin client_rsa_cert.pem read-file.wa
         --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 --output-policy-file $@ --certificate-expiry $(CERTIFICATE_EXPIRY) \
 		--enclave-debug-mode true --execution-strategy Interpretation \
 		--stdin "stdin : $(READ_RIGHT)" --stdout "stdout : $(WRITE_RIGHT)" --stderr "stderr : $(WRITE_RIGHT)" \
+		--enable-clock true \
 		--css-file $(RUNTIME_MANAGER_CSS_BIN) --pcr-file $(RUNTIME_MANAGER_PCR0) \
 		--proxy-attestation-server-cert ../test-collateral/CACert.pem
 

--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -179,7 +179,7 @@ impl Arguments {
             stdin: None,
             stdout: None,
             stderr: None,
-            enable_clock: None,
+            enable_clock: false,
         }
     }
 }

--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -361,9 +361,7 @@ binary.",
                     "Specifies whether the Veracruz trusted runtime should allow the WASM \
 binary to call clock functions (`clock_getres()`, `clock_gettime()`).",
                 )
-                .required(true)
                 .value_name("BOOLEAN")
-                .default_value(&default_enable_clock),
         )
         .get_matches();
 

--- a/veracruz-utils/src/policy/policy.rs
+++ b/veracruz-utils/src/policy/policy.rs
@@ -37,10 +37,7 @@ use crate::{
     policy::{
         error::PolicyError,
         expiry::Timepoint,
-        principal::{
-            RightsTable, ExecutionStrategy, Identity, Principal, StandardStream,
-            Program,
-        },
+        principal::{ExecutionStrategy, Identity, Principal, Program, RightsTable, StandardStream},
     },
 };
 use ring;
@@ -48,9 +45,9 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{
     collections::HashMap,
+    path::PathBuf,
     string::{String, ToString},
     vec::Vec,
-    path::PathBuf,
 };
 use wasi_types::Rights;
 
@@ -103,7 +100,7 @@ pub struct Policy {
 
     /// Hash of the JSON representation if the Policy was parsed from a file.
     #[serde(skip)]
-    policy_hash: Option<String>
+    policy_hash: Option<String>,
 }
 
 impl Policy {
@@ -159,12 +156,7 @@ impl Policy {
         policy.assert_valid()?;
 
         // include hash?
-        let hash = hex::encode(
-            ring::digest::digest(
-                &ring::digest::SHA256,
-                json.as_bytes()
-            )
-        );
+        let hash = hex::encode(ring::digest::digest(&ring::digest::SHA256, json.as_bytes()));
         policy.policy_hash = Some(hash);
 
         Ok(policy)
@@ -392,14 +384,15 @@ impl Policy {
     /// Extract the input filenames from a right_map. If a prorgam has rights call
     /// fd_read and path_open, it is considered as an input file.
     fn get_required_inputs(right_map: &HashMap<PathBuf, Rights>) -> Vec<PathBuf> {
-        let mut rst = right_map.iter().fold(Vec::new(), |mut acc, (file_name, right)| {
-            if right.contains(Rights::FD_READ | Rights::PATH_OPEN) {
-                acc.push(file_name.into());
-            }
-            acc
-        });
+        let mut rst = right_map
+            .iter()
+            .fold(Vec::new(), |mut acc, (file_name, right)| {
+                if right.contains(Rights::FD_READ | Rights::PATH_OPEN) {
+                    acc.push(file_name.into());
+                }
+                acc
+            });
         rst.sort();
         rst
     }
 }
-

--- a/veracruz-utils/src/policy/policy.rs
+++ b/veracruz-utils/src/policy/policy.rs
@@ -16,6 +16,9 @@
 //!   to execute the WASM binary, as well as a debug configuration flag which
 //!   allows the WASM binary to write data to `stdout` on the untrusted host's
 //!   machine,
+//! - The rights table of the standard streams (`stdin`, `stdout`, `stderr`),
+//! - A clock flag which allows the the WASM binary to call clock functions to
+//!   e.g. get a clock's time or resolution,
 //! - The order in which data inputs provisioned into the enclave will be placed
 //!   which is important for the program provider to understand in order to
 //!   write software for Veracruz.
@@ -87,13 +90,16 @@ pub struct Policy {
     /// platform constraints for the policy
     proxy_service_cert: String,
     /// The debug configuration flag.  This dictates whether the WASM program
-    /// will be able to print debug configuration messages to *stdout* on the
+    /// will be able to print debug configuration messages to `stdout` on the
     /// host's machine.
     debug: bool,
     /// The execution strategy that will be used to execute the WASM binary.
     execution_strategy: ExecutionStrategy,
-    /// The rights table of the standard streams.
+    /// The rights table of the standard streams (`stdin`, `stdout`, `stderr`).
     std_streams_table: Vec<StandardStream>,
+    /// The clock flag.  This dictates whether the WASM program will be able to
+    /// call clock functions to e.g. get a clock's time or resolution.
+    enable_clock: bool,
 
     /// Hash of the JSON representation if the Policy was parsed from a file.
     #[serde(skip)]
@@ -118,6 +124,7 @@ impl Policy {
         debug: bool,
         execution_strategy: ExecutionStrategy,
         std_streams_table: Vec<StandardStream>,
+        enable_clock: bool,
     ) -> Result<Self, PolicyError> {
         let policy = Self {
             identities,
@@ -133,6 +140,7 @@ impl Policy {
             debug,
             execution_strategy,
             std_streams_table,
+            enable_clock,
 
             policy_hash: None,
         };
@@ -256,6 +264,12 @@ impl Policy {
     #[inline]
     pub fn std_streams_table(&self) -> &Vec<StandardStream> {
         &self.std_streams_table
+    }
+
+    /// Returns the clock flag associated with this policy.
+    #[inline]
+    pub fn enable_clock(&self) -> &bool {
+        &self.enable_clock
     }
 
     /// Returns the hash of the source JSON representation, if available


### PR DESCRIPTION
Implement clock functions (`clock_getres()` and `clock_gettime()`) for the standard platform service.
The SGX, Nitro and Trustzone platform services don't implement those functions yet and return `result::Result::Unavailable`. They will be implemented later on in a separate PR.
`result::Result::Success` has been changed to include the time in nanoseconds (u64).

TODO:
+ ~~Link clock functions to policies: Disable them by default, unless specified otherwise~~
+ ~~Rebase on top of @egrimley-arm 's work on clap (#212 and #216)~~
+ ~~Fixing rebase issues~~
+ ~~Return more appropriate error codes~~
