### PR TITLE
Add `RUNTIME_ENCLAVE_BINARY_PATH` environment variable

### DIFF
--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -18,6 +18,7 @@ WORKSPACE_DIR = $(abspath ..)
 OUT_DIR ?= $(abspath test-collateral)
 MEASUREMENT_FILE = $(abspath ../linux-runtime/css-linux.bin)
 MEASUREMENT_PARAMETER = --css-file $(MEASUREMENT_FILE)
+ENCLAVE_BINARY_PATH = $(abspath $(WORKSPACE_DIR)/linux-runtime/runtime_manager_enclave)
 
 include $(WORKSPACE_DIR)/common.mk
 include $(WORKSPACE_DIR)/shared.mk
@@ -52,9 +53,9 @@ test-dependencies: test-collateral $(RUNTIME_MANAGER_ENCLAVE)
 CARGO_TEST = $(CC) $(TEST_PARAMETERS) cargo test $(PROFILE_FLAG) --features linux
 
 test-server: test-dependencies
-	$(CARGO_TEST) -p veracruz-server-test --no-run -- --nocapture
-	$(CARGO_TEST) -p veracruz-server-test -- --test-threads=1 --nocapture
-	$(CARGO_TEST) -p veracruz-server-test test_debug -- --ignored --test-threads=1
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) $(CARGO_TEST) -p veracruz-server-test --no-run -- --nocapture
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) $(CARGO_TEST) -p veracruz-server-test -- --test-threads=1 --nocapture
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) $(CARGO_TEST) -p veracruz-server-test test_debug -- --ignored --test-threads=1
 
 test-client: test-dependencies
 	$(CARGO_TEST) -p veracruz-client --lib --features mock -- --test-threads=1


### PR DESCRIPTION
Add `RUNTIME_ENCLAVE_BINARY_PATH` environment variable.
Allows to decouple execution from the build environment