### PR TITLE
Fix CI with changes needed for wasmi and wasi-types updates

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -14,13 +14,11 @@ icecap = [
 nitro = [
   "platform-services/nitro",
   "policy-utils/std",
-  "wasi-types/std",
   "wasmtime",
 ]
 std = [
   "platform-services/std",
   "policy-utils/std",
-  "wasi-types/std",
   "wasmtime",
 ]
 

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -35,7 +35,7 @@ num-traits = { version = "0.2", default-features = false }
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
 serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
-typetag = "0.1.4"
+typetag = "=0.1.6"
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }
 wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch = "veracruz" }
 wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", branch = "veracruz", optional = true }

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -7,21 +7,28 @@ version = "0.3.0"
 
 [features]
 default = []
-# NOTE: Introduce non_sgx in the dependencies to deal with sgx-related modification.
-icecap = ["platform-services/icecap", "policy-utils/icecap", "wasmi/non_sgx"]
-nitro = ["platform-services/nitro", "policy-utils/std", "wasmtime", "wasi-types/std"]
-std = [
-  "wasmi/non_sgx",
-  "platform-services/std",
-  "wasmtime",
+icecap = [
+  "platform-services/icecap",
+  "policy-utils/icecap",
+]
+nitro = [
+  "platform-services/nitro",
   "policy-utils/std",
-  "wasi-types/std"
+  "wasi-types/std",
+  "wasmtime",
+]
+std = [
+  "platform-services/std",
+  "policy-utils/std",
+  "wasi-types/std",
+  "wasmtime",
 ]
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 byteorder = "1.4.3"
 cfg-if = "1"
+ctor = "=0.1.16"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 num = { version = "0.4", default-features = false }
@@ -30,7 +37,7 @@ num-traits = { version = "0.2", default-features = false }
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
 serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
-typetag = { git = "https://github.com/veracruz-project/typetag.git", branch = "veracruz" }
+typetag = "0.1.4"
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }
 wasmi = { git = "https://github.com/veracruz-project/wasmi.git", branch = "veracruz" }
 wasmtime = { git = "https://github.com/veracruz-project/wasmtime.git", branch = "veracruz", optional = true }
@@ -41,4 +48,4 @@ name = "execution_engine"
 path = "./src/lib.rs"
 
 [patch.crates-io]
-serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
+serde = { git = "https://github.com/veracruz-project/serde.git", branch = "veracruz" }

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.3.0"
 
 [features]
 icecap = ["ring"]
-std = ["serde/std", "serde_json/std", "ring", "x509-parser", "rustls", "wasi-types/std"]
+std = ["serde/std", "serde_json/std", "ring", "x509-parser", "rustls"]
 
 [dependencies]
 err-derive = { version = "0.2", default-features = false }

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -49,7 +49,7 @@ http = "=0.2.4"
 lazy_static = "1.3"
 log = "=0.4.13"
 nb-connect = "=1.0.3"
-nitro-enclave-attestation-document = { git = "https://github.com/veracruz-project/nitro-enclave-attestation-document.git", branch = "main", optional = true }
+nitro-enclave-attestation-document = { git = "https://github.com/veracruz-project/nitro-enclave-attestation-document.git", rev = "4d703bcde209a8d625776f6c346c36a9ad084511", optional = true }
 openssl = "0.10.24"
 openssl-sys = "=0.9.70"
 percent-encoding = "2.1"
@@ -58,6 +58,7 @@ rand = "0.7"
 ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz" }
 rouille = "=3.2.1"
 serde_json = "1.0"
+serde_with = "=1.6.4"
 stringreader = "0.1"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 transport-protocol = { path = "../transport-protocol" }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -89,3 +89,6 @@ wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branc
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+serde = { git = "https://github.com/veracruz-project/serde.git", branch = "veracruz" }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -37,7 +37,6 @@ linux = [
   "clap",
   "nix",
   "bincode",
-  "wasi-types/std",
   "log",
   "env_logger",
 ]
@@ -53,7 +52,6 @@ nitro = [
   "ring/nitro",
   "nix",
   "bincode",
-  "wasi-types/std",
 ]
 
 [dependencies]

--- a/sdk/freestanding-execution-engine/Cargo.toml
+++ b/sdk/freestanding-execution-engine/Cargo.toml
@@ -13,7 +13,11 @@ execution-engine = { path = "../../execution-engine", features = ["std"] }
 log = "0.4.13"
 postcard = "0.7.2"
 policy-utils = { path = "../../policy-utils", features = ["std"] }
+serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
 wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }
+
+[patch.crates-io]
+serde = { git = "https://github.com/veracruz-project/serde.git", branch = "veracruz" }
 
 [[bin]]
 name = "freestanding-execution-engine"

--- a/test-collateral/generate-policy/Cargo.toml
+++ b/test-collateral/generate-policy/Cargo.toml
@@ -18,4 +18,4 @@ policy-utils = { path = "../../policy-utils", features = ["std"] }
 ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz", features = ["non_sgx"] }
 serde_json = { git = "https://github.com/veracruz-project/json.git", branch = "veracruz", features = ["std"] }
 veracruz-utils = {path = "../../veracruz-utils", features = ["std"]}
-wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz", features = ['std'] }
+wasi-types = { git = "https://github.com/veracruz-project/wasi-types.git", branch = "veracruz" }


### PR DESCRIPTION
Following https://github.com/veracruz-project/wasmi/pull/2 and https://github.com/veracruz-project/wasi-types/pull/8 being merged some changes are required to fix `main`.
