### PR TITLE
Reduce latency in the network stack

### DIFF
--- a/io-utils/src/http.rs
+++ b/io-utils/src/http.rs
@@ -267,7 +267,7 @@ where
         HttpError::Base64Error(e)
     })?;
 
-    let response = parse_proxy_attestation_server_response(&response_body).map_err(|e| {
+    let response = parse_proxy_attestation_server_response(None, &response_body).map_err(|e| {
         error!("Failed to parse response to Start message from Proxy Attestation Service.  Error produced: {:?}.", e);
 
         HttpError::TransportProtocolError(e)

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -99,7 +99,7 @@ pub async fn start(body_string: String) -> ProxyAttestationServerResponder {
             err
         })?;
 
-    let parsed = transport_protocol::parse_proxy_attestation_server_request(&received_bytes)
+    let parsed = transport_protocol::parse_proxy_attestation_server_request(None, &received_bytes)
         .map_err(|err| {
             println!("proxy-attestation-server::attestation::start failed to parse_proxy_attestation_server_request:{:?}", err);
             err

--- a/proxy-attestation-server/src/attestation/nitro.rs
+++ b/proxy-attestation-server/src/attestation/nitro.rs
@@ -108,7 +108,7 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
             err
         })?;
 
-    let parsed = transport_protocol::parse_proxy_attestation_server_request(&received_bytes)
+    let parsed = transport_protocol::parse_proxy_attestation_server_request(None, &received_bytes)
         .map_err(|err| {
             println!("proxy-attestation-server::attestation::nitro::attestation_token failed to parse proxy attestation server request:{:?}", err);
             let _ignore = std::io::stdout().flush();

--- a/proxy-attestation-server/src/attestation/psa.rs
+++ b/proxy-attestation-server/src/attestation/psa.rs
@@ -67,7 +67,7 @@ pub fn start(firmware_version: &str, device_id: i32) -> ProxyAttestationServerRe
 pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder {
     let received_bytes = base64::decode(&body_string)?;
 
-    let parsed = transport_protocol::parse_proxy_attestation_server_request(&received_bytes)?;
+    let parsed = transport_protocol::parse_proxy_attestation_server_request(None, &received_bytes)?;
     if !parsed.has_native_psa_attestation_token() {
         println!("proxy-attestation-server::attestation::psa::attestation_token received data is incorrect.");
         return Err(ProxyAttestationServerError::MissingFieldError(

--- a/proxy-attestation-server/src/server.rs
+++ b/proxy-attestation-server/src/server.rs
@@ -49,7 +49,7 @@ async fn verify_iat(input_data: String) -> ProxyAttestationServerResponder {
         err
     })?;
 
-    let proto = transport_protocol::parse_proxy_attestation_server_request(&proto_bytes)
+    let proto = transport_protocol::parse_proxy_attestation_server_request(None, &proto_bytes)
         .map_err(|err| {
             println!("proxy-attestation-server::verify_iat parse_proxy_attestation_server_request failed:{:?}", err);
             err

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -11,22 +11,14 @@
 //! information on licensing and copyright.
 
 use super::{ProtocolState, ProvisioningResult, RuntimeManagerError};
-use lazy_static::lazy_static;
 use policy_utils::principal::Principal;
-use std::sync::Mutex;
-use std::{collections::HashMap, result::Result, vec::Vec};
-use transport_protocol::transport_protocol::{
-    RuntimeManagerRequest as REQUEST, RuntimeManagerRequest_oneof_message_oneof as MESSAGE,
+use std::{result::Result, vec::Vec};
+use transport_protocol::{
+    transport_protocol::{
+        RuntimeManagerRequest as REQUEST, RuntimeManagerRequest_oneof_message_oneof as MESSAGE,
+    },
+    TransportProtocolError,
 };
-
-////////////////////////////////////////////////////////////////////////////////
-// The buffer of incoming data.
-////////////////////////////////////////////////////////////////////////////////
-
-lazy_static! {
-    // TODO: wrap into a runtime manager management object.
-    static ref INCOMING_BUFFER_HASH: Mutex<HashMap<u32, (u64, Vec<u8>)>> = Mutex::new(HashMap::new());
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Protocol response messages.
@@ -149,74 +141,19 @@ fn dispatch_on_request(client_id: u64, request: MESSAGE) -> ProvisioningResult {
     }
 }
 
-/// Append received chunks to the session's incoming buffer until the protocol
-/// buffer, serializing a request, is complete and can be deserialized.
-/// Each request is serialized on the client side, prefixed by its length, then
-/// passed to the TLS client which encrypts it and splits it into an array of
-/// 16KB TLS records, sent one by one to the runtime manager.
-/// The first chunk received by the runtime manager therefore contains the
-/// protocol buffer's total length.
-/// If the incoming buffer reaches its expected length, then the protocol buffer
-/// is considered complete and parsed into a `RuntimeManagerRequest` before
-/// flushing the incoming buffer and returning `Ok(request)`.
-/// Otherwise, the runtime manager knows it still needs to receive more data in
-/// order to parse a full request, and returns `Ok(None)`.
-/// This technique significantly decreases buffer processing time hence latency,
-/// especially when dealing with large requests, e.g. files.
-///
-/// TODO: harden this against potential malfeasance.  See the note, below.
+/// Try to parse the incoming buffer into a `RuntimeManagerRequest` message.
+/// Return `Ok(request)` if it's a success or `Ok(None)` if the message is
+/// partial. Propagate the error otherwise
 fn parse_incoming_buffer(
     tls_session_id: u32,
-    mut input: Vec<u8>,
+    input: Vec<u8>,
 ) -> Result<Option<transport_protocol::RuntimeManagerRequest>, RuntimeManagerError> {
-    let mut incoming_buffer_hash = INCOMING_BUFFER_HASH.lock()?;
-
-    // First, make sure there is an entry in the hash for the TLS session.
-    // If not, this means we are receiving the first chunk of the protocol
-    // buffer.
-    if incoming_buffer_hash.get(&tls_session_id).is_none() {
-        if input.len() < transport_protocol::LENGTH_PREFIX_SIZE {
-            return Ok(None);
-        }
-
-        // Extract the protocol buffer's total length as u64
-        let (expected_length, input_unprefixed) = transport_protocol::get_length_prefix(&mut input);
-
-        // Insert the expected length in the hash table
-        incoming_buffer_hash.insert(tls_session_id, (expected_length, Vec::new()));
-
-        input = input_unprefixed.to_vec();
-    }
-
-    // This should not panic, given the above.  If it does, something is wrong.
-    let (expected_length, incoming_buffer) = incoming_buffer_hash.get_mut(&tls_session_id).ok_or(
-        RuntimeManagerError::UnavailableIncomeBufferError(tls_session_id as u64),
-    )?;
-
-    incoming_buffer.append(&mut input);
-
-    // We return `Ok(None)` as long as the full protocol buffer has not yet been
-    // received. Once received, `parse_from_bytes()` parses it and returns
-    // `Ok(parsed)`.
-    // In a well-behaving system, this is reasonable.  In a poorly-behaved
-    // system (under attack, clients just getting confused) it is not
-    // reasonable, and can eventually result in "Out of Memory" or Garbage out.
-    //
-    // TODO: It would be nice to check the error, and then determine if this might
-    // be the case or if it is hopeless and we could just error out.
-
-    if incoming_buffer.len() < *expected_length as usize {
-        return Ok(None);
-    } else {
-        match protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerRequest>(
-            &incoming_buffer,
-        ) {
-            Err(_) => Ok(None),
-            Ok(parsed) => {
-                incoming_buffer_hash.remove(&tls_session_id);
-                Ok(Some(parsed))
-            }
-        }
+    match transport_protocol::parse_runtime_manager_request(Some(tls_session_id), &input) {
+        Ok(v) => Ok(Some(v)),
+        Err(e) => match e {
+            TransportProtocolError::PartialBuffer(_) => Ok(None),
+            e2 => Err(RuntimeManagerError::TransportProtocolError(e2)),
+        },
     }
 }
 

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -204,12 +204,12 @@ fn parse_incoming_buffer(
     // TODO: It would be nice to check the error, and then determine if this might
     // be the case or if it is hopeless and we could just error out.
 
-	if incoming_buffer.len() < *expected_length as usize {
-		return Ok(None)
-	}
-    else {
-        match protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerRequest>(&incoming_buffer)
-        {
+    if incoming_buffer.len() < *expected_length as usize {
+        return Ok(None);
+    } else {
+        match protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerRequest>(
+            &incoming_buffer,
+        ) {
             Err(_) => Ok(None),
             Ok(parsed) => {
                 incoming_buffer_hash.remove(&tls_session_id);

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -175,6 +175,10 @@ fn parse_incoming_buffer(
     // If not, this means we are receiving the first chunk of the protocol
     // buffer.
     if incoming_buffer_hash.get(&tls_session_id).is_none() {
+        if input.len() < 8 {
+            return Ok(None);
+        }
+
         // Extract the protocol buffer's total length as u64
         let remaining_data = input.split_off(8);
         let mut expected_length_bytes: [u8; 8] = [0; 8];

--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -225,7 +225,7 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
 
     // Configure TCP to flush outgoing buffers immediately. This reduces latency
     // when dealing with small packets
-    fd.set_nodelay(true);
+    let _ = fd.set_nodelay(true);
 
     info!("TCP listener connected on {:?}.", client_addr);
 

--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -223,6 +223,10 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
         RuntimeManagerError::IOError(ioerr)
     })?;
 
+    // Configure TCP to flush outgoing buffers immediately. This reduces latency
+    // when dealing with small packets
+    fd.set_nodelay(true);
+
     info!("TCP listener connected on {:?}.", client_addr);
 
     let mut abort = false;

--- a/transport-protocol/Cargo.toml
+++ b/transport-protocol/Cargo.toml
@@ -11,6 +11,7 @@ icecap = []
 
 [dependencies]
 err-derive = "0.2"
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 protobuf = "=2.8.1"
 
 [build-dependencies]

--- a/transport-protocol/src/custom.rs
+++ b/transport-protocol/src/custom.rs
@@ -29,7 +29,8 @@ pub enum TransportProtocolError {
 type TransportProtocolResult = Result<std::vec::Vec<u8>, TransportProtocolError>;
 
 // Strip length prefix from protocol buffer.
-// Return length and stripped protocol buffer
+// Return length and stripped protocol buffer.
+// This function must be called before deserializing a message
 pub fn get_length_prefix(buffer: &[u8]) -> (u64, &[u8]) {
     let mut length_bytes: [u8; LENGTH_PREFIX_SIZE] = [0; LENGTH_PREFIX_SIZE];
     length_bytes.copy_from_slice(&buffer[..LENGTH_PREFIX_SIZE]);
@@ -37,7 +38,8 @@ pub fn get_length_prefix(buffer: &[u8]) -> (u64, &[u8]) {
     (u64::from_be_bytes(length_bytes), remaining_buffer)
 }
 
-// Return protocol buffer prefixed with its length
+// Return protocol buffer prefixed with its length.
+// This function must be called after serializing a message
 pub fn set_length_prefix(buffer: &mut Vec<u8>) -> TransportProtocolResult {
     let length = u64::to_be_bytes(buffer.len() as u64);
     let mut length_bytes = length.to_vec();

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -447,7 +447,9 @@ impl VeracruzClient {
             None => (),
         }
 
-        self.tls_session.write_all(&data[..])?;
+        // Write the data to the TLS session, prefixed by the data length.
+        let data_len = u64::to_be_bytes(data.len() as u64);
+        self.tls_session.write_all(&[&data_len, &data[..]].concat())?;
 
         let mut outgoing_data_vec = Vec::new();
         let outgoing_data = Vec::new();

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -447,9 +447,7 @@ impl VeracruzClient {
             None => (),
         }
 
-        // Write the data to the TLS session, prefixed by the data length.
-        let data_len = u64::to_be_bytes(data.len() as u64);
-        self.tls_session.write_all(&[&data_len, &data[..]].concat())?;
+        self.tls_session.write_all(&data[..])?;
 
         let mut outgoing_data_vec = Vec::new();
         let outgoing_data = Vec::new();
@@ -502,6 +500,7 @@ impl VeracruzClient {
             match plaintext_data_option {
                 Some(plaintext_data) => {
                     self.remote_session_id = Some(enclave_session_id);
+
                     return Ok(plaintext_data);
                 }
                 None => (),

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -238,7 +238,8 @@ impl VeracruzClient {
         );
         let serialized_program = transport_protocol::serialize_program(&program, &path)?;
         let response = self.send(&serialized_program)?;
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response =
+            transport_protocol::parse_runtime_manager_response(self.remote_session_id, &response)?;
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => return Ok(()),
@@ -265,7 +266,8 @@ impl VeracruzClient {
         let serialized_data = transport_protocol::serialize_program_data(&data, &path)?;
         let response = self.send(&serialized_data)?;
 
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response =
+            transport_protocol::parse_runtime_manager_response(self.remote_session_id, &response)?;
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => return Ok(()),
@@ -292,7 +294,8 @@ impl VeracruzClient {
         let serialized_read_result = transport_protocol::serialize_request_result(&path)?;
         let response = self.send(&serialized_read_result)?;
 
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response =
+            transport_protocol::parse_runtime_manager_response(self.remote_session_id, &response)?;
         let status = parsed_response.get_status();
         if status != transport_protocol::ResponseStatus::SUCCESS {
             return Err(VeracruzClientError::ResponseError(
@@ -320,7 +323,8 @@ impl VeracruzClient {
         let serialized_read_result = transport_protocol::serialize_read_file(&path)?;
         let response = self.send(&serialized_read_result)?;
 
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response =
+            transport_protocol::parse_runtime_manager_response(self.remote_session_id, &response)?;
         let status = parsed_response.get_status();
         if status != transport_protocol::ResponseStatus::SUCCESS {
             return Err(VeracruzClientError::ResponseError("get_result", status));
@@ -343,7 +347,8 @@ impl VeracruzClient {
     fn check_policy_hash(&mut self) -> Result<(), VeracruzClientError> {
         let serialized_rph = transport_protocol::serialize_request_policy_hash()?;
         let response = self.send(&serialized_rph)?;
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response =
+            transport_protocol::parse_runtime_manager_response(self.remote_session_id, &response)?;
         match parsed_response.status {
             transport_protocol::ResponseStatus::SUCCESS => {
                 let received_hash = std::str::from_utf8(&parsed_response.get_policy_hash().data)?;

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -899,7 +899,7 @@ mod tests {
                 )?;
                 info!(
                     "             Client received acknowledgement after sending program: {:?}",
-                    transport_protocol::parse_runtime_manager_response(&response)
+                    transport_protocol::parse_runtime_manager_response(None, &response)
                 );
                 info!(
                     "             Provisioning program time (μs): {}.",
@@ -940,7 +940,7 @@ mod tests {
                 )?;
                 info!(
                     "             Client received acknowledgement after sending data: {:?},",
-                    transport_protocol::parse_runtime_manager_response(&response)
+                    transport_protocol::parse_runtime_manager_response(None, &response)
                 );
                 info!(
                     "             Provisioning data time (μs): {}.",
@@ -990,7 +990,7 @@ mod tests {
                     )?;
                     info!(
                         "             Client received acknowledgement after sending data: {:?},",
-                        transport_protocol::parse_runtime_manager_response(&response)
+                        transport_protocol::parse_runtime_manager_response(None, &response)
                     );
                     info!(
                         "             Provisioning data time (μs): {}.",
@@ -1044,7 +1044,8 @@ mod tests {
                         &client_tls_rx,
                         &remote_file_name,
                     )?;
-                    let response = transport_protocol::parse_runtime_manager_response(&response)?;
+                    let response =
+                        transport_protocol::parse_runtime_manager_response(None, &response)?;
                     let response = transport_protocol::parse_result(&response)?;
                     let result = response.ok_or(VeracruzServerError::MissingFieldError(
                         "Result retrievers response",
@@ -1068,7 +1069,7 @@ mod tests {
             )?;
             info!(
                 "             Client received acknowledgment after shutdown request: {:?}",
-                transport_protocol::parse_runtime_manager_response(&response)
+                transport_protocol::parse_runtime_manager_response(None, &response)
             );
             info!(
                 "             Shutdown time (μs): {}.",
@@ -1277,7 +1278,7 @@ mod tests {
 
         info!("Reponse received: {:?}", response);
 
-        let parsed_response = transport_protocol::parse_runtime_manager_response(&response)?;
+        let parsed_response = transport_protocol::parse_runtime_manager_response(None, &response)?;
         let status = parsed_response.get_status();
 
         if status != transport_protocol::ResponseStatus::SUCCESS {

--- a/veracruz-server/fuzz/fuzz_targets/provision_data.rs
+++ b/veracruz-server/fuzz/fuzz_targets/provision_data.rs
@@ -77,7 +77,7 @@ fuzz_target!(|buffer: &[u8]| {
             &request,
         )
         .unwrap();
-        let rst = transport_protocol::parse_runtime_manager_response(&rst);
+        let rst = transport_protocol::parse_runtime_manager_response(None, &rst);
         assert!(rst.is_ok());
 
         flag_main.store(false, Ordering::SeqCst);

--- a/veracruz-server/fuzz/fuzz_targets/provision_data.rs
+++ b/veracruz-server/fuzz/fuzz_targets/provision_data.rs
@@ -77,7 +77,7 @@ fuzz_target!(|buffer: &[u8]| {
             &request,
         )
         .unwrap();
-        let rst = protobuf::parse_from_bytes::<transport_protocol::RuntimeManagerResponse>(&rst);
+        let rst = transport_protocol::parse_runtime_manager_response(&rst);
         assert!(rst.is_ok());
 
         flag_main.store(false, Ordering::SeqCst);

--- a/veracruz-server/src/veracruz_server_icecap.rs
+++ b/veracruz-server/src/veracruz_server_icecap.rs
@@ -232,7 +232,7 @@ impl VeracruzServer for VeracruzServerIceCap {
             );
             let resp = post_buffer(&url, &req).map_err(VeracruzServerError::HttpError)?;
             let resp = base64::decode(&resp)?;
-            let pasr = transport_protocol::parse_proxy_attestation_server_response(&resp)
+            let pasr = transport_protocol::parse_proxy_attestation_server_response(None, &resp)
                 .map_err(VeracruzServerError::TransportProtocolError)?;
             let cert_chain = pasr.get_cert_chain();
             let root_cert = cert_chain.get_root_cert();

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -416,7 +416,7 @@ pub mod veracruz_server_linux {
 
                     VeracruzServerError::Base64Error(e)
                 })?;
-                let pasr = parse_proxy_attestation_server_response(&resp).map_err(|e| {
+                let pasr = parse_proxy_attestation_server_response(None, &resp).map_err(|e| {
                     error!("Failed to parse reponse from proxy attestation server.  Error received: {:?}.", e);
 
                     VeracruzServerError::TransportProtocolError(e)

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -339,7 +339,7 @@ pub mod veracruz_server_linux {
 
             // Configure TCP to flush outgoing buffers immediately. This reduces
             // latency when dealing with small packets
-            runtime_manager_socket.set_nodelay(true);
+            let _ = runtime_manager_socket.set_nodelay(true);
 
             info!(
                 "Connected to Runtime Manager enclave at address {}.",

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -337,6 +337,10 @@ pub mod veracruz_server_linux {
                 VeracruzServerError::IOError(e)
             })?;
 
+            // Configure TCP to flush outgoing buffers immediately. This reduces
+            // latency when dealing with small packets
+            runtime_manager_socket.set_nodelay(true);
+
             info!(
                 "Connected to Runtime Manager enclave at address {}.",
                 runtime_manager_address

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -286,7 +286,7 @@ pub mod veracruz_server_nitro {
 
         let body_vec =
             base64::decode(&received_body).map_err(|err| VeracruzServerError::Base64Decode(err))?;
-        let response = transport_protocol::parse_proxy_attestation_server_response(&body_vec)
+        let response = transport_protocol::parse_proxy_attestation_server_response(None, &body_vec)
             .map_err(|err| VeracruzServerError::TransportProtocol(err))?;
 
         let (re_cert, ca_cert) = if response.has_cert_chain() {


### PR DESCRIPTION
Reduce latency in the network stack, specifically on the runtime manager and client sides.
- Prefix every protocol buffer (runtime manager & proxy attestation messages) with their length to allow the receiver to know when a protocol buffer is complete. This avoids the need to try to deserialize the protocol buffer until it succeeds, which is more and more time consuming as the incoming buffer grows (it takes about 100ms to deserialize a 30MB protocol buffer)
- Turn 'TCP no delay' on to reduce latency on the Linux backend, the only one for which the server and the runtime manager communicate over TCP. This is effective when small packets are regularly sent, which is the case here. This measure decreases latency from 40ms down to <1ms

Note that a high latency between the client and server will still have a big impact on throughput, as 16KB protobuf fragments –split by TLS – are still sent between the client and runtime manager one by one.
The obvious solution is to remove HTTP on the client/server side and replace it with a plain TCP repeater.
Other ideas:
* The client could encapsulate groups of fragments in each HTTP request to the server, which might require to configure the TLS server to handle groups of TLS records. This would have the downside of increasing memory usage on the server.
* Remove base64 (de)serializing, which could shave off a few hundreds of microseconds here and there

All these suggestions are however out of the scope of this PR.

TODO:
* Benchmark "no length prefix" vs "length prefix" to validate changes
* Avoid unnecessary conversions between arrays, vectors and mutable vectors