### PR TITLE
Replace occurrences of LICENSE.markdown

### DIFF
--- a/icecap/src/rust/icecap-wrapper/src/lib.rs
+++ b/icecap/src/rust/icecap-wrapper/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 pub use icecap_core;

--- a/io-utils/src/fd.rs
+++ b/io-utils/src/fd.rs
@@ -6,7 +6,7 @@
 //!
 //! # Copyright and licensing
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for copyright
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for copyright
 //! and licensing information.
 
 use byteorder::{ByteOrder, LittleEndian};

--- a/io-utils/src/http.rs
+++ b/io-utils/src/http.rs
@@ -9,7 +9,7 @@
 //!
 //! # Copyright and licensing
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for copyright
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for copyright
 //! and licensing information.
 
 use curl::{

--- a/io-utils/src/tcp.rs
+++ b/io-utils/src/tcp.rs
@@ -6,7 +6,7 @@
 //!
 //! # Copyright and licensing
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for copyright
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for copyright
 //! and licensing information.
 
 use super::{

--- a/platform-services/src/icecap_platform_services.rs
+++ b/platform-services/src/icecap_platform_services.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use crate::Result;

--- a/policy-utils/src/parsers.rs
+++ b/policy-utils/src/parsers.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 #[cfg(feature = "std")]

--- a/proxy-attestation-server/src/cli.rs
+++ b/proxy-attestation-server/src/cli.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use actix_rt;

--- a/runtime-manager/src/runtime_manager_icecap.rs
+++ b/runtime-manager/src/runtime_manager_icecap.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 extern crate alloc;

--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use crate::managers::{

--- a/sdk/data-generators/shamir-secret-sharing/Makefile
+++ b/sdk/data-generators/shamir-secret-sharing/Makefile
@@ -6,7 +6,7 @@
 #
 # COPYRIGHT
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for licensing
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
 
 TARGET_DATS = share-1.dat share-2.dat share-3.dat

--- a/sdk/data-generators/shamir-secret-sharing/src/main.rs
+++ b/sdk/data-generators/shamir-secret-sharing/src/main.rs
@@ -6,7 +6,7 @@
 //!
 //! # Copyright
 //!
-//! See the file `LICENSE.markdown` in the Veracruz root directory for licensing
+//! See the file `LICENSE_MIT.markdown` in the Veracruz root directory for licensing
 //! and copyright information.
 
 use rand::Rng;

--- a/veracruz-client/src/cli.rs
+++ b/veracruz-client/src/cli.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use policy_utils::{error::PolicyError, parsers, policy::Policy};

--- a/veracruz-mcu-client/base64.c
+++ b/veracruz-mcu-client/base64.c
@@ -7,7 +7,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/base64.h
+++ b/veracruz-mcu-client/base64.h
@@ -7,7 +7,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/find_memory_breakdown.py
+++ b/veracruz-mcu-client/find_memory_breakdown.py
@@ -8,7 +8,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/http.c
+++ b/veracruz-mcu-client/http.c
@@ -8,7 +8,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/http.h
+++ b/veracruz-mcu-client/http.h
@@ -8,7 +8,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/policy_to_header.py
+++ b/veracruz-mcu-client/policy_to_header.py
@@ -10,7 +10,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/samples/audio-event-triangulation/claps_to_header.py
+++ b/veracruz-mcu-client/samples/audio-event-triangulation/claps_to_header.py
@@ -8,7 +8,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/samples/audio-event-triangulation/main.c
+++ b/veracruz-mcu-client/samples/audio-event-triangulation/main.c
@@ -17,7 +17,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/samples/shamir-secret-sharing/binary_to_header.py
+++ b/veracruz-mcu-client/samples/shamir-secret-sharing/binary_to_header.py
@@ -8,7 +8,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/samples/shamir-secret-sharing/main.c
+++ b/veracruz-mcu-client/samples/shamir-secret-sharing/main.c
@@ -14,7 +14,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/slip-setup.sh
+++ b/veracruz-mcu-client/slip-setup.sh
@@ -10,7 +10,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/tap-setup.sh
+++ b/veracruz-mcu-client/tap-setup.sh
@@ -10,7 +10,7 @@
 #
 # ## Licensing and copyright notice
 #
-# See the `LICENSE.markdown` file in the Veracruz root directory for
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 # information on licensing and copyright.
 #
 

--- a/veracruz-mcu-client/vc.c
+++ b/veracruz-mcu-client/vc.c
@@ -7,7 +7,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/vc.h
+++ b/veracruz-mcu-client/vc.h
@@ -13,7 +13,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/xxd.c
+++ b/veracruz-mcu-client/xxd.c
@@ -7,7 +7,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-mcu-client/xxd.h
+++ b/veracruz-mcu-client/xxd.h
@@ -7,7 +7,7 @@
  *
  * ## Licensing and copyright notice
  *
- * See the `LICENSE.markdown` file in the Veracruz root directory for
+ * See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
  * information on licensing and copyright.
  *
  */

--- a/veracruz-server/src/cli.rs
+++ b/veracruz-server/src/cli.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use actix_rt;

--- a/veracruz-server/src/veracruz_server_icecap.rs
+++ b/veracruz-server/src/veracruz_server_icecap.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use crate::veracruz_server::{VeracruzServer, VeracruzServerError};

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 #[cfg(feature = "linux")]

--- a/veracruz-utils/src/platform/error.rs
+++ b/veracruz-utils/src/platform/error.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use err_derive::Error;

--- a/veracruz-utils/src/platform/icecap/message.rs
+++ b/veracruz-utils/src/platform/icecap/message.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use serde::{Deserialize, Serialize};

--- a/veracruz-utils/src/platform/icecap/mod.rs
+++ b/veracruz-utils/src/platform/icecap/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 pub mod message;

--- a/veracruz-utils/src/platform/vm.rs
+++ b/veracruz-utils/src/platform/vm.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Licensing and copyright notice
 //!
-//! See the `LICENSE.markdown` file in the Veracruz root directory for
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Replaces all stray occurrences of `LICENSE.markdown` with `LICENSE_MIT.markdown`.

Closes #219.