### PR TITLE
PAS: Removed dependency on policy.json in the Proxy Attestation Server CLI

### DIFF
--- a/GETTING_STARTED_CLI.markdown
+++ b/GETTING_STARTED_CLI.markdown
@@ -204,7 +204,7 @@ Now we can launch the Proxy Attestation Server with the
 character `&` to launch the Proxy Attestation Server in the background:
 
 ``` bash
-$ vc-pas example/example-policy.json \
+$ vc-pas :3010 \
     --database-url=example/example-pas.db \
     --ca-cert=example/example-ca-cert.pem \
     --ca-key=example/example-ca-key.pem &

--- a/proxy-attestation-server/src/server.rs
+++ b/proxy-attestation-server/src/server.rs
@@ -18,6 +18,7 @@ use crate::attestation::sgx;
 use crate::attestation::nitro;
 
 use lazy_static::lazy_static;
+use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 lazy_static! {
@@ -195,8 +196,9 @@ async fn nitro_router(nitro_request: web::Path<String>, input_data: String) -> P
     Err(ProxyAttestationServerError::UnimplementedRequestError)
 }
 
-pub fn server<P1, P2>(url: String, ca_cert_path: P1, ca_key_path: P2, debug: bool) -> Result<Server, String>
+pub fn server<U, P1, P2>(url: U, ca_cert_path: P1, ca_key_path: P2, debug: bool) -> Result<Server, String>
 where
+    U: ToSocketAddrs,
     P1: AsRef<path::Path>,
     P2: AsRef<path::Path>
 {
@@ -220,7 +222,7 @@ where
             .route("/PSA/{psa_request}", web::post().to(psa_router))
             .route("/Nitro/{nitro_request}", web::post().to(nitro_router))
     })
-    .bind(&url)
+    .bind(url)
     .map_err(|err| format!("binding error: {:?}", err))?
     .run();
     Ok(server)


### PR DESCRIPTION
This was a lingering limitation from when the Proxy Attestation Server required more info from the policy file.

Now, in `vc-pas`, the primary argument is what address to bind to, and no policy is needed in the Proxy Attestation Server.

It's almost possible to let users omit this argument, and default to the standard Proxy Attestation Port for all addresses, except, well, we don't have a standard port for the Proxy Attestation Server. Choosing two arbitrary ports as standard ports for Veracruz's Proxy Attestation Server and Server Server would be nice for quality-of-life things like this, but I've omitted it for now.