### PR TITLE
icecap/ci/run.sh: Run "df -H" before exiting.

### DIFF
--- a/icecap/ci/run.sh
+++ b/icecap/ci/run.sh
@@ -1,5 +1,20 @@
 set -e
 
+error_df()
+{
+    set +e
+    echo
+    echo df -H
+    df -H
+    echo
+    echo du -sh
+    du -sh /nix /root /work
+    echo
+    echo du -k
+    du -k /work | sort -rn | head -n 30
+}
+trap error_df EXIT
+
 cd /work/veracruz/icecap
 
 make run-tests


### PR DESCRIPTION
Unless there's an easy way of getting this from
https://github.com/veracruz-project/veracruz/actions which I have
failed to spot, this might be useful for monitoring disc usage.