### PR TITLE
Add AArch64 support Linux platform

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -9,10 +9,6 @@ rustflags = [
     "-C", "link-dead-code",
 ]
 
-[target.aarch64-unknown-linux-gnu]
-linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc"
-ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc-ar"
-
 [target.arm-unknown-optee-trustzone]
 linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd"
 ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ar"
@@ -23,10 +19,6 @@ rustflags = [
     "-C", "link-arg=-pie",
     "-C", "link-dead-code",
 ]
-
-[target.arm-unknown-linux-gnueabihf]
-linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc"
-ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc-ar"
 
 [net]
 retry = 3

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,14 @@ trustzone-cli: trustzone-env
 	# build CLIs in top-level crates
 	cd proxy-attestation-server && \
 		CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(AARCH64_GCC) \
 		OPENSSL_INCLUDE_DIR=$(OPENSSL_INCLUDE_DIR) \
 		OPENSSL_LIB_DIR=$(OPENSSL_LIB_DIR) \
 		C_INCLUDE_PATH=$(TRUSTZONE_C_INCLUDE_PATH) \
 		cargo build --target aarch64-unknown-linux-gnu --features tz --features cli
 	cd veracruz-server && \
 		CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(AARCH64_GCC) \
 		OPENSSL_INCLUDE_DIR=$(OPENSSL_INCLUDE_DIR) \
 		OPENSSL_LIB_DIR=$(OPENSSL_LIB_DIR) \
 		C_INCLUDE_PATH=$(TRUSTZONE_C_INCLUDE_PATH) \
@@ -198,12 +200,14 @@ sgx-psa-attestation: sgx-env
 
 tz-psa-attestation: trustzone-env
 	cd psa-attestation && CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(AARCH64_GCC) \
 		cargo build --target aarch64-unknown-linux-gnu --features tz
 
 trustzone-veracruz-server-test: trustzone-test-collateral trustzone trustzone-test-env veracruz-server-test/proxy-attestation-server.db
 	cd veracruz-server-test \
         && CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) OPENSSL_INCLUDE_DIR=$(OPENSSL_INCLUDE_DIR) \
                 OPENSSL_LIB_DIR=$(OPENSSL_LIB_DIR) C_INCLUDE_PATH=$(TRUSTZONE_C_INCLUDE_PATH) \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(AARCH64_GCC) \
                 cargo test --target aarch64-unknown-linux-gnu --no-run --features tz -- --test-threads=1 \
 		&& ./cp-veracruz-server-test-tz.sh
 	chmod u+x run_veracruz_server_test_tz.sh
@@ -213,6 +217,7 @@ trustzone-veracruz-test: trustzone-test-collateral trustzone trustzone-test-env 
 	cd veracruz-test \
         && CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) OPENSSL_INCLUDE_DIR=$(OPENSSL_INCLUDE_DIR) \
                 OPENSSL_LIB_DIR=$(OPENSSL_LIB_DIR) C_INCLUDE_PATH=$(TRUSTZONE_C_INCLUDE_PATH) \
+		CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(AARCH64_GCC) \
                 cargo test --target aarch64-unknown-linux-gnu --no-run --features tz -- --test-threads=1
 	cd veracruz-test && ./cp-veracruz-tz.sh
 	chmod u+x run_veracruz_test_tz.sh

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,8 @@ sgx-psa-attestation: sgx-env
 	cd psa-attestation && cargo build --features sgx
 
 tz-psa-attestation: trustzone-env
-	cd psa-attestation && cargo build --target aarch64-unknown-linux-gnu --features tz
+	cd psa-attestation && CC_aarch64_unknown_linux_gnu=$(AARCH64_GCC) \
+		cargo build --target aarch64-unknown-linux-gnu --features tz
 
 trustzone-veracruz-server-test: trustzone-test-collateral trustzone trustzone-test-env veracruz-server-test/proxy-attestation-server.db
 	cd veracruz-server-test \

--- a/linux-root-enclave/src/main.rs
+++ b/linux-root-enclave/src/main.rs
@@ -564,13 +564,18 @@ fn native_attestation(
     let mut token_buffer = Vec::with_capacity(1024);
     let mut token_size = 0u64;
 
+    #[cfg(target_arch = "aarch64")]
+    let enclave_name = std::ptr::null() as *const u8;
+    #[cfg(target_arch = "x86_64")]
+    let enclave_name = std::ptr::null() as *const i8;
+
     if 0 != unsafe {
         psa_initial_attest_get_token(
             LINUX_ROOT_ENCLAVE_MEASUREMENT.as_ptr() as *const u8,
             LINUX_ROOT_ENCLAVE_MEASUREMENT.len() as u64,
             csr_hash.as_ptr() as *const u8,
             csr_hash.len() as u64,
-            std::ptr::null() as *const i8,
+            enclave_name,
             0,
             challenge.as_ptr() as *const u8,
             challenge.len() as u64,

--- a/runtime-manager/.cargo/config
+++ b/runtime-manager/.cargo/config
@@ -9,10 +9,6 @@ rustflags = [
     "-C", "link-dead-code",
 ]
 
-[target.aarch64-unknown-linux-gnu]
-linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc"
-ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc-ar"
-
 [target.arm-unknown-optee-trustzone]
 linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd"
 ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ar"
@@ -23,7 +19,3 @@ rustflags = [
     "-C", "link-arg=-pie",
     "-C", "link-dead-code",
 ]
-
-[target.arm-unknown-linux-gnueabihf]
-linker = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc"
-ar = "/work/rust-optee-trustzone-sdk/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc-ar"


### PR DESCRIPTION
This requires https://github.com/veracruz-project/veracruz-docker-image/pull/24 to be merged, and must be built on AArch64 Linux system.