### PR TITLE
Make changes required by changes in aws-nitro-enclaves-nsm-api.

### DIFF
--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 [features]
 default = []
 icecap = []
-nitro = ["nix", "nsm_io", "nsm_lib"]
+nitro = ["nix", "nsm_api", "nsm_lib"]
 std = ["getrandom", "nix"]
 
 [lib]
@@ -20,7 +20,7 @@ cfg-if = "0.1.10"
 getrandom = { version = "0.1.14", optional = true }
 half = "=1.7.1"
 nix = { version = "0.22", optional = true }
-nsm_io = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
 
 [profile.release]

--- a/platform-services/src/nitro_platform_services.rs
+++ b/platform-services/src/nitro_platform_services.rs
@@ -14,7 +14,7 @@
 
 use super::result;
 use nix::{errno::Errno, sys::time::TimeValLike, time};
-use nsm_io;
+use nsm_api;
 use nsm_lib;
 
 /// Fills a buffer, `buffer`, with random bytes sampled from the thread-local
@@ -28,7 +28,7 @@ pub fn platform_getrandom(buffer: &mut [u8]) -> result::Result<()> {
 
     let status = unsafe { nsm_lib::nsm_get_random(nsm_fd, buffer.as_mut_ptr(), &mut buffer_len) };
     return match status {
-        nsm_io::ErrorCode::Success => result::Result::Success(()),
+        nsm_api::api::ErrorCode::Success => result::Result::Success(()),
         _ => result::Result::UnknownError,
     };
 }

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -13,7 +13,7 @@ std = ["serde/std", "serde_json/std", "ring", "x509-parser", "rustls"]
 err-derive = { version = "0.2", default-features = false }
 hex = { version = "0.4.2" }
 lexical-core = { version = "0.8.2", default-features = false }
-ring = { git = "https://github.com/veracruz-project/ring.git", version = "=0.16.11", branch = "veracruz", optional = true }
+ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz", optional = true }
 rustls = { git = "https://github.com/veracruz-project/rustls.git", branch = "veracruz", optional = true }
 serde = { git = "https://github.com/veracruz-project/serde.git", features = ["derive"], branch = "veracruz" }
 serde_json = { git = "https://github.com/veracruz-project/json.git", branch = "veracruz", default-features = false }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -52,7 +52,7 @@ nitro = [
   "io-utils/nitro",
   "libc",
   "policy-utils/std",
-  "nsm_io",
+  "nsm_api",
   "nsm_lib",
   "nix",
   "ring/nitro",
@@ -80,7 +80,7 @@ libc = { git = "https://github.com/veracruz-project/libc.git", branch = "veracru
 libm = { version = "0.2", optional = true }
 log = { version = "=0.4.13", optional = true }
 nix = { version = "0.15", optional = true }
-nsm_io = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
 policy-utils = { path = "../policy-utils" }
 protobuf = { git = "https://github.com/veracruz-project/rust-protobuf.git", branch = "veracruz" }

--- a/runtime-manager/src/managers/error.rs
+++ b/runtime-manager/src/managers/error.rs
@@ -73,7 +73,7 @@ pub enum RuntimeManagerError {
     NsmLibError(i32),
     #[cfg(feature = "nitro")]
     #[error(display = "RuntimeManager: NSM Error code: {:?}", _0)]
-    NsmErrorCode(nsm_io::ErrorCode),
+    NsmErrorCode(nsm_api::api::ErrorCode),
     #[cfg(feature = "nitro")]
     #[error(display = "RuntimeManager: wrong message type received: {:?}", _0)]
     WrongMessageTypeError(NitroRootEnclaveMessage),

--- a/runtime-manager/src/runtime_manager_nitro.rs
+++ b/runtime-manager/src/runtime_manager_nitro.rs
@@ -16,7 +16,7 @@ use io_utils::{
 use nix::sys::socket::listen as listen_vsock;
 use nix::sys::socket::{accept, bind, SockAddr};
 use nix::sys::socket::{socket, AddressFamily, SockFlag, SockType};
-use nsm_io;
+use nsm_api;
 use nsm_lib;
 use std::os::unix::io::AsRawFd;
 use veracruz_utils::platform::{
@@ -176,7 +176,7 @@ fn attestation(
             )
         };
         match status {
-            nsm_io::ErrorCode::Success => (),
+            nsm_api::api::ErrorCode::Success => (),
             _ => return Err(RuntimeManagerError::NsmErrorCode(status)),
         }
         unsafe {

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -13,7 +13,7 @@ std = ["serde/std", "ring/std", "rustls", "serde_json/std"]
 
 [dependencies]
 err-derive = "0.2"
-ring = { git = "https://github.com/veracruz-project/ring.git", version = "=0.16.11", branch = "veracruz", default-features = false }
+ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz", default-features = false }
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 rustls = { git = "https://github.com/veracruz-project/rustls.git", branch = "veracruz", optional = true }
 serde = { git = "https://github.com/veracruz-project/serde.git", default-features = false, branch = "veracruz", optional = true }


### PR DESCRIPTION
They have reorganised the subcrates into modules.

Redirect to egrimley-arm to test while ring is not yet updated.
