### PR TITLE
Add a facility similar to strace for showing WASI calls.

### DIFF
--- a/execution-engine/src/lib.rs
+++ b/execution-engine/src/lib.rs
@@ -45,9 +45,11 @@ pub struct Options {
     /// if any.
     pub program_arguments: Vec<String>,
     /// Whether clock-related functionality is enabled for the program.  If not
-    /// enabled, clock- and time-related WASI host-calls return an unimpleemnted
+    /// enabled, clock- and time-related WASI host-calls return an unimplemented
     /// status code.
     pub enable_clock: bool,
+    /// Whether strace-like output is enabled.
+    pub enable_strace: bool,
 }
 
 impl Default for Options {
@@ -57,6 +59,7 @@ impl Default for Options {
             environment_variables: Vec::new(),
             program_arguments: Vec::new(),
             enable_clock: false,
+            enable_strace: false,
         }
     }
 }

--- a/execution-engine/src/wasi/mod.rs
+++ b/execution-engine/src/wasi/mod.rs
@@ -10,6 +10,7 @@
 //! information on licensing and copyright.
 
 pub mod common;
+pub mod strace;
 pub(crate) mod wasmi;
 #[cfg(feature = "std")]
 pub(crate) mod wasmtime;

--- a/execution-engine/src/wasi/strace.rs
+++ b/execution-engine/src/wasi/strace.rs
@@ -1,0 +1,112 @@
+//! An implementation of the WASI API for Execution Engine.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Licensing and copyright notice
+//!
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
+//! information on licensing and copyright.
+
+#![allow(unused_variables)] // while most of the functions are unimplemented
+
+use super::common::MemoryHandler;
+use crate::fs::FileSystemResult;
+use std::fmt;
+
+pub struct Strace {}
+
+impl Strace {
+    pub fn func(enabled: bool, name: &str) -> Self {
+        // NOT YET IMPLEMENTED
+        Strace {}
+    }
+
+    pub fn arg_buffer<T: MemoryHandler>(&mut self, mem: &mut T, adr: u32, len: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_dec<T: fmt::Display>(&mut self, n: T) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_dots(&mut self) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_dirents<T: MemoryHandler>(
+        &mut self,
+        _mem: &mut T,
+        _buf_ptr: u32,
+        _buf_len: u32,
+        _result_ptr: u32,
+    ) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_events<T: MemoryHandler>(&mut self, _mem: &mut T, _events: u32, _size: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_fdstat<T: MemoryHandler>(&mut self, _mem: &mut T, _adr: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_filestat<T: MemoryHandler>(&mut self, _mem: &mut T, _adr: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_hex<T: fmt::LowerHex>(&mut self, n: T) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_iovec<T: MemoryHandler>(
+        &mut self,
+        res: FileSystemResult<()>,
+        memory_ref: &mut T,
+        base: u32,
+        count: u32,
+        address: u32,
+    ) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_p_u16_hex<T: MemoryHandler>(&mut self, mem: &mut T, adr: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_p_u32<T: MemoryHandler>(&mut self, mem: &mut T, adr: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_p_u64<T: MemoryHandler>(&mut self, mem: &mut T, adr: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_path<T: MemoryHandler>(&mut self, mem: &mut T, adr: u32, len: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_prestat_out<T: MemoryHandler>(
+        &mut self,
+        res: FileSystemResult<()>,
+        mem: &mut T,
+        adr: u32,
+    ) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_rights(&mut self, rights: u64) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn arg_subscriptions<T: MemoryHandler>(&mut self, _mem: &mut T, _expr: u32, _size: u32) {
+        // NOT YET IMPLEMENTED
+    }
+
+    pub fn result(&mut self, result: FileSystemResult<()>) -> FileSystemResult<()> {
+        // NOT YET IMPLEMENTED
+        result
+    }
+}

--- a/execution-engine/src/wasi/wasmi.rs
+++ b/execution-engine/src/wasi/wasmi.rs
@@ -1250,6 +1250,7 @@ impl ExecutionEngine for WASMIRuntimeState {
     ) -> Result<u32, FatalEngineError> {
         self.load_program(&program)?;
         self.vfs.enable_clock = options.enable_clock;
+        self.vfs.enable_strace = options.enable_strace;
 
         let execute_result = self.invoke_export(WasiWrapper::ENTRY_POINT_NAME);
         let exit_code = self.vfs.exit_code();

--- a/execution-engine/src/wasi/wasmtime.rs
+++ b/execution-engine/src/wasi/wasmtime.rs
@@ -826,6 +826,7 @@ impl ExecutionEngine for WasmtimeRuntimeState {
         VFS_INSTANCE.lock()?.environment_variables = options.environment_variables;
         VFS_INSTANCE.lock()?.program_arguments = options.program_arguments;
         VFS_INSTANCE.lock()?.enable_clock = options.enable_clock;
+        VFS_INSTANCE.lock()?.enable_strace = options.enable_strace;
         Self::invoke_entry_point(program)
     }
 }


### PR DESCRIPTION
The command-line option is added and all WASI calls are instrumented,
but currently no output is generated as the corresponding functions
in strace.rs are just stubs, marked with "NOT YET IMPLEMENTED".