### PR TITLE
Force rustfmt to use 2018 Rust edition in pre-commit hook

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -20,7 +20,7 @@ HAS_ISSUES=0
 echo "Checking code formatting of files staged for commit."
 
 for file in $(git diff --name-only --staged \*.rs); do
-    RUSTFMT="$(rustfmt --check --skip-children --unstable-features $file)"
+    RUSTFMT="$(rustfmt --edition=2018 --check --skip-children --unstable-features $file)"
     if [ "$RUSTFMT" != "" ]; then
         printf "[ERROR]: $file\n"
         HAS_ISSUES=1


### PR DESCRIPTION
There is a bug in `rustfmt` currently that ignores the edition set in `Cargo.toml` files and defaults to 2015 edition. This means it errors on any staged file containing the `async` keyword, and any other change introduced in rust 2018.
The solution is to force the Rust edition to use when calling `rustfmt`.