### PR TITLE
WIP: Update rustls, webpki, and ring

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -37,7 +37,7 @@ num-derive = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
-ring = { version = "0.16.11", optional = true }
+ring = { version = "0.16.20", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 typetag = "=0.1.6"
 wasi-types = { path = "../third-party/wasi-types" }

--- a/linux-root-enclave/Cargo.toml
+++ b/linux-root-enclave/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.13"
 net2 = "0.2.37"
 nix = "0.20.0"
 psa-attestation = { path = "../psa-attestation", features = ["linux"] }
-ring = "0.16.11"
+ring = "0.16.20"
 serde = { version = "1.0.115", features = ["derive"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils/", features = ["linux"] }

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -21,8 +21,3 @@ getrandom = { version = "0.1.14", optional = true }
 nix = { version = "0.22", optional = true }
 nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
-
-[profile.release]
-codegen-units = 1
-lto = true
-opt-level = 3

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -19,8 +19,8 @@ std = [
 err-derive = { version = "0.2", default-features = false }
 hex = { version = "0.4.2" }
 lexical-core = { version = "0.8.2", default-features = false }
-ring = "0.16.11"
-rustls = { version = "0.16", optional = true }
+ring = "0.16.20"
+rustls = { version = "0.20.4", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 wasi-types = { path = "../third-party/wasi-types" }

--- a/policy-utils/src/error.rs
+++ b/policy-utils/src/error.rs
@@ -11,7 +11,7 @@
 
 use err_derive::Error;
 #[cfg(feature = "std")]
-use rustls::{CipherSuite, TLSError};
+use rustls;
 use std::{string::String, time::SystemTimeError};
 #[cfg(feature = "std")]
 use x509_parser::error::PEMError;
@@ -43,9 +43,9 @@ pub enum PolicyError {
     X509ParserError(String),
     #[cfg(feature = "std")]
     #[error(display = "PolicyError: TLSError: {:?}.", _0)]
-    TLSError(#[error(source)] TLSError),
+    TLSError(#[error(source)] rustls::Error),
     #[error(display = "PolicyError: TLSError: invalid cyphersuite: {:?}.", _0)]
-    TLSInvalidCyphersuiteError(String),
+    TLSInvalidCiphersuiteError(String),
     #[error(display = "PolicyError: SystemTimeError: {:?}.", _0)]
     SystemTimeError(#[error(source)] SystemTimeError),
     #[error(display = "PolicyError: unauthorized client certificate: {}.", _0)]
@@ -58,7 +58,7 @@ pub enum PolicyError {
     CertificateExpireError(String),
     #[cfg(feature = "std")]
     #[error(display = "PolicyError: TLSError: Unsupported cyphersuite {:?}.", _0)]
-    TLSUnsupportedCyphersuiteError(CipherSuite),
+    TLSUnsupportedCyphersuiteError(rustls::CipherSuite),
     #[error(display = "PolicyError: Certificate format error: {:?}.", _0)]
     CertificateFormatError(String),
     #[error(display = "PolicyError: Duplicated client ID {}.", _0)]

--- a/policy-utils/src/policy.rs
+++ b/policy-utils/src/policy.rs
@@ -281,7 +281,7 @@ impl Policy {
         {
             let policy_ciphersuite = rustls::CipherSuite::lookup_value(self.ciphersuite())
                 .map_err(|_| {
-                    PolicyError::TLSInvalidCyphersuiteError(self.get_ciphersuite().to_string())
+                    PolicyError::TLSInvalidCiphersuiteError(self.get_ciphersuite().to_string())
                 })?;
             if !rustls::ALL_CIPHERSUITES
                 .iter()

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -54,8 +54,8 @@ openssl = "0.10.24"
 percent-encoding = "2.1"
 psa-attestation = { path = "../psa-attestation" }
 rand = "0.7"
-ring = "0.16.11"
-rustls = "0.16"
+ring = "0.16.20"
+rustls = "0.20.4"
 serde_json = "1.0"
 stringreader = "0.1"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -85,8 +85,8 @@ nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", bran
 policy-utils = { path = "../policy-utils" }
 protobuf = "=2.8.1"
 psa-attestation = { path = "../psa-attestation", optional = true }
-ring = "0.16.11"
-rustls = "0.16"
+ring = "0.16.20"
+rustls = "0.20.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = "1.0"
 session-manager = { path = "../session-manager" }

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -13,7 +13,10 @@
 use super::{ProtocolState, ProvisioningResult, RuntimeManagerError};
 use lazy_static::lazy_static;
 use policy_utils::principal::Principal;
-use std::sync::Mutex;
+use std::{
+    panic::panic_any,
+    sync::Mutex
+};
 use std::{collections::HashMap, result::Result, vec::Vec};
 use transport_protocol::transport_protocol::{
     RuntimeManagerRequest as REQUEST, RuntimeManagerRequest_oneof_message_oneof as MESSAGE,
@@ -37,7 +40,7 @@ lazy_static! {
 #[inline]
 fn response_success(result: Option<Vec<u8>>) -> Vec<u8> {
     transport_protocol::serialize_result(transport_protocol::ResponseStatus::SUCCESS as i32, result)
-        .unwrap_or_else(|err| panic!(err))
+        .unwrap_or_else(|err| panic_any(err))
 }
 
 /// Encodes an error code indicating that somebody sent an invalid or malformed

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -15,6 +15,7 @@ use execution_engine::{execute, fs::FileSystem};
 use lazy_static::lazy_static;
 use std::{
     collections::HashMap,
+    panic::panic_any,
     path::PathBuf,
     string::{String, ToString},
     sync::{
@@ -228,7 +229,7 @@ impl ProtocolState {
             transport_protocol::ResponseStatus::SUCCESS as i32,
             Some(error_code.to_le_bytes().to_vec()),
         )
-        .unwrap_or_else(|err| panic!(err))
+        .unwrap_or_else(|err| panic_any(err))
     }
 }
 

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -21,8 +21,10 @@ std = [
 
 [dependencies]
 err-derive = "0.2"
+log = { version = "0.4.13" }
 policy-utils = { path = "../policy-utils" }
-ring = "0.16.11"
-rustls = "0.16"
-webpki = "=0.21.2"
-webpki-roots = "0.19.0"
+ring = "0.16.20"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
+veracruz-utils = { path = "../veracruz-utils" }
+webpki = "0.22.0"

--- a/session-manager/src/error.rs
+++ b/session-manager/src/error.rs
@@ -23,7 +23,7 @@ pub enum SessionManagerError {
     /// A TLS error originating in the `RusTLS` library occurred, with an
     /// accompanying error code.
     #[error(display = "Session manager: a TLS error occurred: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] rustls::Error),
     /// A generic, unspecified TLS error occurred.
     #[error(display = "Session manager: an unspecified or unknown TLS error occurred.")]
     TLSUnspecifiedError,
@@ -32,7 +32,7 @@ pub enum SessionManagerError {
         display = "Session manager: an invalid cyphersuite was requested in the TLS handshake: {:?}.",
         _0
     )]
-    TLSInvalidCyphersuiteError(std::string::String),
+    TLSInvalidCiphersuiteError(std::string::String),
     /// An unsupported ciphersuite was requested.
     #[error(
         display = "Session manager: an unsupported cyphersuite was requested in the TLS handshake: {:?}.",

--- a/session-manager/src/session.rs
+++ b/session-manager/src/session.rs
@@ -12,6 +12,7 @@
 //! information on licensing and copyright.
 
 use crate::error::SessionManagerError;
+use log::error;
 use policy_utils::principal::Identity;
 
 use std::{
@@ -19,7 +20,7 @@ use std::{
     vec::Vec,
 };
 
-use rustls::{Certificate, ServerSession, Session as TLSSession};
+use rustls::{Certificate, ServerConnection};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Sessions.
@@ -34,7 +35,7 @@ pub type Principal = Identity<Certificate>;
 /// their identifying information.
 pub struct Session {
     /// The TLS server session.
-    tls_session: ServerSession,
+    tls_connection: ServerConnection,
     /// The list of principals, their identities, and roles in the Veracruz
     /// computation.
     principals: Vec<Principal>,
@@ -44,10 +45,10 @@ impl Session {
     /// Creates a new session from a server configuration and a list of
     /// principals.
     pub fn new(config: rustls::ServerConfig, principals: &Vec<Principal>) -> Self {
-        let tls_session = ServerSession::new(&std::sync::Arc::new(config));
+        let tls_connection = ServerConnection::new(std::sync::Arc::new(config)).unwrap();
 
         Session {
-            tls_session: tls_session,
+            tls_connection: tls_connection,
             principals: principals.to_vec(),
         }
     }
@@ -55,15 +56,15 @@ impl Session {
     /// Writes the contents of `input` over the session's TLS server session.
     pub fn send_tls_data(&mut self, input: &mut Vec<u8>) -> Result<(), SessionManagerError> {
         let mut slice = input.as_slice();
-        self.tls_session.read_tls(&mut slice)?;
-        self.tls_session.process_new_packets()?;
+        self.tls_connection.read_tls(&mut slice)?;
+        self.tls_connection.process_new_packets()?;
         Ok(())
     }
 
     /// Writes the entirety of the `input` buffer over the TLS connection.
     #[inline]
     pub fn return_data(&mut self, input: &[u8]) -> Result<(), SessionManagerError> {
-        self.tls_session.write_all(input)?;
+        self.tls_connection.writer().write_all(input)?;
         Ok(())
     }
 
@@ -72,9 +73,9 @@ impl Session {
     /// for reading, returns `Ok(Some(buffer))` for some byte buffer, `buffer`.
     /// If reading fails, then an error is returned.
     pub fn read_tls_data(&mut self) -> Result<Option<Vec<u8>>, SessionManagerError> {
-        if self.tls_session.wants_write() {
+        if self.tls_connection.wants_write() {
             let mut output = Vec::new();
-            self.tls_session.write_tls(&mut output)?;
+            self.tls_connection.write_tls(&mut output)?;
             Ok(Some(output))
         } else {
             Ok(None)
@@ -86,12 +87,16 @@ impl Session {
     /// data.
     pub fn read_plaintext_data(&mut self) -> Result<Option<(u32, Vec<u8>)>, SessionManagerError> {
         let mut received_buffer: Vec<u8> = Vec::new();
-        let num_bytes = self.tls_session.read_to_end(&mut received_buffer)?;
+        let num_bytes = self.tls_connection.reader().read(&mut received_buffer)
+            .map_err(|err| {
+                error!("read_plaintext_data read_to_end failed:{:?}", err);
+                err
+            })?;
 
         if num_bytes > 0 {
             let peer_certs = self
-                .tls_session
-                .get_peer_certificates()
+                .tls_connection
+                .peer_certificates()
                 .ok_or(SessionManagerError::PeerCertificateError)?;
 
             if peer_certs.len() != 1 {
@@ -115,13 +120,13 @@ impl Session {
     /// Returns `true` iff the session's TLS server session has data to be read.
     #[inline]
     pub fn read_tls_needed(&self) -> bool {
-        self.tls_session.wants_write()
+        self.tls_connection.wants_write()
     }
 
     /// Returns `true` iff the session's TLS server session has finished
     /// handshaking and therefore authentication has been completed.
     #[inline]
     pub fn is_authenticated(&self) -> bool {
-        !self.tls_session.is_handshaking()
+        !self.tls_connection.is_handshaking()
     }
 }

--- a/session-manager/src/session_context.rs
+++ b/session-manager/src/session_context.rs
@@ -14,7 +14,7 @@
 
 use std::{
     io::Cursor,
-    string::{String, ToString},
+    string::String,
     vec::Vec,
 };
 
@@ -26,8 +26,10 @@ use policy_utils::policy::Policy;
 
 use ring::{rand::SystemRandom, signature::EcdsaKeyPair};
 use rustls::{
-    AllowAnyAuthenticatedClient, Certificate, CipherSuite, PrivateKey, RootCertStore, ServerConfig,
+    Certificate, PrivateKey, RootCertStore, ServerConfig,
 };
+use rustls_pemfile;
+use veracruz_utils;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Constants.
@@ -43,13 +45,13 @@ where
     U: Into<&'a String>,
 {
     let mut cursor = Cursor::new(cert_string.into());
-    rustls::internal::pemfile::certs(&mut cursor)
+    rustls_pemfile::certs(&mut cursor)
         .map_err(|_| SessionManagerError::TLSUnspecifiedError)
         .and_then(|certs| {
             if certs.is_empty() {
                 Err(SessionManagerError::NoCertificateError)
             } else {
-                Ok(certs[0].clone())
+                Ok(rustls::Certificate(certs[0].clone()))
             }
         })
 }
@@ -61,6 +63,9 @@ where
 /// A session context contains various bits of meta-data, such as certificates
 /// and server configuration options, for managing a server session.
 pub struct SessionContext {
+    /// An intermediate ConfigBuilder that will be present after the policy is 
+    /// provided but before the certificate chain is provided
+    server_config_builder: Option<rustls::ConfigBuilder<rustls::ServerConfig, rustls::server::WantsServerCert>>,
     /// The configuration options for the server.
     server_config: Option<ServerConfig>,
     /// The global policy associated with the Veracruz computation, detailing
@@ -92,6 +97,7 @@ impl SessionContext {
         };
 
         Ok(Self {
+            server_config_builder: None,
             server_config: None,
             principals: None,
             policy: None,
@@ -115,38 +121,22 @@ impl SessionContext {
                 identity.file_rights().to_vec(),
             );
 
-            root_cert_store.add(&cert)?;
+            root_cert_store.add(&cert)
+                .map_err(|err| SessionManagerError::WebpkiError(err))?;
 
             principals.push(principal);
         }
         // create the configuration
-        let mut server_config =
-            ServerConfig::new(AllowAnyAuthenticatedClient::new(root_cert_store));
+        let policy_ciphersuite = veracruz_utils::lookup_ciphersuite(&policy.ciphersuite())
+            .ok_or_else(|| SessionManagerError::TLSInvalidCiphersuiteError(policy.ciphersuite().clone()))?;
 
-        // Set the supported ciphersuites in the server to the one specified in
-        // the policy.  This is a dumb way to do this, but I leave it up to the
-        // student to find a better way (the ALL_CIPHERSUITES array is not very
-        // long, anyway).
+        let server_config_builder = rustls::ServerConfig::builder()
+            .with_cipher_suites(&[policy_ciphersuite])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12])?
+            .with_client_cert_verifier(rustls::server::AllowAnyAuthenticatedClient::new(root_cert_store));
 
-        let policy_ciphersuite = CipherSuite::lookup_value(policy.ciphersuite()).map_err(|_| {
-            SessionManagerError::TLSInvalidCyphersuiteError(policy.ciphersuite().to_string())
-        })?;
-        let mut supported_ciphersuite = None;
-
-        for this_supported_cs in rustls::ALL_CIPHERSUITES.iter() {
-            if this_supported_cs.suite == policy_ciphersuite {
-                supported_ciphersuite = Some(this_supported_cs);
-            }
-        }
-
-        let supported_ciphersuite = supported_ciphersuite.ok_or(
-            SessionManagerError::TLSUnsupportedCyphersuiteError(policy_ciphersuite),
-        )?;
-
-        server_config.ciphersuites = vec![supported_ciphersuite];
-        server_config.versions = vec![rustls::ProtocolVersion::TLSv1_2];
-
-        self.server_config = Some(server_config);
+        self.server_config_builder = Some(server_config_builder);
         self.principals = Some(principals);
         self.policy = Some(policy);
 
@@ -159,9 +149,14 @@ impl SessionContext {
             let cert: rustls::Certificate = rustls::Certificate(this_chain_data.clone());
             cert_chain.push(cert);
         }
-        match &mut self.server_config {
-            Some(config) => config.set_single_cert(cert_chain, self.server_private_key.clone())?,
+        let config_builder_option = self.server_config_builder.take(); // After this, server_config_builder will be None
+        match config_builder_option {
+            Some(config_builder) => {
+                let config = config_builder.with_single_cert(cert_chain, self.server_private_key.clone())?;
+                self.server_config = Some(config);
+            }
             None => return Err(SessionManagerError::InvalidStateError),
+            
         }
         return Ok(());
     }

--- a/test-collateral/generate-policy/Cargo.toml
+++ b/test-collateral/generate-policy/Cargo.toml
@@ -13,7 +13,7 @@ data-encoding = "2.3.2"
 env_logger = "0.8.2"
 log = "0.4.13"
 policy-utils = { path = "../../policy-utils", features = ["std"] }
-ring = "0.16.11"
+ring = "0.16.20"
 serde = { version = "1.0.115", features = ["std"] }
 serde_json = { version = "1.0", features = ["std"] }
 veracruz-utils = {path = "../../veracruz-utils", features = ["std"]}

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -31,16 +31,17 @@ mockall = { version = "0.5.0", optional = true }
 policy-utils = { path = "../policy-utils", features = ["std"] }
 rand = "0.7.0"
 reqwest = { version = "0.9", default-features = false }
-ring = "0.16.11"
+ring = "0.16.20"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
-rustls = "0.16"
+rustls = "0.20.4"
 serde_json = "1.0"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", features = ["std"] }
-webpki = "0.21.2"
-webpki-roots = "0.19.0"
+webpki = "0.22.0"
+webpki-roots = "0.22.0"
 x509-parser = "0.12.0"
+rustls-pemfile = "0.3.0"
 
 [dev-dependencies]
 actix-http = "2.2.0"

--- a/veracruz-client/src/error.rs
+++ b/veracruz-client/src/error.rs
@@ -27,7 +27,7 @@ pub enum VeracruzClientError {
     #[error(display = "VeracruzClient: IOError: {:?}.", _0)]
     IOError(#[error(source)] std::io::Error),
     #[error(display = "VeracruzClient: TLSError: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] rustls::Error),
     #[error(
         display = "VeracruzClient: TLSError: unsupported cyphersuite {:?}.",
         _0
@@ -36,7 +36,7 @@ pub enum VeracruzClientError {
     #[error(display = "VeracruzClient: TLSError: unspecified.")]
     TLSUnspecifiedError,
     #[error(display = "VeracruzClient: TLSError: invalid cyphersuite {:?}.", _0)]
-    TLSInvalidCyphersuiteError(std::string::String),
+    TLSInvalidCiphersuiteError(std::string::String),
     #[error(display = "VeracruzClient: RingError: {:?}", _0)]
     RingError(std::string::String),
     #[error(display = "VeracruzClient: SerdeJsonError: {:?}.", _0)]
@@ -47,8 +47,8 @@ pub enum VeracruzClientError {
     X509ParserError(String),
     #[error(display = "VeracruzClient: WebpkiError: {:?}.", _0)]
     WebpkiError(#[error(source)] webpki::Error),
-    #[error(display = "VeracruzClient: WebpkiError: {:?}.", _0)]
-    WebpkiDNSError(#[error(source)] webpki::InvalidDNSNameError),
+    #[error(display = "VeracruzClient: Invalid DNS Error: {:?}", _0)]
+    InvalidDnsNameError(#[error(source)] rustls::client::InvalidDnsNameError),
     #[error(display = "VeracruzClient: TryIntoError: {}.", _0)]
     TryIntoError(#[error(source)] std::num::TryFromIntError),
     #[error(display = "VeracruzClient: ParseIntError: {}.", _0)]

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -40,13 +40,14 @@ lazy_static = "1.4"
 log = "0.4.13"
 policy-utils = { path = "../policy-utils", optional = true }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
-ring = "0.16.11"
-rustls = "0.16"
+ring = "0.16.20"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
 transport-protocol = { path = "../transport-protocol" }
 veracruz-server = { path = "../veracruz-server" }
 veracruz-utils = { path = "../veracruz-utils", optional = true }
-webpki = "=0.21.2"
-webpki-roots = "0.19.0"
+webpki = "=0.22.0"
+webpki-roots = "0.22.0"
 
 [patch.crates-io]
 rustls = { path = "../third-party/rustls" }

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -56,11 +56,11 @@ nix = { version = "0.15", optional = true }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }
-ring = "0.16.11"
-rustls = "0.16"
+ring = "0.16.20"
+rustls = "0.20.4"
 serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", optional = true }
-webpki = "=0.21.2"
+webpki = "0.22.0"

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -27,7 +27,7 @@ pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 #[derive(Debug, Error)]
 pub enum VeracruzServerError {
     #[error(display = "VeracruzServer: TLSError: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] rustls::Error),
     #[error(display = "VeracruzServer: HexError: {:?}.", _0)]
     HexError(#[error(source)] hex::FromHexError),
     #[error(display = "VeracruzServer: Utf8Error: {:?}.", _0)]
@@ -48,10 +48,12 @@ pub enum VeracruzServerError {
     Base64Error(#[error(source)] base64::DecodeError),
     #[error(display = "VeracruzServer: TLSError: unspecified.")]
     TLSUnspecifiedError,
+    #[error(display = "VeracruzServer: Invalid cipher suite: {:?}", _0)]
+    InvalidCiphersuiteError(String),
     #[error(display = "VeracruzServer: webpki: {:?}.", _0)]
     WebpkiError(#[error(source)] webpki::Error),
     #[error(display = "VeracruzServer: webpki: {:?}.", _0)]
-    WebpkiDNSNameError(#[error(source)] webpki::InvalidDNSNameError),
+    WebpkiDNSNameError(#[error(source)] rustls::client::InvalidDnsNameError),
     #[error(display = "VeracruzServer: Failed to obtain lock {:?}.", _0)]
     LockError(String),
     #[error(display = "VeracruzServer: TryIntoError: {}.", _0)]
@@ -90,13 +92,6 @@ pub enum VeracruzServerError {
         _0
     )]
     InvalidRuntimeManagerMessage(veracruz_utils::platform::vm::RuntimeManagerMessage),
-    #[cfg(feature = "nitro")]
-    #[error(
-        display = "VeracruzServer: Received Invalid Nitro Root Enclave Message: {:?}",
-        _0
-    )]
-    #[cfg(feature = "nitro")]
-    InvalidNitroRootEnclaveMessage(veracruz_utils::platform::nitro::nitro::NitroRootEnclaveMessage),
     #[cfg(any(feature = "linux", feature = "nitro"))]
     #[error(display = "VeracruzServer: Received Invalid Protocol Buffer Message")]
     InvalidProtoBufMessage,

--- a/veracruz-test/Cargo.toml
+++ b/veracruz-test/Cargo.toml
@@ -36,8 +36,8 @@ log = "0.4.13"
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", features = ["std"] }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
-ring = "0.16.11"
-rustls = "0.16"
+ring = "0.16.20"
+rustls = "0.20.4"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"
 transport-protocol = { path = "../transport-protocol" }

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -25,13 +25,10 @@ std = [
 [dependencies]
 bincode = { version = "1.2.1", default-features = false, optional = true }
 err-derive = "0.2"
-ring = "0.16.11"
+ring = "0.16.20"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
-rustls = { version = "0.16", optional = true }
+rustls = { version = "0.20.4" }
 serde = { version = "1.0.115", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false }
-webpki = "=0.21.2"
+webpki = "=0.22.0"
 x509-parser = { version = "0.7.0", optional = true }
-
-[patch.crates-io]
-rustls = { path = "../third-party/rustls" }

--- a/veracruz-utils/src/lib.rs
+++ b/veracruz-utils/src/lib.rs
@@ -18,6 +18,8 @@ pub mod platform;
 #[cfg(feature = "nitro")]
 pub use crate::platform::nitro::*;
 
+use rustls;
+
 /// Material related to cerficate signing requests (CSR).
 pub mod csr;
 
@@ -26,3 +28,16 @@ pub mod csr;
 /// ID as long as it doesn't collide with the ID of an extension in our
 /// certificates.
 pub static VERACRUZ_RUNTIME_HASH_EXTENSION_ID: [u8; 4] = [2, 5, 30, 1];
+
+pub fn lookup_ciphersuite(suite_string: &str) -> Option<rustls::SupportedCipherSuite> {
+    let ciphersuite_enum = match rustls::CipherSuite::lookup_value(suite_string) {
+        Ok(suite) => suite,
+        Err(_) => return None,
+    };
+    for this_supported_ciphersuite in rustls::ALL_CIPHER_SUITES {
+        if this_supported_ciphersuite.suite() == ciphersuite_enum {
+            return Some(this_supported_ciphersuite.clone());
+        }
+    }
+    return None;
+}

--- a/workspaces/host/Cargo.lock
+++ b/workspaces/host/Cargo.lock
@@ -134,15 +134,6 @@ checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -1878,9 +1869,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
@@ -1933,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2666,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",

--- a/workspaces/host/Cargo.toml
+++ b/workspaces/host/Cargo.toml
@@ -42,5 +42,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -3230,8 +3230,6 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -3313,13 +3311,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3361,9 +3367,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4329,6 +4335,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "serde_json",
  "structopt",
  "transport-protocol",
@@ -4383,6 +4390,7 @@ dependencies = [
  "proxy-attestation-server",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "transport-protocol",
  "veracruz-server",
  "veracruz-utils",
@@ -4579,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -4587,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -3483,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.12.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
 dependencies = [
  "rustversion",
  "serde",

--- a/workspaces/linux-host/Cargo.toml
+++ b/workspaces/linux-host/Cargo.toml
@@ -28,5 +28,6 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }
+ring = { path = "crates/third-party/ring" }

--- a/workspaces/linux-runtime/Cargo.lock
+++ b/workspaces/linux-runtime/Cargo.lock
@@ -107,15 +107,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -1570,6 +1561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,13 +1896,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.20"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cc",
- "lazy_static",
  "libc 0.2.119",
  "nsm-lib",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -1993,13 +1990,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2061,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2124,11 +2129,13 @@ name = "session-manager"
 version = "0.3.0"
 dependencies = [
  "err-derive 0.2.4",
+ "log",
  "policy-utils",
  "ring",
  "rustls",
+ "rustls-pemfile",
+ "veracruz-utils",
  "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2772,19 +2779,10 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/workspaces/linux-runtime/Cargo.toml
+++ b/workspaces/linux-runtime/Cargo.toml
@@ -30,5 +30,5 @@ opt-level = 3
 
 [patch.crates-io]
 ring = { path = "crates/third-party/ring" }
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -650,6 +650,12 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -3313,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.12.1",
  "log",
  "ring",
  "sct",

--- a/workspaces/nitro-host/Cargo.toml
+++ b/workspaces/nitro-host/Cargo.toml
@@ -32,5 +32,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/nitro-runtime/Cargo.lock
+++ b/workspaces/nitro-runtime/Cargo.lock
@@ -107,18 +107,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "base64"
@@ -1945,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.12.1",
  "log",
  "ring",
  "sct",

--- a/workspaces/nitro-runtime/Cargo.toml
+++ b/workspaces/nitro-runtime/Cargo.toml
@@ -29,5 +29,5 @@ opt-level = 3
 
 [patch.crates-io]
 ring = { path = "crates/third-party/ring" }
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }


### PR DESCRIPTION
Updated rustls, webpki, and ring to the latest released versions.
This should have been fairly simple, since the rustls API didn't change. However, the behavior of the existing functions changed quite a bit, and required quite a lot of work to figure out.

As is, the changes we now require in rustls are very minimal: a convenience function. After this is done, I will investigate removing the need for a fork of rustls entirely.

The changes we now require in webpki are limited to support for unrecognized extensions. This would be a generally useful feature. I am going to see how difficult it would be to upstream this change. After that, we may no longer require a fork of webpki.

The changes for ring involve platform-specific support for random number generation. The platforms that we have added are not of general interest and therefore are unlikely to be upstreamed as-is. We have discussed changing the way it is done to make adding platform-specific support easier. If we were to do that, it could be upstreamed (but it's unclear how likely that would be to succeed).