### PR TITLE
v1: Fix CLI quickstarts

### DIFF
--- a/CLI_INSTRUCTIONS.markdown
+++ b/CLI_INSTRUCTIONS.markdown
@@ -23,7 +23,7 @@ rules, allowing you to maximize the time you have to get coffee while the code
 is compiling:
 
 ``` bash
-$ make sgx-cli-install sdk
+$ make sdk sgx-cli-install
 ...
 ```
 

--- a/CLI_INSTRUCTIONS.markdown
+++ b/CLI_INSTRUCTIONS.markdown
@@ -159,17 +159,17 @@ $ vc-pgen \
     --certificate-expiry "$(date --rfc-2822 -d 'now + 100 days')" \
     --css-file runtime-manager/css-sgx.bin \
     --certificate example/example-program-cert.pem \
-    --capability "example-binary.wasm:w" \
+    --capability "/program/:w" \
     --certificate example/example-data0-cert.pem \
-    --capability "input-0:w" \
+    --capability "/input/:w" \
     --certificate example/example-data1-cert.pem \
-    --capability "input-1:w" \
+    --capability "/input/:w" \
     --certificate example/example-data2-cert.pem \
-    --capability "input-2:w" \
+    --capability "/input/:w" \
     --certificate example/example-result-cert.pem \
-    --capability "output:r" \
-    --binary example-binary.wasm=example/example-binary.wasm \
-    --capability "input-0:r,input-1:r,input-2:r,output:w" \
+    --capability "/program/:r,/output/:r" \
+    --binary /program/example-binary.wasm=example/example-binary.wasm \
+    --capability "/input/:r,/output/:w" \
     --output-policy-file example/example-policy.json
 ```
 
@@ -243,7 +243,7 @@ identity with the "ProgramProvider" role:
 $ vc-client example/example-policy.json \
     --identity example/example-program-cert.pem \
     --key example/example-program-key.pem \
-    --program example-binary.wasm=example/example-binary.wasm
+    --program /program/example-binary.wasm=example/example-binary.wasm
 Loaded policy example/example-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
 Connecting to 127.0.0.1:3017
 Submitting <enclave>/example-binary.wasm from example/example-binary.wasm
@@ -258,26 +258,26 @@ different devices:
 $ vc-client example/example-policy.json \
     --identity example/example-data0-cert.pem \
     --key example/example-data0-key.pem \
-    --data input-0=<(echo "01dc061a7bdaf77616dd5915f3b4" | xxd -r -p)
+    --data /input/shamir-0.dat=<(echo "01dc061a7bdaf77616dd5915f3b4" | xxd -r -p)
 Loaded policy example/example-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
 Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-0 from /dev/fd/63
+Submitting <enclave>/input/shamir-0.dat from /dev/fd/63
 
 $ vc-client example/example-policy.json \
     --identity example/example-data1-cert.pem \
     --key example/example-data1-key.pem \
-    --data input-1=<(echo "027f38e27b5a02a288d064965364" | xxd -r -p)
+    --data /input/shamir-1.dat=<(echo "027f38e27b5a02a288d064965364" | xxd -r -p)
 Loaded policy example/example-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
 Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-1 from /dev/fd/63
+Submitting <enclave>/input/shamir-1.dat from /dev/fd/63
 
 $ vc-client example/example-policy.json \
     --identity example/example-data2-cert.pem \
     --key example/example-data2-key.pem \
-    --data input-2=<(echo "03eb5b946cefd583f17f51e781da" | xxd -r -p)
+    --data /input/shamir-2.dat=<(echo "03eb5b946cefd583f17f51e781da" | xxd -r -p)
 Loaded policy example/example-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
 Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-2 from /dev/fd/63
+Submitting <enclave>/input/shamir-2.dat from /dev/fd/63
 ```
 
 And finally, we can request a computation and read the result using an identity
@@ -287,18 +287,18 @@ with the "RequestResult" role:
 $ vc-client example/example-policy.json \
     --identity example/example-result-cert.pem \
     --key example/example-result-key.pem \
-    --compute example-binary.wasm \
-    --result output=-
+    --compute /program/example-binary.wasm \
+    --result /output/shamir.dat=-
 Loaded policy example/example-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
 Connecting to 127.0.0.1:3017
 Requesting compute of <enclave>/example-binary.wasm
-Reading <enclave>/output into <stdout>
+Reading <enclave>/output/shamir.dat into <stdout>
 Hello World!
 Shutting down enclave
 ```
 
-Note that `--result example-binary.wasm=-` indicates that the output
-of the `example-binary.wasm` binary should be written to stdout.
+Note that `--result /output/shamir.dat=-` indicates that the output
+should be written to stdout.
 
 And that's it! You've now completed a confidential computation. Only the
 original creator of the shares and the result reader had the permission and

--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -24,7 +24,7 @@ These can be combined into one command to maximize the time you have to
 make coffee while the code is compiling:
 
 ``` bash
-$ make sgx-cli-install sgx-test-collateral sdk
+$ make sdk sgx-cli-install sgx-test-collateral
 ...
 ```
 
@@ -56,8 +56,8 @@ $ sleep 10
 Now we can launch the Veracruz Server using the `vc-server` program:
 
 ``` bash
-$ vc-server test-collateral/shamir-secret-sharing-policy.json &
-Veracruz Server running on 127.0.0.1:3017
+$ vc-server test-collateral/triple_policy_1.json &
+Veracruz Server running on 127.0.0.1:3021
 $ sleep 10
 ```
 
@@ -72,56 +72,69 @@ The identity of each client is determined by a signed certificate, and the
 permissions each client has is stored in the policy file.
 
 ``` bash
-$ vc-client test-collateral/shamir-secret-sharing-policy.json \
+$ vc-client test-collateral/triple_policy_1.json \
     --identity test-collateral/program_client_cert.pem \
     --key test-collateral/program_client_key.pem \
-    --program shamir-secret-sharing.wasm=test-collateral/shamir-secret-sharing.wasm
-Loaded policy test-collateral/shamir-secret-sharing-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
-Connecting to 127.0.0.1:3017
+    --program /program/shamir-secret-sharing.wasm=test-collateral/shamir-secret-sharing.wasm
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
 Submitting <enclave>/shamir-secret-sharing.wasm from test-collateral/shamir-secret-sharing.wasm
 ```
 
 ``` bash
-$ vc-client test-collateral/shamir-secret-sharing-policy.json \
+$ vc-client test-collateral/triple_policy_1.json \
     --identity test-collateral/data_client_cert.pem \
     --key test-collateral/data_client_key.pem \
-    --data input-0=<(cat test-collateral/share-1.dat | xxd -r -p)
-Loaded policy test-collateral/shamir-secret-sharing-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
-Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-0 from /dev/fd/63
+    --data /input/shamir-0.dat=<(cat test-collateral/share-1.dat | xxd -r -p)
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
+Submitting <enclave>/input/shamir-0.dat from /dev/fd/63
 ```
 
 ``` bash
-$ vc-client test-collateral/shamir-secret-sharing-policy.json \
+$ vc-client test-collateral/triple_policy_1.json \
     --identity test-collateral/data_client_cert.pem \
     --key test-collateral/data_client_key.pem \
-    --data input-1=<(cat test-collateral/share-2.dat | xxd -r -p)
-Loaded policy test-collateral/shamir-secret-sharing-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
-Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-1 from /dev/fd/63
+    --data /input/shamir-1.dat=<(cat test-collateral/share-2.dat | xxd -r -p)
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
+Submitting <enclave>/input/shamir-1.dat from /dev/fd/63
 ```
 
 ``` bash
-$ vc-client test-collateral/shamir-secret-sharing-policy.json \
+$ vc-client test-collateral/triple_policy_1.json \
     --identity test-collateral/data_client_cert.pem \
     --key test-collateral/data_client_key.pem \
-    --data input-2=<(cat test-collateral/share-3.dat | xxd -r -p)
-Loaded policy test-collateral/shamir-secret-sharing-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
-Connecting to 127.0.0.1:3017
-Submitting <enclave>/input-2 from /dev/fd/63
+    --data /input/shamir-2.dat=<(cat test-collateral/share-3.dat | xxd -r -p)
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
+Submitting <enclave>/input/shamir-2.dat from /dev/fd/63
+```
+
+We can request a computation as long as we have read access to the program we
+want to execute:
+
+``` bash
+$ vc-client test-collateral/triple_policy_1.json \
+    --identity test-collateral/program_client_cert.pem \
+    --key test-collateral/program_client_key.pem \
+    --compute /program/shamir-secret-sharing.wasm
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
+Requesting compute of <enclave>/program/shamir-secret-sharing.wasm
 ```
 
 And finally, we can get request the result, as long as our client certificate
 has the permission to do so:
 
 ``` bash
-$ vc-client test-collateral/shamir-secret-sharing-policy.json \
+$ vc-client test-collateral/triple_policy_1.json \
     --identity test-collateral/result_client_cert.pem \
     --key test-collateral/result_client_key.pem \
-    --result shamir-secret-sharing.wasm=-
-Loaded policy test-collateral/shamir-secret-sharing-policy.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
-Connecting to 127.0.0.1:3017
-Reading <enclave>/shamir-secret-sharing.wasm into <stdout>
+    --result /output/shamir.dat=-
+Loaded policy test-collateral/triple_policy_1.json 645ae94ea86eaf15cfc04c07a17bd9b6a3b3b6c3558fae6fb93d8ee4c3e71241
+Connecting to 127.0.0.1:3021
+Reading <enclave>/output/shamir.dat into <stdout>
 Hello World!
 Shutting down enclave
 ```


### PR DESCRIPTION
These just fell a bit out of date due to VFS changes made since the CLI quickstarts were introduced.

The quickstarts should really be in CI, but this makes the most sense after changing the quickstarts to use a non-hardware platform (Linux?). This is less high-priority and can be done later.

I'm going to make one PR directly against the v1 branch, and another against main, in case there is a different merge pattern we want to use in this situation.

The only changes are to the files CLI_INSTRUCTIONS.md and CLI_QUICKSTART.md, which, since they're not in CI, should have no impact on existing tests or CI.