### PR TITLE
pre-commit: Run rustfmt without "--skip-children --unstable-features".

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -15,13 +15,17 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz repository root
 # directory for copyright and licensing information.
 
+HAS_RUSTFMT_ERROR=0
 HAS_RUSTFMT_ISSUES=0
 HAS_SPACE_ISSUES=0
 
 echo "Checking code formatting of files staged for commit."
 
 for file in $(git diff --name-only --staged \*.rs); do
-    RUSTFMT="$(rustfmt --edition=2018 --check --skip-children --unstable-features $file)"
+    RUSTFMT="$(rustfmt --edition=2018 --check $file)"
+    if [ "$?" != 0 ] ; then
+        HAS_RUSTFMT_ERROR=1
+    fi
     SPACES="$(perl -ne 'print if /[ \t]$/;' $file)"
     if [ "$RUSTFMT" != "" -o "$SPACES" != "" ]; then
         printf "[ERROR]: $file\n"
@@ -52,6 +56,10 @@ elif [ $HAS_SPACE_ISSUES -eq 1 ]; then
     echo "before committing."
     exit 1
 else
-    echo "Code formatting style is OK."
+    if [ $HAS_RUSTFMT_ERROR -eq 1 ]; then
+        echo "WARNING: rustfmt did not run correctly!"
+    else
+        echo "Code formatting style is OK."
+    fi
     exit 0
 fi


### PR DESCRIPTION
Now we are using a stable compiler people are likely to have the
stable rustfmt, which does not have "--skip-children". Also we have
applied rustfmt uniformly across the codebase so it should not hurt to
apply rustfmt more broadly.

This patch also adds code to check that rustfmt ran correctly. The
problem with rustfmt failing was previously easy to ignore.