### PR TITLE
Fix runtime manager's Makefiles across workspaces

### DIFF
--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -188,7 +188,7 @@ $ vc-pgen \
     --proxy-attestation-server-cert example/example-ca-cert.pem \
     --veracruz-server-ip 127.0.0.1:3017 \
     --certificate-expiry "$(date --rfc-2822 -d 'now + 100 days')" \
-    --css-file workspaces/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave \
+    --css-file workspaces/linux-runtime/target/release/runtime_manager_enclave \
     --certificate example/example-program-cert.pem \
     --capability "/program/:w" \
     --certificate example/example-data0-cert.pem \

--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -188,7 +188,7 @@ $ vc-pgen \
     --proxy-attestation-server-cert example/example-ca-cert.pem \
     --veracruz-server-ip 127.0.0.1:3017 \
     --certificate-expiry "$(date --rfc-2822 -d 'now + 100 days')" \
-    --css-file workspaces/linux-runtime/css-linux.bin \
+    --css-file workspaces/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave \
     --certificate example/example-program-cert.pem \
     --capability "/program/:w" \
     --certificate example/example-data0-cert.pem \

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -17,27 +17,27 @@ default: build
 
 tests: test-server test-client veracruz-test
 
-WORKSPACE_DIR = $(abspath ..)
-OUT_DIR ?= $(abspath test-collateral)
-MEASUREMENT_FILE = $(abspath ../linux-runtime/css-linux.bin)
-MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)
-
 include $(WORKSPACE_DIR)/common.mk
 include $(WORKSPACE_DIR)/shared.mk
 
+WORKSPACE_DIR = $(abspath ..)
+OUT_DIR ?= $(abspath test-collateral)
+MEASUREMENT_FILE = $(abspath ../linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave)
+MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)
+
 CC = CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc
-RUNTIME_MANAGER_ENCLAVE = $(WORKSPACE_DIR)/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave
+RUNTIME_ENCLAVE_BINARY_PATH = $(WORKSPACE_DIR)/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave
 TEST_PARAMETERS = DATABASE_URL=$(PROXY_ATTESTATION_SERVER_DB) \
 	VERACRUZ_POLICY_DIR=$(OUT_DIR) \
 	VERACRUZ_TRUST_DIR=$(OUT_DIR) \
 	VERACRUZ_PROGRAM_DIR=$(OUT_DIR) \
 	VERACRUZ_DATA_DIR=$(OUT_DIR) \
-	RUNTIME_ENCLAVE_BINARY_PATH=$(WORKSPACE_DIR)/linux-runtime/runtime_manager_enclave
+	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH)
 
 all: build test-collateral
 
 build:
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) \
+	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) \
 	$(CC) \
 		cargo build $(PROFILE_FLAG) $(V_FLAG) \
 		-p proxy-attestation-server \
@@ -61,9 +61,9 @@ install:
 $(MEASUREMENT_FILE):
 	$(MAKE) -C ../linux-runtime linux
 
-test-dependencies: test-collateral $(RUNTIME_MANAGER_ENCLAVE)
+test-dependencies: test-collateral $(RUNTIME_ENCLAVE_BINARY_PATH)
 
-CARGO_TEST = RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) \
+CARGO_TEST = RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) \
 	$(CC) \
 	$(TEST_PARAMETERS) \
 	cargo test $(PROFILE_FLAG) --features linux
@@ -80,7 +80,7 @@ veracruz-test: test-dependencies
 	$(CARGO_TEST) -p veracruz-test --no-run
 	$(CARGO_TEST) -p veracruz-test -- --test-threads=1
 
-$(RUNTIME_MANAGER_ENCLAVE):
+$(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
 doc:

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -17,10 +17,10 @@ default: build
 
 tests: test-server test-client veracruz-test
 
+WORKSPACE_DIR = $(abspath ..)
 include $(WORKSPACE_DIR)/common.mk
 include $(WORKSPACE_DIR)/shared.mk
 
-WORKSPACE_DIR = $(abspath ..)
 OUT_DIR ?= $(abspath test-collateral)
 MEASUREMENT_FILE = $(abspath ../linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave)
 MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -19,14 +19,14 @@ tests: test-server test-client veracruz-test
 
 WORKSPACE_DIR = $(abspath ..)
 include $(WORKSPACE_DIR)/common.mk
-include $(WORKSPACE_DIR)/shared.mk
 
 OUT_DIR ?= $(abspath test-collateral)
-MEASUREMENT_FILE = $(abspath ../linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave)
+RUNTIME_ENCLAVE_BINARY_PATH = $(WORKSPACE_DIR)/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave
+MEASUREMENT_FILE = $(RUNTIME_ENCLAVE_BINARY_PATH)
 MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)
+include $(WORKSPACE_DIR)/shared.mk
 
 CC = CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc
-RUNTIME_ENCLAVE_BINARY_PATH = $(WORKSPACE_DIR)/linux-runtime/target/$(PROFILE_PATH)/runtime_manager_enclave
 TEST_PARAMETERS = DATABASE_URL=$(PROXY_ATTESTATION_SERVER_DB) \
 	VERACRUZ_POLICY_DIR=$(OUT_DIR) \
 	VERACRUZ_TRUST_DIR=$(OUT_DIR) \
@@ -56,10 +56,6 @@ install:
 	ln -sf $(BIN_DIR)/proxy-attestation-server $(BIN_DIR)/vc-pas
 	ln -sf $(BIN_DIR)/veracruz-server $(BIN_DIR)/vc-server
 	ln -sf $(BIN_DIR)/veracruz-client $(BIN_DIR)/vc-client
-
-.PHONY: $(MEASUREMENT_FILE)
-$(MEASUREMENT_FILE):
-	$(MAKE) -C ../linux-runtime linux
 
 test-dependencies: test-collateral $(RUNTIME_ENCLAVE_BINARY_PATH)
 

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -21,7 +21,6 @@ WORKSPACE_DIR = $(abspath ..)
 OUT_DIR ?= $(abspath test-collateral)
 MEASUREMENT_FILE = $(abspath ../linux-runtime/css-linux.bin)
 MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)
-ENCLAVE_BINARY_PATH = $(abspath $(WORKSPACE_DIR)/linux-runtime/runtime_manager_enclave)
 
 include $(WORKSPACE_DIR)/common.mk
 include $(WORKSPACE_DIR)/shared.mk
@@ -33,7 +32,7 @@ TEST_PARAMETERS = DATABASE_URL=$(PROXY_ATTESTATION_SERVER_DB) \
 	VERACRUZ_TRUST_DIR=$(OUT_DIR) \
 	VERACRUZ_PROGRAM_DIR=$(OUT_DIR) \
 	VERACRUZ_DATA_DIR=$(OUT_DIR) \
-	RUNTIME_MANAGER_ENCLAVE_PATH=$(RUNTIME_MANAGER_ENCLAVE)
+	RUNTIME_ENCLAVE_BINARY_PATH=$(WORKSPACE_DIR)/linux-runtime/runtime_manager_enclave
 
 all: build test-collateral
 

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -19,14 +19,10 @@ include $(WORKSPACE_DIR)/common.mk
 
 all: linux
 
-linux: runtime-manager-enclave css-linux.bin
+linux: runtime-manager-enclave
 
 runtime-manager-enclave:
 	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux -p runtime_manager_enclave
-	cp target/$(PROFILE_PATH)/runtime_manager_enclave .
-
-css-linux.bin: runtime-manager-enclave
-	cp target/$(PROFILE_PATH)/runtime_manager_enclave $@
 
 doc:
 	cargo doc
@@ -36,7 +32,6 @@ fmt:
 
 clean:
 	@cargo clean
-	@rm -f css-linux.bin
 
 clean-cargo-lock:
 	rm -f Cargo.lock

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -25,7 +25,7 @@ runtime-manager-enclave:
 	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux -p runtime_manager_enclave
 
 css-linux.bin: runtime-manager-enclave
-	cp $< $@
+	cp target/$(PROFILE_PATH)/runtime_manager_enclave $@
 
 doc:
 	cargo doc

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -23,6 +23,7 @@ linux: runtime-manager-enclave css-linux.bin
 
 runtime-manager-enclave:
 	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux -p runtime_manager_enclave
+	cp target/$(PROFILE_PATH)/runtime_manager_enclave .
 
 css-linux.bin: runtime-manager-enclave
 	cp target/$(PROFILE_PATH)/runtime_manager_enclave $@

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz root director for licensing
 # and copyright information.
 
-.PHONY: all clean clean-cargo-lock doc fmt linux
+.PHONY: all clean clean-cargo-lock doc fmt linux runtime-manager-enclave
 
 default: all
 
@@ -17,23 +17,14 @@ WORKSPACE_DIR = $(abspath ..)
 
 include $(WORKSPACE_DIR)/common.mk
 
-############# Source code #################
-SRC_DIR = $(abspath crates/runtime-manager)
-COMMON_Src = $(SRC_DIR)/src/managers/*.rs
-Linux_Src = $(COMMON_Src) $(SRC_DIR)/src/runtime_manager_linux.rs $(SRC_DIR)/src/main.rs
-
 all: linux
 
-linux: target/$(PROFILE_PATH)/runtime_manager_enclave \
-	css-linux.bin
+linux: runtime-manager-enclave css-linux.bin
 
-target/$(PROFILE_PATH)/runtime_manager_enclave: \
-	Cargo.toml $(Linux_Src)
-	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux \
-		-p runtime_manager_enclave
-	cp target/$(PROFILE_PATH)/runtime_manager_enclave .
+runtime-manager-enclave:
+	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux -p runtime_manager_enclave
 
-css-linux.bin: target/$(PROFILE_PATH)/runtime_manager_enclave
+css-linux.bin: runtime-manager-enclave
 	cp $< $@
 
 doc:

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -27,7 +27,7 @@ nitro: runtime_manager.eif PCR0 css-nitro.bin
 css-nitro.bin: PCR0
 	cp $< $@
 
-runtime_manager.eif PCR0: runtime-manager-enclave crates/runtime-manager/dockerdir/Dockerfile
+runtime_manager.eif PCR0: target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave crates/runtime-manager/dockerdir/Dockerfile
 	rm -rf docker
 	mkdir -p docker
 	cp target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave docker
@@ -36,6 +36,8 @@ runtime_manager.eif PCR0: runtime-manager-enclave crates/runtime-manager/dockerd
 	nitro-cli build-enclave --docker-dir docker --docker-uri runtime_manager --output-file runtime_manager.eif > measurements.json
 	cat measurements.json | jq -r '.Measurements.PCR0' > PCR0
 	rm -rf docker
+
+target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave: runtime-manager-enclave
 
 runtime-manager-enclave:
 	rustup target add $(ARCH)-unknown-linux-musl

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -22,10 +22,7 @@ include $(WORKSPACE_DIR)/shared.mk
 
 all: nitro
 
-nitro: runtime_manager.eif PCR0 css-nitro.bin
-
-css-nitro.bin: PCR0
-	cp $< $@
+nitro: runtime_manager.eif PCR0
 
 runtime_manager.eif PCR0: target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave crates/runtime-manager/dockerdir/Dockerfile
 	rm -rf docker
@@ -53,7 +50,7 @@ fmt:
 
 clean:
 	@cargo clean
-	@rm -f css-nitro.bin PCR0
+	@rm -f PCR0
 
 clean-cargo-lock:
 	rm -f Cargo.lock

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz root director for licensing
 # and copyright information.
 
-.PHONY: all clean clean-cargo-lock default doc fmt nitro test-collateral
+.PHONY: all clean clean-cargo-lock default doc fmt nitro test-collateral runtime-manager-enclave
 
 default: all
 
@@ -20,11 +20,6 @@ ARCH = $(shell uname -m)
 include $(WORKSPACE_DIR)/common.mk
 include $(WORKSPACE_DIR)/shared.mk
 
-############# Source code #################
-SRC_DIR = $(abspath crates/runtime-manager)
-COMMON_Src = $(SRC_DIR)/src/managers/*.rs
-Nitro_Src = $(COMMON_Src) $(SRC_DIR)/src/runtime_manager_nitro.rs $(SRC_DIR)/src/main.rs
-
 all: nitro
 
 nitro: runtime_manager.eif PCR0 css-nitro.bin
@@ -32,7 +27,7 @@ nitro: runtime_manager.eif PCR0 css-nitro.bin
 css-nitro.bin: PCR0
 	cp $< $@
 
-runtime_manager.eif PCR0: target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave crates/runtime-manager/dockerdir/Dockerfile
+runtime_manager.eif PCR0: runtime-manager-enclave crates/runtime-manager/dockerdir/Dockerfile
 	rm -rf docker
 	mkdir -p docker
 	cp target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave docker
@@ -42,7 +37,7 @@ runtime_manager.eif PCR0: target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runt
 	cat measurements.json | jq -r '.Measurements.PCR0' > PCR0
 	rm -rf docker
 
-target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave: Cargo.toml $(Nitro_Src)
+runtime-manager-enclave:
 	rustup target add $(ARCH)-unknown-linux-musl
 	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
 	cargo build --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \


### PR DESCRIPTION
Currently the build system doesn't recompile the runtime manager when its dependencies, e.g. `transport-protocol`, are modified.
This makes debugging tedious and error prone: many times I was trying to figure out the reason for network issues or crashes, before realising the binaries had not been recompiled.  @egrimley-arm faced similar issues.
This PR fixes that by calling Cargo to look for changes in the source of  runtime-manager and all its dependencies, instead of relying on traditional Makefile targets.