### PR TITLE
Test if we can call psa_crypto::init.

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -37,6 +37,11 @@ tz = [
 anyhow = { version = "1.0", default-features = false }
 byteorder = { git = "https://github.com/veracruz-project/byteorder.git", branch = "veracruz" }
 cfg-if = "1"
+# cmake is not a dependency of this crate, but we have to stop cmake 0.1.46,
+# which needs a newer version of cmake (one that accepts --parallel) than
+# the one which comes with Ubuntu 18.04.5, currently used by our CI tests,
+# from being picked up by psa-crypto-sys.
+cmake = "<0.1.46"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 num = { version = "0.4", default-features = false }
@@ -45,6 +50,7 @@ num-traits = { version = "0.2", default-features = false }
 pinecone = "0.2"
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
+psa-crypto = { git = "https://github.com/egrimley-arm/rust-psa-crypto.git", branch = "veracruz" }
 serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
 sgx_alloc = { branch = "veracruz", git = "https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { branch = "veracruz", git = "https://github.com/veracruz-project/incubator-teaclave-sgx-sdk.git", optional = true }

--- a/icecap/nix/env/host-test-generic.nix
+++ b/icecap/nix/env/host-test-generic.nix
@@ -8,7 +8,7 @@
 # and copyright information.
 
 { lib, stdenv, buildPackages, mkShell
-, rustc, cargo, git, cacert
+, rustc, cargo, cmake, git, cacert
 , crateUtils, nixToToml, rustTargetName
 , protobuf, perl, python3
 , pkgconfig, openssl, sqlite
@@ -40,7 +40,7 @@ mkShell (crateUtils.baseEnv // rec {
   ];
 
   nativeBuildInputs = [
-    rustc cargo git cacert
+    rustc cargo cmake git cacert
     protobuf perl python3
     pkgconfig
   ];

--- a/icecap/nix/env/runtime-manager.nix
+++ b/icecap/nix/env/runtime-manager.nix
@@ -8,7 +8,7 @@
 # and copyright information.
 
 { lib, stdenv, buildPackages, mkShell
-, rustc, cargo, git, cacert, rustfmt
+, rustc, cargo, cmake, git, cacert, rustfmt
 , crateUtils, nixToToml, rustTargetName
 , protobuf, perl, python3
 , libsel4, libs, sysroot-rs
@@ -50,7 +50,7 @@ mkShell (crateUtils.baseEnv // rec {
   ];
 
   nativeBuildInputs = [
-    rustc cargo git cacert rustfmt
+    rustc cargo cmake git cacert rustfmt
     protobuf perl python3
   ];
 

--- a/runtime-manager/Makefile
+++ b/runtime-manager/Makefile
@@ -167,9 +167,11 @@ Nitro_Src = $(COMMON_Src) src/runtime_manager_nitro.rs src/main.rs
 
 nitro: runtime_manager.eif
 
-runtime_manager.eif: target/x86_64-unknown-linux-musl/release/runtime_manager_enclave Dockerfile
-	nitro-cli build-enclave --docker-dir . --docker-uri runtime_manager --output-file runtime_manager.eif > measurements.json
+runtime_manager.eif: target/x86_64-unknown-linux-musl/release/runtime_manager_enclave dockerdir/Dockerfile
+	ln -f target/x86_64-unknown-linux-musl/release/runtime_manager_enclave dockerdir/
+	nitro-cli build-enclave --docker-dir dockerdir --docker-uri runtime_manager --output-file $@.new > measurements.json
 	cat measurements.json | jq -r '.Measurements.PCR0' > PCR0
+	mv $@.new $@
 
 target/x86_64-unknown-linux-musl/release/runtime_manager_enclave: Cargo.toml $(Nitro_Src)
 	cargo build --target x86_64-unknown-linux-musl --release --features nitro

--- a/runtime-manager/dockerdir/Dockerfile
+++ b/runtime-manager/dockerdir/Dockerfile
@@ -1,6 +1,6 @@
 # Note to self: Alpine Linux is the devil and should not be used
 FROM alpine:latest
 # copy the vsock-sample binary
-COPY target/x86_64-unknown-linux-musl/release/runtime_manager_enclave .
+COPY runtime_manager_enclave .
 # start the server inside the enclave
 CMD export RUST_BACKTRACE=1 && ./runtime_manager_enclave


### PR DESCRIPTION
The "system call" test_psa_crypto is added, in the same way that
fd_create was added, but it takes no arguments and just calls
psa_crypto::init.

rust-examples/linear-regression is modified so that it calls
that function.
