### PR TITLE
Cargo Git configuration improvements

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -27,3 +27,7 @@ rustflags = [
 [target.arm-unknown-linux-gnueabihf]
 linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc"
 ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc-ar"
+
+[net]
+retry = 3
+git-fetch-with-cli = true


### PR DESCRIPTION
Configured Cargo to:
- Use the Git command line tool rather than the Rust `libgit2` library,
- Retry all network attempts 3 times.