### PR TITLE
Delayed load of policy in IceCap attestation

### DIFF
--- a/runtime-manager/src/runtime_manager_icecap.rs
+++ b/runtime-manager/src/runtime_manager_icecap.rs
@@ -112,15 +112,14 @@ impl RuntimeManager {
             Request::Attestation {
                 device_id,
                 challenge,
-            } => match session::manager::init_session_manager()
+            } => match session_manager::init_session_manager()
                 .and(self.handle_attestation(device_id, &challenge))
             {
                 Err(_) => Response::Error(Error::Unspecified),
                 Ok((token, csr)) => Response::Attestation { token, csr },
             },
             Request::Initialize {
-                policy,
-                _json,
+                policy_json,
                 root_cert,
                 compute_cert,
             } => match session_manager::load_policy(&policy_json).and(

--- a/veracruz-server/src/veracruz_server_icecap.rs
+++ b/veracruz-server/src/veracruz_server_icecap.rs
@@ -191,17 +191,6 @@ impl VeracruzServer for VeracruzServerIceCap {
             realm_process,
         };
 
-        match server.send(&Request::Initialize {
-            policy_json: policy_json.to_string(),
-        })? {
-            Response::Initialize => (),
-            resp => {
-                return Err(VeracruzServerError::IceCapError(
-                    IceCapError::UnexpectedRuntimeManagerResponse(resp),
-                ))
-            }
-        }
-
         let (device_id, challenge) = send_proxy_attestation_server_start(
             policy.proxy_attestation_server_url(),
             "psa",
@@ -240,11 +229,12 @@ impl VeracruzServer for VeracruzServerIceCap {
             (root_cert.to_vec(), compute_cert.to_vec())
         };
 
-        match server.send(&Request::CertificateChain {
+        match server.send(&Request::Initialize {
+            policy_json: policy_json.to_string(),
             root_cert,
             compute_cert,
         })? {
-            Response::CertificateChain => (),
+            Response::Initialize => (),
             resp => {
                 return Err(VeracruzServerError::IceCapError(
                     IceCapError::UnexpectedRuntimeManagerResponse(resp),

--- a/veracruz-utils/src/platform/icecap/message.rs
+++ b/veracruz-utils/src/platform/icecap/message.rs
@@ -17,14 +17,12 @@ pub type SessionId = u32;
 /// Type of requests from the host to the realm
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Request {
-    Initialize {
-        policy_json: String,
-    },
     Attestation {
         device_id: i32,
         challenge: Vec<u8>,
     },
-    CertificateChain {
+    Initialize {
+        policy_json: String,
         root_cert: Vec<u8>,
         compute_cert: Vec<u8>,
     },
@@ -40,7 +38,6 @@ pub enum Request {
 pub enum Response {
     Initialize,
     Attestation { token: Vec<u8>, csr: Vec<u8> },
-    CertificateChain,
     NewTlsSession(SessionId),
     CloseTlsSession,
     SendTlsData,


### PR DESCRIPTION
Deferred provisioning of JSON policy during IceCap attestation to make the process match attestation on Nitro and Linux.

Closes #363.