### PR TITLE
Use workspaces for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
+      image: ghcr.io/veracruz-project/veracruz/veracruz-ci-linux:ci-v2
       volumes:
         - ${{ github.workspace }}:/work/veracruz
     steps:
@@ -32,7 +32,7 @@ jobs:
   icecap:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
+      image: ghcr.io/veracruz-project/veracruz/veracruz-ci-icecap:ci-v2
       volumes:
         - ${{ github.workspace }}:/work/veracruz
     steps:
@@ -45,11 +45,10 @@ jobs:
             make -C /work/veracruz/workspaces icecap
             make -C /work/veracruz/workspaces/icecap-host run-tests
 
-
   nitro:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
+      image: ghcr.io/veracruz-project/veracruz/veracruz-ci-nitro:ci-v2
       volumes:
         - ${{ github.workspace }}:/work/veracruz
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Running linux test script
         id: linux-build-and-test
         run: |
-            make -C /work/veracruz/workspaces linux
-            make -C /work/veracruz/workspaces/linux-host test-client test-server veracruz-test
+            make -C /work/veracruz/workspaces linux PROFILE=dev
+            make -C /work/veracruz/workspaces/linux-host test-client test-server veracruz-test PROFILE=dev
 
   icecap:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
       - name: Running Nitro test script
         id: nitro-build
         run: |
-            make -C /work/veracruz/workspaces nitro
+            make -C /work/veracruz/workspaces nitro PROFILE=dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,22 +29,6 @@ jobs:
             make -C /work/veracruz/workspaces linux PROFILE=dev
             make -C /work/veracruz/workspaces/linux-host test-client test-server veracruz-test PROFILE=dev
 
-  icecap:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz-ci-icecap:ci-v2
-      volumes:
-        - ${{ github.workspace }}:/work/veracruz
-    steps:
-      - name: Check out the Veracruz repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Build and test Veracruz on IceCap
-        run: |
-            make -C /work/veracruz/workspaces icecap
-            make -C /work/veracruz/workspaces/icecap-host run-tests
-
   nitro:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,97 +12,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-repo-and-compile-sdk:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz:ci
-      volumes:
-        - ${{ github.workspace }}:/work/veracruz
-
-    steps:
-
-      # Remove pre-installed .Net, Android, and Glasgow Haskell Compiler
-      - name: Free-up disk space
-        id: disk-space
-        run: sudo rm -rf /usr/local/share/boost && sudo rm -rf /usr/share/dotnet && sudo rm -rf /usr/local/lib/android && sudo rm -rf /opt/ghc
-
-      # Check out the repo, using the action from github
-      - name: Check out the repo
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      # Check source file formatting, then compile all examples and data sources in the SDK
-      - name: Check source file formatting
-        id: rustfmt-check
-        run: |
-          cd /work/veracruz
-          make fmt-check
-
-      - name: Compile SDK
-        id: sdk
-        run: |
-          cd /work/veracruz
-          make sdk
-
-      # Pack cache
-      - name: Pack cache
-        id: pack-cache
-        run: |
-          cd /
-          tar -cvf veracruz.tar -C /work/veracruz --exclude=./veracruz.tar --exclude-vcs --exclude-backups .
-
-     # Update the repo and sdk artifact, using the action from github
-      - name: Upload veracruz cache artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: veracruz.tar
-          path: /veracruz.tar
-          if-no-files-found: error
-
   linux:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz:ci
+      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
       volumes:
         - ${{ github.workspace }}:/work/veracruz
-    needs: [check-repo-and-compile-sdk]
     steps:
-      # Remove pre-installed .Net, Android, and Glasgow Haskell Compiler
-      - name: Free-up disk space
-        id: disk-space
-        run: sudo rm -rf /usr/local/share/boost && sudo rm -rf /usr/share/dotnet && sudo rm -rf /usr/local/lib/android && sudo rm -rf /opt/ghc
-
-      # Download the artifact containing repo and sdk artifact, using the action from github
-      - name: Download veracruz cache artifact
-        uses: actions/download-artifact@v2
+      - name: Check out the Veracruz repository
+        uses: actions/checkout@v2
         with:
-          name: veracruz.tar
-          path: /
-      # Unpack
-      - name: Unpack veracruz cache artifact
-        id: linux-unpack
-        run: |
-            cd /
-            mkdir -p /work/veracruz
-            mv veracruz.tar /work/veracruz
-            cd /work/veracruz
-            tar -xvf veracruz.tar
-            rm veracruz.tar
+          submodules: recursive
       - name: Running linux test script
         id: linux-build-and-test
         run: |
-            cd /work/veracruz
-            make linux
-            make linux-cli
-            make linux-veracruz-server-test
-            make linux-veracruz-test
-            make linux-veracruz-client-test
+            make -C /work/veracruz/workspaces linux
+            make -C /work/veracruz/workspaces/linux-host test-client test-server veracruz-test
 
   icecap:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/veracruz-project/veracruz/veracruz-icecap:ci-57aa33370d
+      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
       volumes:
         - ${{ github.workspace }}:/work/veracruz
     steps:
@@ -111,36 +41,23 @@ jobs:
         with:
           submodules: recursive
       - name: Build and test Veracruz on IceCap
-        run: bash /work/veracruz/icecap/ci/run.sh
+        run: |
+            make -C /work/veracruz/workspaces icecap
+            make -C /work/veracruz/workspaces/icecap-host run-tests
+
 
   nitro:
-     runs-on: ubuntu-latest
-     container:
-       image: ghcr.io/veracruz-project/veracruz/veracruz-nitro:latest
-       volumes: 
-         - ${{ github.workspace }}:/work/veracruz 
-     needs: [check-repo-and-compile-sdk]
-
-     steps:
-
-       # Download the artifact containing repo and sdk artifact, using the action from github
-       - name: Download veracruz cache artifact
-         uses: actions/download-artifact@v2
-         with:
-           name: veracruz.tar
-           path: /
-       # Unpack
-       - name: Unpack veracruz cache artifact
-         id: nitro-unpack
-         run: |
-             cd /
-             mkdir -p /work/veracruz
-             tar -C /work/veracruz -xvf veracruz.tar
-             rm veracruz.tar
-       
-       - name: Running Nitro test script
-         id: nitro-build
-         run: |
-             cd /work/veracruz
-             make nitro
-             make nitro-cli
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/veracruz-project/veracruz/veracruz:ci-v2
+      volumes:
+        - ${{ github.workspace }}:/work/veracruz
+    steps:
+      - name: Check out the Veracruz repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Running Nitro test script
+        id: nitro-build
+        run: |
+            make -C /work/veracruz/workspaces nitro


### PR DESCRIPTION
Currently a draft to get some feedback. Initially I created a single CI image that would work for `linux`, `nitro` and `icecap`. I ended up running out of space for `icecap` build. Instead it now runs with 3 separate dedicated images. I remove the `check-repo-and-compile-sdk ` job because it did not seem to save any wallclock time.
