### PR TITLE
WIP: Added a new feature for veracruz-utils to specify it should be built …

### DIFF
--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -58,6 +58,7 @@ nitro = [
   "ring/nitro",
   "ring/std",
   "session-manager/nitro",
+  "veracruz-utils/nitro_enclave",
   "veracruz-utils/nitro",
 ]
 

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -56,9 +56,9 @@ nix = { version = "0.15", optional = true }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }
-ring = "0.16.11"
-rouille = "3.2.1"
-rustls = "0.16"
+ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz" }
+rouille = "=3.2.1"
+rustls = { git = "https://github.com/veracruz-project/rustls.git", branch = "veracruz" }
 serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -17,6 +17,11 @@ nitro = [
   "serde/derive",
   "serde_json/std",
 ]
+
+nitro_enclave = [
+  "ring/nitro"
+]
+
 std = [
   "serde/std",
   "serde_json/std",
@@ -25,7 +30,7 @@ std = [
 [dependencies]
 bincode = { version = "1.2.1", default-features = false, optional = true }
 err-derive = "0.2"
-ring = "0.16.11"
+ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz", default-features = false }
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 rustls = { version = "0.16", optional = true }
 serde = { version = "1.0.115", default-features = false, optional = true }


### PR DESCRIPTION
…for inside a nitro enclave

This is a fix for #349.

The issue was that for nitro platforms, even when outside of the enclave, the `ring` crate was being built to use the AWS nitro `nsm_lib` crate for random number generation. This is only supported inside an enclave.

Added an additional feature to `veracruz-utils`, `nitro_enclave` to clarify that it is being built for execution inside the enclave.

This is certainly one of those bugs that makes you think "How did this ever work". I suppose, but have not investigated, that it has something to do with how `cargo` resolved dependencies.