### PR TITLE
Fix pgen

### DIFF
--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -332,7 +332,7 @@ binary.",
         )
         .arg(
             Arg::with_name("enable-clock")
-                .short("c")
+                .short("n")
                 .long("enable-clock")
                 .help(
                     "Specifies whether the Veracruz trusted runtime should allow the WASM \


### PR DESCRIPTION
Change short name for --enable-clock to avoid collisions with other arguments (certificates).
Fixes crash when running pgen aka generate-policy