### PR TITLE
Adopt copy-less APIs in the VFS

### DIFF
--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -220,9 +220,8 @@ impl InodeImpl {
         //             ----------------------------------
         //             | buf                            |
         //             ----------------------------------
-        let remain_length = bytes.len() - offset;
-        if buf.len() > remain_length{
-            bytes.resize(buf.len() - remain_length, 0);
+        if offset + buf.len() > bytes.len() {
+            bytes.resize(offset + buf.len(), 0);
         }
         let write_length = buf.len();
         bytes[offset..(offset + write_length)].copy_from_slice(&buf);

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -21,8 +21,9 @@ use policy_utils::principal::{FileRights, Principal, RightsTable};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
 use std::{
+    cmp::min,
     collections::HashMap,
-    convert::{AsRef, TryFrom},
+    convert::{AsRef, TryFrom, TryInto},
     ffi::OsString,
     // TODO: wait for icecap to support direct conversion between bytes and os_str, bypassing
     // potential utf-8 encoding check
@@ -84,15 +85,15 @@ impl InodeEntry {
     /// Read maximum `max` bytes from the offset `offset`.
     /// Return ErrNo::IsDir if it is not a file.
     #[inline]
-    pub(self) fn read_file(&self, max: usize, offset: FileSize) -> FileSystemResult<Vec<u8>> {
-        self.data.read_file(max, offset)
+    pub(self) fn read_file(&self, buf: &mut [u8], offset: FileSize) -> FileSystemResult<usize> {
+        self.data.read_file(buf, offset)
     }
 
     /// Write `buf` to the file from the offset `offset`,
     /// update the file status and return the number of written bytes.
     /// Otherwise, return ErrNo::IsDir if it is not a file.
     #[inline]
-    pub(self) fn write_file(&mut self, buf: Vec<u8>, offset: FileSize) -> FileSystemResult<Size> {
+    pub(self) fn write_file(&mut self, buf: &[u8], offset: FileSize) -> FileSystemResult<usize> {
         let rst = self.data.write_file(buf, offset)?;
         self.file_stat.file_size = self.data.len()?;
         Ok(rst)
@@ -179,7 +180,7 @@ impl InodeImpl {
 
     /// Read maximum `max` bytes from the offset `offset`.
     /// Otherwise, return ErrNo::IsDir if it is not a file.
-    pub(self) fn read_file(&self, max: usize, offset: FileSize) -> FileSystemResult<Vec<u8>> {
+    pub(self) fn read_file(&self, buf: &mut [u8], offset: FileSize) -> FileSystemResult<usize> {
         let bytes = match self {
             Self::File(b) => b,
             Self::Directory(_) => return Err(ErrNo::IsDir),
@@ -196,18 +197,14 @@ impl InodeImpl {
         //             | rst                  |
         //             ------------------------
         let (_, to_read) = bytes.split_at(offset);
-        let read_length = if max < to_read.len() {
-            max
-        } else {
-            to_read.len()
-        };
-        let (rst, _) = to_read.split_at(read_length);
-        Ok(rst.to_vec())
+        let read_length = min(buf.len(), to_read.len());
+        buf[..read_length].copy_from_slice(&to_read[..read_length]);
+        Ok(read_length)
     }
 
     /// Write `buf` to the file from the offset `offset` and return the number of written bytes.
     /// Otherwise, return ErrNo::IsDir if it is not a file.
-    pub(self) fn write_file(&mut self, buf: Vec<u8>, offset: FileSize) -> FileSystemResult<Size> {
+    pub(self) fn write_file(&mut self, buf: &[u8], offset: FileSize) -> FileSystemResult<usize> {
         let bytes = match self {
             Self::File(b) => b,
             Self::Directory(_) => return Err(ErrNo::IsDir),
@@ -224,13 +221,12 @@ impl InodeImpl {
         //             | buf                            |
         //             ----------------------------------
         let remain_length = bytes.len() - offset;
-        if remain_length <= buf.len() {
-            let mut grow_vec = vec![0; buf.len() - remain_length];
-            bytes.append(&mut grow_vec);
+        if buf.len() > remain_length{
+            bytes.resize(buf.len() - remain_length, 0);
         }
-        let rst = buf.len();
-        bytes[offset..(offset + rst)].copy_from_slice(&buf);
-        Ok(rst as Size)
+        let write_length = buf.len();
+        bytes[offset..(offset + write_length)].copy_from_slice(&buf);
+        Ok(write_length)
     }
 
     /// Truncate the file.
@@ -998,18 +994,27 @@ impl FileSystem {
     /// how a particular execution engine handles the memory.
     /// That is, different engines provide different API to interact the linear memory
     /// space of WASM. Hence, the method here return the read bytes as `Vec<u8>`.
-    pub(crate) fn fd_pread(
+    pub(crate) fn fd_pread<B: AsMut<[u8]>>(
         &self,
         fd: Fd,
-        buffer_len: usize,
+        bufs: &mut [B],
         offset: FileSize,
-    ) -> FileSystemResult<Vec<u8>> {
+    ) -> FileSystemResult<usize> {
         self.check_right(&fd, Rights::FD_READ)?;
         let inode = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.inode;
 
-        self.lock_inode_table()?
-            .get(&inode)?
-            .read_file(buffer_len, offset)
+        let f = self.lock_inode_table()?;
+        let f = f.get(&inode)?;
+
+        let mut offset = offset;
+        let mut len = 0;
+        for buf in bufs {
+            let delta = f.read_file(buf.as_mut(), offset)?;
+            offset += u64::try_from(delta).unwrap();
+            len += delta;
+        }
+
+        Ok(len)
     }
 
     /// Return the status of a pre-opened Fd `fd`.
@@ -1035,29 +1040,42 @@ impl FileSystem {
     /// how a particular execution engine handles the memory.
     /// That is, different engines provide different API to interact the linear memory
     /// space of WASM.
-    pub(crate) fn fd_pwrite(
+    pub(crate) fn fd_pwrite<B: AsRef<[u8]>>(
         &mut self,
         fd: Fd,
-        buf: Vec<u8>,
+        bufs: &[B],
         offset: FileSize,
-    ) -> FileSystemResult<Size> {
+    ) -> FileSystemResult<usize> {
         self.check_right(&fd, Rights::FD_WRITE)?;
         let inode = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.inode;
 
-        self.lock_inode_table()?
-            .get_mut(&inode)?
-            .write_file(buf, offset)
+        let mut f = self.lock_inode_table()?;
+        let f = f.get_mut(&inode)?;
+
+        let mut offset = offset;
+        let mut len = 0;
+        for buf in bufs {
+            let delta = f.write_file(buf.as_ref(), offset)?;
+            offset += u64::try_from(delta).unwrap();
+            len += delta;
+        }
+
+        Ok(len)
     }
 
     /// A rust-style base implementation for `fd_read`. It directly calls `fd_pread` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
-    pub(crate) fn fd_read(&mut self, fd: Fd, len: usize) -> FileSystemResult<Vec<u8>> {
+    pub(crate) fn fd_read<B: AsMut<[u8]>>(
+        &mut self,
+        fd: Fd,
+        bufs: &mut [B]
+    ) -> FileSystemResult<usize> {
         self.check_right(&fd, Rights::FD_READ)?;
         let offset = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.offset;
 
-        let rst = self.fd_pread(fd, len, offset)?;
-        self.fd_seek(fd, rst.len() as i64, Whence::Current)?;
-        Ok(rst)
+        let read_len = self.fd_pread(fd, bufs, offset)?;
+        self.fd_seek(fd, read_len as i64, Whence::Current)?;
+        Ok(read_len)
     }
 
     /// The implementation of `fd_readdir`.
@@ -1151,11 +1169,15 @@ impl FileSystem {
 
     /// A rust-style base implementation for `fd_write`. It directly calls `fd_pwrite` with the
     /// current `offset` of Fd `fd` and then calls `fd_seek`.
-    pub(crate) fn fd_write(&mut self, fd: Fd, buf: Vec<u8>) -> FileSystemResult<Size> {
+    pub(crate) fn fd_write<B: AsRef<[u8]>>(
+        &mut self,
+        fd: Fd,
+        bufs: &[B]
+    ) -> FileSystemResult<usize> {
         self.check_right(&fd, Rights::FD_WRITE)?;
         let offset = self.fd_table.get(&fd).ok_or(ErrNo::BadF)?.offset;
 
-        let rst = self.fd_pwrite(fd, buf, offset)?;
+        let rst = self.fd_pwrite(fd, bufs, offset)?;
         self.fd_seek(fd, rst as i64, Whence::Current)?;
         Ok(rst)
     }
@@ -1423,22 +1445,22 @@ impl FileSystem {
 
     /// The stub implementation of `sock_recv`. Return unsupported error `NoSys`.
     #[inline]
-    pub(crate) fn sock_recv(
+    pub(crate) fn sock_recv<B: AsMut<[u8]>>(
         &mut self,
         socket: Fd,
-        _buffer_len: usize,
+        _bufs: &[B],
         _ri_flags: RiFlags,
-    ) -> FileSystemResult<(Vec<u8>, RoFlags)> {
+    ) -> FileSystemResult<(Size, RoFlags)> {
         self.check_right(&socket, Rights::FD_READ)?;
         Err(ErrNo::NoSys)
     }
 
     /// The stub implementation of `sock_send`. Return unsupported error `NoSys`.
     #[inline]
-    pub(crate) fn sock_send(
+    pub(crate) fn sock_send<B: AsRef<[u8]>>(
         &mut self,
         socket: Fd,
-        _buf: Vec<u8>,
+        _bufs: &[B],
         _si_flags: SiFlags,
     ) -> FileSystemResult<Size> {
         self.check_right(&socket, Rights::FD_WRITE)?;
@@ -1519,7 +1541,7 @@ impl FileSystem {
         if is_append {
             self.fd_seek(fd, 0, Whence::End)?;
         }
-        self.fd_write(fd, data)?;
+        self.fd_write(fd, &[data])?;
         self.fd_close(fd)?;
         Ok(())
     }
@@ -1553,9 +1575,11 @@ impl FileSystem {
             return Err(ErrNo::Access);
         }
         let file_stat = self.fd_filestat_get(fd)?;
-        let rst = self.fd_read(fd, try_from_or_errno(file_stat.file_size)?)?;
+        let mut vec = vec![0u8; file_stat.file_size as usize];
+        let read_size = self.fd_read(fd, &mut [&mut vec[..]])?;
+        debug_assert_eq!(read_size, vec.len());
         self.fd_close(fd)?;
-        Ok(rst)
+        Ok(vec)
     }
 
     /// Read all files recursively on path `path`.
@@ -1609,8 +1633,8 @@ impl FileSystem {
 
     /// A public API for writing to stdin.
     #[inline]
-    pub fn write_stdin(&mut self, buf: Vec<u8>) -> FileSystemResult<Size> {
-        self.fd_write(Fd(0), buf)
+    pub fn write_stdin(&mut self, buf: &[u8]) -> FileSystemResult<usize> {
+        self.fd_write(Fd(0), &[buf])
     }
 
     /// A public API for reading from stdout.
@@ -1630,7 +1654,10 @@ impl FileSystem {
         // read the length of a stream
         let inode = self.get_inode_by_fd(&fd)?;
         let len = self.lock_inode_table()?.get(&inode)?.len()?;
-        self.fd_read(fd, try_from_or_errno(len)?)
+        let mut vec = vec![0u8; len as usize];
+        let read_len = self.fd_read(fd, &mut [&mut vec[..]])?;
+        debug_assert_eq!(read_len, vec.len());
+        Ok(vec)
     }
 }
 fn try_from_or_errno<T, K: TryFrom<T>>(i: T) -> FileSystemResult<K> {

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -23,7 +23,7 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::{
     cmp::min,
     collections::HashMap,
-    convert::{AsRef, TryFrom, TryInto},
+    convert::{AsRef, TryFrom},
     ffi::OsString,
     // TODO: wait for icecap to support direct conversion between bytes and os_str, bypassing
     // potential utf-8 encoding check

--- a/execution-engine/src/lib.rs
+++ b/execution-engine/src/lib.rs
@@ -17,6 +17,9 @@
 
 #![cfg_attr(feature = "sgx", no_std)]
 
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
 #[cfg(feature = "sgx")]
 #[macro_use]
 extern crate sgx_tstd as std;

--- a/execution-engine/src/lib.rs
+++ b/execution-engine/src/lib.rs
@@ -17,9 +17,6 @@
 
 #![cfg_attr(feature = "sgx", no_std)]
 
-#![allow(incomplete_features)]
-#![feature(generic_associated_types)]
-
 #[cfg(feature = "sgx")]
 #[macro_use]
 extern crate sgx_tstd as std;

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -37,67 +37,28 @@ impl HostError for FatalEngineError {}
 // The WASMI host provisioning state.
 ////////////////////////////////////////////////////////////////////////////////
 
-///// Newtype for locked references to memory in wasmi, required for
-///// general MemoryHandler trait
-//struct WasmiSlice<'a>(Box<dyn AsRef<[u8]> + 'a>);
-//
-//impl AsRef<[u8]> for WasmiSlice<'_> {
-//    fn as_ref<'a>(&'a self) -> &'a [u8] {
-//        self.as_ref()
-//    }
-//}
-//
-///// Newtype for locked references to memory in wasmi, required for
-///// general MemoryHandler trait
-//struct WasmiSliceMut<'a>(Box<dyn AsMut<[u8]> + 'a>);
-//
-//impl AsMut<[u8]> for WasmiSliceMut<'_> {
-//    fn as_mut<'a>(&'a mut self) -> &'a mut [u8] {
-//        self.as_mut()
-//    }
-//}
-
 /// Impl the MemoryHandler for MemoryRef.
 /// This allows passing the MemoryRef to WasiWrapper on any VFS call.
 impl MemoryHandler for MemoryRef {
-    /// A type representing a direct reference to memory
-    ///
-    /// Note this may both lock the underlying engine and allocate memory (if
-    /// the engines underlying memory is not linear). These should generally
-    /// be short-lived to pass to other APIs.
-    type Slice = &'static [u8]; // WasmiSlice<'a>;
+    type Slice = &'static [u8];
+    type SliceMut = &'static mut [u8];
 
-    /// A type representing a direct mutable reference to memory
-    ///
-    /// Note this may both lock the underlying engine and allocate memory (if
-    /// the engines underlying memory is not linear). These should generally
-    /// be short-lived to pass to other APIs.
-    type SliceMut = &'static mut [u8]; // WasmiSliceMut<'a>;
-
-    /// Get an immutable slice of the memory
     fn get_slice<'a>(
         &'a self,
         _address: u32,
         _length: u32
     ) -> FileSystemResult<Bound<'a, Self::Slice>> {
         todo!()
-//        let x: &[u8] = self.with_direct_access(|r: &[u8]| { r });
-//        Ok(x)
-        //Ok(Box::new(self.direct_access()))
     }
 
-    /// Get a mutable slice of the memory
     fn get_slice_mut<'a>(
         &'a mut self,
         _address: u32,
         _length: u32
     ) -> FileSystemResult<BoundMut<'a, Self::SliceMut>> {
         todo!()
-        //Ok(self.with_direct_access_mut(|r| r))
-        //Ok(Box::new(self.direct_access_mut()))
     }
 
-    /// Get the size of available memory
     fn get_size(&self) -> FileSystemResult<u32> {
         todo!()
     }

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -37,60 +37,60 @@ impl HostError for FatalEngineError {}
 // The WASMI host provisioning state.
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Newtype for locked references to memory in wasmi, required for
-/// general MemoryHandler trait
-struct WasmiSlice<'a>(Box<dyn AsRef<[u8]> + 'a>);
-
-impl AsRef<[u8]> for WasmiSlice<'_> {
-    fn as_ref<'a>(&'a self) -> &'a [u8] {
-        self.as_ref()
-    }
-}
-
-/// Newtype for locked references to memory in wasmi, required for
-/// general MemoryHandler trait
-struct WasmiSliceMut<'a>(Box<dyn AsMut<[u8]> + 'a>);
-
-impl AsMut<[u8]> for WasmiSliceMut<'_> {
-    fn as_mut<'a>(&'a mut self) -> &'a mut [u8] {
-        self.as_mut()
-    }
-}
+///// Newtype for locked references to memory in wasmi, required for
+///// general MemoryHandler trait
+//struct WasmiSlice<'a>(Box<dyn AsRef<[u8]> + 'a>);
+//
+//impl AsRef<[u8]> for WasmiSlice<'_> {
+//    fn as_ref<'a>(&'a self) -> &'a [u8] {
+//        self.as_ref()
+//    }
+//}
+//
+///// Newtype for locked references to memory in wasmi, required for
+///// general MemoryHandler trait
+//struct WasmiSliceMut<'a>(Box<dyn AsMut<[u8]> + 'a>);
+//
+//impl AsMut<[u8]> for WasmiSliceMut<'_> {
+//    fn as_mut<'a>(&'a mut self) -> &'a mut [u8] {
+//        self.as_mut()
+//    }
+//}
 
 /// Impl the MemoryHandler for MemoryRef.
 /// This allows passing the MemoryRef to WasiWrapper on any VFS call.
-impl<'a> MemoryHandler<'a> for MemoryRef {
+impl MemoryHandler for MemoryRef {
     /// A type representing a direct reference to memory
     ///
     /// Note this may both lock the underlying engine and allocate memory (if
     /// the engines underlying memory is not linear). These should generally
     /// be short-lived to pass to other APIs.
-    type Slice = &'a [u8]; // WasmiSlice<'a>;
+    type Slice<'a> = &'a [u8]; // WasmiSlice<'a>;
 
     /// A type representing a direct mutable reference to memory
     ///
     /// Note this may both lock the underlying engine and allocate memory (if
     /// the engines underlying memory is not linear). These should generally
     /// be short-lived to pass to other APIs.
-    type SliceMut = &'a mut [u8]; // WasmiSliceMut<'a>;
+    type SliceMut<'a> = &'a mut [u8]; // WasmiSliceMut<'a>;
 
     /// Get an immutable slice of the memory
-    fn get_slice(&'a self, _address: u32, _length: u32) -> FileSystemResult<Self::Slice> {
+    fn get_slice<'a>(&'a self, _address: u32, _length: u32) -> FileSystemResult<Self::Slice<'a>> {
         todo!()
-//        let x: &'a [u8] = self.with_direct_access(|r: &'a [u8]| { r });
+//        let x: &[u8] = self.with_direct_access(|r: &[u8]| { r });
 //        Ok(x)
         //Ok(Box::new(self.direct_access()))
     }
 
     /// Get a mutable slice of the memory
-    fn get_slice_mut(&'a mut self, _address: u32, _length: u32) -> FileSystemResult<Self::SliceMut> {
+    fn get_slice_mut<'a>(&'a mut self, _address: u32, _length: u32) -> FileSystemResult<Self::SliceMut<'a>> {
         todo!()
         //Ok(self.with_direct_access_mut(|r| r))
         //Ok(Box::new(self.direct_access_mut()))
     }
 
     /// Get the size of available memory
-    fn get_size(&'a self) -> FileSystemResult<u32> {
+    fn get_size(&self) -> FileSystemResult<u32> {
         todo!()
     }
 }

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -12,8 +12,8 @@
 use crate::{
     fs::{FileSystem, FileSystemResult},
     wasi::common::{
-        EntrySignature, ExecutionEngine, FatalEngineError, HostFunctionIndexOrName, MemoryHandler,
-        WasiAPIName, WasiWrapper,
+        Bound, BoundMut, EntrySignature, ExecutionEngine, FatalEngineError, HostFunctionIndexOrName,
+        MemoryHandler, WasiAPIName, WasiWrapper,
     },
     Options,
 };
@@ -65,17 +65,21 @@ impl MemoryHandler for MemoryRef {
     /// Note this may both lock the underlying engine and allocate memory (if
     /// the engines underlying memory is not linear). These should generally
     /// be short-lived to pass to other APIs.
-    type Slice<'a> = &'a [u8]; // WasmiSlice<'a>;
+    type Slice = &'static [u8]; // WasmiSlice<'a>;
 
     /// A type representing a direct mutable reference to memory
     ///
     /// Note this may both lock the underlying engine and allocate memory (if
     /// the engines underlying memory is not linear). These should generally
     /// be short-lived to pass to other APIs.
-    type SliceMut<'a> = &'a mut [u8]; // WasmiSliceMut<'a>;
+    type SliceMut = &'static mut [u8]; // WasmiSliceMut<'a>;
 
     /// Get an immutable slice of the memory
-    fn get_slice<'a>(&'a self, _address: u32, _length: u32) -> FileSystemResult<Self::Slice<'a>> {
+    fn get_slice<'a>(
+        &'a self,
+        _address: u32,
+        _length: u32
+    ) -> FileSystemResult<Bound<'a, Self::Slice>> {
         todo!()
 //        let x: &[u8] = self.with_direct_access(|r: &[u8]| { r });
 //        Ok(x)
@@ -83,7 +87,11 @@ impl MemoryHandler for MemoryRef {
     }
 
     /// Get a mutable slice of the memory
-    fn get_slice_mut<'a>(&'a mut self, _address: u32, _length: u32) -> FileSystemResult<Self::SliceMut<'a>> {
+    fn get_slice_mut<'a>(
+        &'a mut self,
+        _address: u32,
+        _length: u32
+    ) -> FileSystemResult<BoundMut<'a, Self::SliceMut>> {
         todo!()
         //Ok(self.with_direct_access_mut(|r| r))
         //Ok(Box::new(self.direct_access_mut()))

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -37,28 +37,61 @@ impl HostError for FatalEngineError {}
 // The WASMI host provisioning state.
 ////////////////////////////////////////////////////////////////////////////////
 
+/// Newtype for locked references to memory in wasmi, required for
+/// general MemoryHandler trait
+struct WasmiSlice<'a>(Box<dyn AsRef<[u8]> + 'a>);
+
+impl AsRef<[u8]> for WasmiSlice<'_> {
+    fn as_ref<'a>(&'a self) -> &'a [u8] {
+        self.as_ref()
+    }
+}
+
+/// Newtype for locked references to memory in wasmi, required for
+/// general MemoryHandler trait
+struct WasmiSliceMut<'a>(Box<dyn AsMut<[u8]> + 'a>);
+
+impl AsMut<[u8]> for WasmiSliceMut<'_> {
+    fn as_mut<'a>(&'a mut self) -> &'a mut [u8] {
+        self.as_mut()
+    }
+}
+
 /// Impl the MemoryHandler for MemoryRef.
 /// This allows passing the MemoryRef to WasiWrapper on any VFS call.
-impl MemoryHandler for MemoryRef {
-    /// Writes a buffer of bytes, `buffer`, to the runtime state's memory at
-    /// address, `address`.  Success on returing ErrNo::Success,
-    /// Fails with `ErrNo::NoMem` if no memory is registered in the runtime state.
-    #[inline]
-    fn write_buffer(&mut self, address: u32, buffer: &[u8]) -> FileSystemResult<()> {
-        if let Err(_e) = self.set(address, buffer) {
-            return Err(ErrNo::NoMem);
-        }
-        Ok(())
+impl<'a> MemoryHandler<'a> for MemoryRef {
+    /// A type representing a direct reference to memory
+    ///
+    /// Note this may both lock the underlying engine and allocate memory (if
+    /// the engines underlying memory is not linear). These should generally
+    /// be short-lived to pass to other APIs.
+    type Slice = &'a [u8]; // WasmiSlice<'a>;
+
+    /// A type representing a direct mutable reference to memory
+    ///
+    /// Note this may both lock the underlying engine and allocate memory (if
+    /// the engines underlying memory is not linear). These should generally
+    /// be short-lived to pass to other APIs.
+    type SliceMut = &'a mut [u8]; // WasmiSliceMut<'a>;
+
+    /// Get an immutable slice of the memory
+    fn get_slice(&'a self, _address: u32, _length: u32) -> FileSystemResult<Self::Slice> {
+        todo!()
+//        let x: &'a [u8] = self.with_direct_access(|r: &'a [u8]| { r });
+//        Ok(x)
+        //Ok(Box::new(self.direct_access()))
     }
 
-    /// Read a buffer of bytes from the runtime state's memory at
-    /// address, `address`. Return the bytes or Err with ErrNo,
-    /// e.g. `Err(ErrNo::NoMem)` if no memory is registered in the runtime state.
-    #[inline]
-    fn read_buffer(&self, address: u32, length: u32) -> FileSystemResult<Vec<u8>> {
-        self.get(address, length as usize)
-            .map_err(|_e| ErrNo::Fault)
-            .map(|buf| buf.to_vec())
+    /// Get a mutable slice of the memory
+    fn get_slice_mut(&'a mut self, _address: u32, _length: u32) -> FileSystemResult<Self::SliceMut> {
+        todo!()
+        //Ok(self.with_direct_access_mut(|r| r))
+        //Ok(Box::new(self.direct_access_mut()))
+    }
+
+    /// Get the size of available memory
+    fn get_size(&'a self) -> FileSystemResult<u32> {
+        todo!()
     }
 }
 

--- a/runtime-manager/Makefile
+++ b/runtime-manager/Makefile
@@ -57,10 +57,10 @@ RUST_SGX_SDK_PATH = ../third-party/rust-sgx-sdk
 $(EDL_Files): $(SGX_EDGER8R) runtime_manager.edl
 	$(SGX_EDGER8R) --use-prefix --trusted runtime_manager.edl --search-path $(SGX_SDK)/include --search-path $(RUST_SGX_SDK_PATH)/edl --trusted-dir .
 	$(SGX_EDGER8R) --use-prefix --untrusted runtime_manager.edl --search-path $(SGX_SDK)/include --search-path $(RUST_SGX_SDK_PATH)/edl --untrusted-dir .
-	cp -u runtime_manager_t.c $(OUT_DIR)
-	cp -u runtime_manager_u.c $(OUT_DIR)
-	cp -u runtime_manager_u.h $(OUT_DIR)
-	cp -u runtime_manager_t.h $(OUT_DIR)
+	cp runtime_manager_t.c $(OUT_DIR)
+	cp runtime_manager_u.c $(OUT_DIR)
+	cp runtime_manager_u.h $(OUT_DIR)
+	cp runtime_manager_t.h $(OUT_DIR)
 	@echo $(INFO_COLOR) "GEN => $(EDL_Files)" $(RESET_COLOR)
 
 SGX_COMMON_CFLAGS += -O0 -g


### PR DESCRIPTION
This mostly required changes to the MemoryHandler trait in order to allow direct access to the WebAssembly's linear memory space. This turned out to be surprisingly complicated because of Rust's borrow checker and differences between Wasmi's and Wasmtime's linear memory APIs (though this does mean this code should be portable to other execution engines).

I've tried to document the code thoroughly as this borders on what's possible in Rust. And considering the amount of transmutes I needed I may be doing something terribly wrong, but this was the best solution I could come up with to provide safe access to engine memories safely. I'm open to other ideas if there are any.

---

- Added `get_slice` and `get_slice_mut`, which return associated types `Slice` and `SliceMut`. These represent slices of the underlying linear memory, but can other contexts that may be required by the execution engine such as Mutex/RefCell guards, Rcs, or even a Vec if the underlying engine doesn't actually have a linear memory.

  There's a bit more trickiness here due to lifetimes.
  
  `Slice` and `SliceMut` share the lifetime of the linear memory they take a slice of. The proper way to describe this in Rust would be like this:
  
  ``` rust
  trait MemoryHandler {
      type Slice<'a>: AsRef<[u8]>;
      fn get_slice<'a>(&'a self) -> Slice<'a>;
  }
  ```
  
  But this requires a nightly, and unfinished, feature called GATs (the `type Slice<'a>: AsRef<[u8]>` part specifically):
  
  https://github.com/rust-lang/rust/issues/44265
  
  The workaround here is to require the associated-type implementations to all be "lifetime-less", which probably requires unsafe code in the implementations.
  
  To keep this API from being just completely unsafe (we could just pass around pointers). I've added a new type called Bound for the sole purpose of binding an unrelated lifetime to a lifetime-less object. Whether or not the lifetime is valid can't be checked by the compiler of course, but this at least means any consuming code will be borrow-checked correctly:
  
  ``` rust
  trait MemoryHandler {
      type Slice: AsRef<[u8]>;
      fn get_slice<'a>(&'a self) -> Bound<'a, Slice>;
  }
  ```

- Added `unpack_iovec` and `unpack_iovec_mut` which return _sets_ of these slices. This allows iovecs to be passed all the way from the WebAssembly application to the internals of the filesystem, allowing multiple iovecs to be consumed in a single filesystem operation.

  This also handles the splitting of the linear memory's mutable borrow, which is difficult to do otherwise.

- Required MemoryHandler::Slice and MemoryHandler::SliceMut to be _movable_, even behind a borrow. This is a very _very_ unusual trait requirement but prevents the need for unnecessary boxing in the hot-path of file read/writes. Fortunately it holds true for most of the types you would use in this API, such as slices and even vecs.

- Added small-object optimization (SOO) for 1 and 2 element iovecs (these are by far the most common from personal experience, I've never actually seen a >2 iovec used before, though it's certainly possible in hand-optimized code)

---

The end result is zero allocations in the hot-path of file reads/writes, aside from the internal allocations required for the filesystem's internal data-structures.

This results in a significant performance gain, mostly due to no longer copying the read/write buffers multiple times before the data reaches the filesystem.

![image](https://user-images.githubusercontent.com/1075160/142341622-3b0d11be-87d0-4e55-b2b9-e5b70582c26d.png)


