### PR TITLE
Add `http = "=0.2.4"` to veracruz_server to fix E0658

### DIFF
--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -55,4 +55,4 @@ uuid = { version = "0.7", optional = true }
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 env_logger = { version = "0.7", optional = true }
 actix-rt = { version = "1.0.0", optional = true }
-
+http = "=0.2.4"


### PR DESCRIPTION
See https://github.com/veracruz-project/veracruz/pull/224

This was brought in suddenly by a version bump in Actix, previously veracruz_server didn't depend on the http crate directly.