### PR TITLE
Implement time functions in Nitro

### DIFF
--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 [features]
 default = []
 icecap = []
-nitro = ["nsm_io", "nsm_lib"]
+nitro = ["nix", "nsm_io", "nsm_lib"]
 std = ["getrandom", "nix"]
 
 [lib]


### PR DESCRIPTION
This PR adds support for time functions (`getclockres()` and `getclocktime()`) in Nitro