### PR TITLE
githooks/pre-commit: Also check for trailing whitespace.

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -15,25 +15,43 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz repository root
 # directory for copyright and licensing information.
 
-HAS_ISSUES=0
+HAS_RUSTFMT_ISSUES=0
+HAS_SPACE_ISSUES=0
 
 echo "Checking code formatting of files staged for commit."
 
 for file in $(git diff --name-only --staged \*.rs); do
     RUSTFMT="$(rustfmt --edition=2018 --check --skip-children --unstable-features $file)"
-    if [ "$RUSTFMT" != "" ]; then
+    SPACES="$(sed -n '/[\t ]$/p' $file)"
+    if [ "$RUSTFMT" != "" -o "$SPACES" != "" ]; then
         printf "[ERROR]: $file\n"
-        HAS_ISSUES=1
+        if [ "$RUSTFMT" != "" ]; then
+            # Since rustfmt will detect/delete some trailing whitespace,
+            # we ignore trailing whitespace when rustfmt finds a problem.
+            HAS_RUSTFMT_ISSUES=1
+        else
+            HAS_SPACE_ISSUES=1
+        fi
     else
         printf "[   OK]: $file\n"
     fi
 done
 
-if [ $HAS_ISSUES -eq 0 ]; then
+if [ $HAS_RUSTFMT_ISSUES -eq 1 ]; then
+    echo "There are formatting issues in all of the files marked with ERROR"
+    echo "above. Please format your code with \`make fmt\` or call \`rustfmt\`"
+    echo "manually before committing."
+    if [ $HAS_SPACE_ISSUES -eq 1 ]; then
+        echo "Also, some files had trailing whitespace that \`rustfmt\` did not"
+        echo "complain about."
+    fi
+    exit 1
+elif [ $HAS_SPACE_ISSUES -eq 1 ]; then
+    echo "Each file marked with ERROR above contains trailing whitespace."
+    echo "Please remove it, for example with \`perl -i -pe 's/[ \t]+$//;'\`,"
+    echo "before committing."
+    exit 1
+else
     echo "Code formatting style is OK."
     exit 0
 fi
-
-echo "There are formatting issues in all of the files marked with ERROR above (if any)."
-echo "First format your code with \`make fmt\` or call \`rustfmt\` manually before committing."
-exit 1


### PR DESCRIPTION
Currently rustfmt does not catch all trailing whitespace, though
that may change.