### PR TITLE
Change bindgen version from 0.59.2 to 0.57.

### DIFF
--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -23,6 +23,6 @@ libc = "0.2.69"
 psa-crypto-sys = { path = "../third-party/rust-psa-crypto/psa-crypto-sys" }
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.57"
 cfg-if = "1.0"
 cmake = "0.1"


### PR DESCRIPTION
The toolchain version currently used for the IceCap build does not
accept the code generated by bindgen 0.59.2.