### PR TITLE
Fix and simplify shutdown mechanism on Nitro and other platforms

### DIFF
--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -188,9 +188,9 @@ impl ProtocolState {
     /// TODO: Do something better (https://github.com/veracruz-project/veracruz/issues/393)
     pub(crate) fn request_and_check_shutdown(
         &mut self,
-        _client_id: u64,
+        client_id: u64,
     ) -> Result<bool, RuntimeManagerError> {
-        Ok(!self.expected_shutdown_sources.is_empty())
+        Ok(self.expected_shutdown_sources.contains(client_id))
     }
 
     /// Execute the program `file_name` on behalf of the client (participant) identified by `client_id`.

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -190,7 +190,7 @@ impl ProtocolState {
         &mut self,
         client_id: u64,
     ) -> Result<bool, RuntimeManagerError> {
-        Ok(self.expected_shutdown_sources.contains(client_id))
+        Ok(self.expected_shutdown_sources.contains(&client_id))
     }
 
     /// Execute the program `file_name` on behalf of the client (participant) identified by `client_id`.

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -184,14 +184,13 @@ impl ProtocolState {
     }
 
     /// Requests shutdown on behalf of a client, as identified by their client
-    /// ID, and then checks if this request was sufficient to reach a threshold
-    /// of requests wherein the platform can finally shutdown.
+    /// ID.
+    /// TODO: Do something better (https://github.com/veracruz-project/veracruz/issues/393)
     pub(crate) fn request_and_check_shutdown(
         &mut self,
-        client_id: u64,
+        _client_id: u64,
     ) -> Result<bool, RuntimeManagerError> {
-        self.expected_shutdown_sources.retain(|v| v != &client_id);
-        Ok(self.expected_shutdown_sources.is_empty())
+        Ok(!self.expected_shutdown_sources.is_empty())
     }
 
     /// Execute the program `file_name` on behalf of the client (participant) identified by `client_id`.

--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -354,13 +354,6 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
                         RuntimeManagerMessage::Status(VMStatus::Fail)
                     })
             }
-            RuntimeManagerMessage::ResetEnclave => {
-                info!("Shutting down enclave.");
-
-                abort = true;
-
-                RuntimeManagerMessage::Status(VMStatus::Success)
-            }
             otherwise => {
                 error!("Received unknown or unimplemented opcode: {:?}.", otherwise);
                 RuntimeManagerMessage::Status(VMStatus::Unimplemented)

--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -229,9 +229,7 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
 
     info!("TCP listener connected on {:?}.", client_addr);
 
-    let mut abort = false;
-
-    while !abort {
+    loop {
         info!("Listening for incoming message...");
 
         let received_buffer: Vec<u8> = receive_buffer(&mut fd).map_err(|err| {
@@ -375,6 +373,4 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
             RuntimeManagerError::IOError(e)
         })?;
     }
-
-    Ok(())
 }

--- a/runtime-manager/src/runtime_manager_nitro.rs
+++ b/runtime-manager/src/runtime_manager_nitro.rs
@@ -117,11 +117,6 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
                 };
                 return_message
             }
-            RuntimeManagerMessage::ResetEnclave => {
-                println!("runtime_manager_nitro::main ResetEnclave");
-                abort = true;
-                RuntimeManagerMessage::Status(VMStatus::Success)
-            }
             _ => {
                 println!("runtime_manager_nitro::main Unknown Opcode");
                 RuntimeManagerMessage::Status(VMStatus::Unimplemented)

--- a/runtime-manager/src/runtime_manager_nitro.rs
+++ b/runtime-manager/src/runtime_manager_nitro.rs
@@ -58,9 +58,7 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
     let fd = accept(socket_fd).map_err(|err| RuntimeManagerError::SocketError(err))?;
     println!("runtime_manager_nitro::nitro_main accept succeeded. looping");
 
-    let mut abort = false;
-
-    while !abort {
+    loop {
         let received_buffer =
             receive_buffer(fd).map_err(|err| RuntimeManagerError::VeracruzSocketError(err))?;
         let received_message: RuntimeManagerMessage = bincode::deserialize(&received_buffer)
@@ -130,9 +128,7 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
         );
         send_buffer(fd, &return_buffer)
             .map_err(|err| RuntimeManagerError::VeracruzSocketError(err))?;
-    };
-
-    Ok(())
+    }
 }
 
 fn attestation(

--- a/runtime-manager/src/runtime_manager_nitro.rs
+++ b/runtime-manager/src/runtime_manager_nitro.rs
@@ -57,7 +57,10 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
 
     let fd = accept(socket_fd).map_err(|err| RuntimeManagerError::SocketError(err))?;
     println!("runtime_manager_nitro::nitro_main accept succeeded. looping");
-    loop {
+
+    let mut abort = false;
+
+    while !abort {
         let received_buffer =
             receive_buffer(fd).map_err(|err| RuntimeManagerError::VeracruzSocketError(err))?;
         let received_message: RuntimeManagerMessage = bincode::deserialize(&received_buffer)
@@ -115,8 +118,8 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
                 return_message
             }
             RuntimeManagerMessage::ResetEnclave => {
-                // Do nothing here for now
                 println!("runtime_manager_nitro::main ResetEnclave");
+                abort = true;
                 RuntimeManagerMessage::Status(VMStatus::Success)
             }
             _ => {
@@ -132,7 +135,9 @@ pub fn nitro_main() -> Result<(), RuntimeManagerError> {
         );
         send_buffer(fd, &return_buffer)
             .map_err(|err| RuntimeManagerError::VeracruzSocketError(err))?;
-    }
+    };
+
+    Ok(())
 }
 
 fn attestation(

--- a/veracruz-server/src/server.rs
+++ b/veracruz-server/src/server.rs
@@ -94,7 +94,7 @@ async fn runtime_manager_request(
     // Shutdown the enclave
     if !active_flag {
         let mut enclave_handler_locked = enclave_handler.lock()?;
-        enclave_handler_locked.as_mut().map(|e| e.close());
+        enclave_handler_locked.as_mut().map(|e| e.shutdown_isolate());
         *enclave_handler_locked = None;
         stopper.send(())?;
     }

--- a/veracruz-server/src/server.rs
+++ b/veracruz-server/src/server.rs
@@ -94,8 +94,10 @@ async fn runtime_manager_request(
     // Shutdown the enclave
     if !active_flag {
         let mut enclave_handler_locked = enclave_handler.lock()?;
-        enclave_handler_locked.as_mut().map(|e| e.shutdown_isolate());
+
+        // Drop the `VeracruzServer` object which triggers enclave shutdown
         *enclave_handler_locked = None;
+
         stopper.send(())?;
     }
 

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -19,6 +19,7 @@ use err_derive::Error;
 #[cfg(feature = "nitro")]
 use io_utils::nitro::NitroError;
 use io_utils::{error::SocketError, http::HttpError};
+use std::error::Error;
 
 pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 
@@ -230,5 +231,5 @@ pub trait VeracruzServer {
         input: Vec<u8>,
     ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError>;
 
-    fn close(&mut self) -> Result<bool, VeracruzServerError>;
+    fn shutdown_isolate(&mut self) -> Result<(), Box<dyn Error>>;
 }

--- a/veracruz-server/src/veracruz_server_icecap.rs
+++ b/veracruz-server/src/veracruz_server_icecap.rs
@@ -310,19 +310,19 @@ impl VeracruzServer for VeracruzServerIceCap {
         ))
     }
 
-    fn close(&mut self) -> Result<bool> {
+    fn shutdown_isolate(&mut self) -> Result<(), Box<dyn Error>> {
         self.realm_process
             .kill()
             .map_err(IceCapError::hoist(IceCapError::ShadowVMMStopError))?;
         self.configuration.destroy_realm()?;
-        Ok(true)
+        Ok(())
     }
 }
 
 impl Drop for VeracruzServerIceCap {
     fn drop(&mut self) {
-        if let Err(err) = self.close() {
-            panic!("Veracruz server failed to close: {}", err)
+        if let Err(err) = self.shutdown_isolate() {
+            panic!("Realm failed to shutdown: {}", err)
         }
     }
 }

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -23,6 +23,7 @@ pub mod veracruz_server_linux {
     use ring::digest::{digest, SHA256};
     use std::{
         env,
+        error::Error,
         fs::{self, File},
         io::Read,
         net::{Shutdown, TcpStream},
@@ -73,22 +74,6 @@ pub mod veracruz_server_linux {
     }
 
     impl VeracruzServerLinux {
-        /// Tears down the Runtime Manager enclave, then closes TCP connections.  Tries
-        /// to be as liberal in ignoring erroneous conditions as possible in order to kill as
-        /// many things as we can.
-        fn teardown(&mut self) -> Result<bool, VeracruzServerError> {
-            info!("Tearing down Linux runtime manager enclave.");
-
-            info!("Killing TCP connections and Runtime Manager process.");
-
-            let _result = self.runtime_manager_socket.shutdown(Shutdown::Both);
-            let _result = self.runtime_manager_process.kill();
-
-            info!("TCP connection and process killed.");
-
-            response
-        }
-
         /// Returns `Ok(true)` iff further TLS data can be read from the socket
         /// connecting the Veracruz server and the Linux root enclave.
         /// Returns `Ok(false)` iff no further TLS data can be read.
@@ -204,10 +189,10 @@ pub mod veracruz_server_linux {
     /// a `VeracruzServerLinux` struct is about to go out of scope.
     impl Drop for VeracruzServerLinux {
         fn drop(&mut self) {
-            info!("Dropping VeracruzServerLinux object, shutting down enclaves...");
-            if let Err(error) = self.teardown() {
+            info!("Dropping VeracruzServerLinux object, shutting down enclave...");
+            if let Err(error) = self.shutdown_isolate() {
                 error!(
-                    "Failed to forcibly kill Runtime Manager and Linux Root enclave process.  Error produced: {:?}.",
+                    "Failed to forcibly shutdown Runtime Manager enclave.  Error produced: {:?}.",
                     error
                 );
             }
@@ -596,12 +581,20 @@ pub mod veracruz_server_linux {
             }
         }
 
-        /// Kills the Linux Root enclave, all spawned Runtime Manager enclaves, and all open
-        /// TCP connections and processes that we have a handle to.
+        /// Kills the Runtime Manager enclave, then closes TCP connection.
         #[inline]
-        fn close(&mut self) -> Result<bool, VeracruzServerError> {
-            info!("Closing...");
-            self.teardown()
+        fn shutdown_isolate(&mut self) -> Result<(), Box<dyn Error>> {
+            info!("Shutting down Linux runtime manager enclave.");
+
+            info!("Closing TCP connection...");
+            self.runtime_manager_socket.shutdown(Shutdown::Both)?;
+
+            info!("Killing and Runtime Manager process...");
+            //self.runtime_manager_process.kill().map_err(|err| VeracruzServerError::EnclaveShutdownError(err))?;
+            self.runtime_manager_process.kill()?;
+
+            info!("TCP connection and process killed.");
+            Ok(())
         }
     }
 }

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -590,7 +590,6 @@ pub mod veracruz_server_linux {
             self.runtime_manager_socket.shutdown(Shutdown::Both)?;
 
             info!("Killing and Runtime Manager process...");
-            //self.runtime_manager_process.kill().map_err(|err| VeracruzServerError::EnclaveShutdownError(err))?;
             self.runtime_manager_process.kill()?;
 
             info!("TCP connection and process killed.");

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -79,45 +79,6 @@ pub mod veracruz_server_linux {
         fn teardown(&mut self) -> Result<bool, VeracruzServerError> {
             info!("Tearing down Linux runtime manager enclave.");
 
-            info!("Sending shutdown message.");
-
-            send_message(
-                &mut self.runtime_manager_socket,
-                &RuntimeManagerMessage::ResetEnclave,
-            )
-            .map_err(VeracruzServerError::SocketError)?;
-
-            info!("Shutdown message successfully sent, awaiting response...");
-
-            let response: RuntimeManagerMessage = receive_message(&mut self.runtime_manager_socket)
-                .map_err(VeracruzServerError::SocketError)?;
-
-            info!("Response received.");
-
-            let response = match response {
-                RuntimeManagerMessage::Status(VMStatus::Success) => {
-                    info!("Enclave successfully shutdown.");
-
-                    Ok(true)
-                }
-                RuntimeManagerMessage::Status(otherwise) => {
-                    info!(
-                        "Enclave failed to shutdown (status {:?} received.",
-                        otherwise
-                    );
-
-                    Ok(false)
-                }
-                otherwise => {
-                    error!(
-                        "Unexpected response received from runtime enclave: {:?}.",
-                        otherwise
-                    );
-
-                    Err(VeracruzServerError::InvalidRuntimeManagerMessage(otherwise))
-                }
-            };
-
             info!("Killing TCP connections and Runtime Manager process.");
 
             let _result = self.runtime_manager_socket.shutdown(Shutdown::Both);

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -219,11 +219,8 @@ pub mod veracruz_server_nitro {
         }
 
         fn close(&mut self) -> Result<bool, VeracruzServerError> {
-            let re_message: RuntimeManagerMessage = RuntimeManagerMessage::ResetEnclave;
-            let re_buffer: Vec<u8> = bincode::serialize(&re_message)?;
-
-            self.enclave.send_buffer(&re_buffer)?;
-
+            // Don't do anything. The enclave gets shutdown when the
+            // `NitroEnclave` object is dropped
             return Ok(true);
         }
     }

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -17,7 +17,7 @@ pub mod veracruz_server_nitro {
         nitro::NitroEnclave,
     };
     use policy_utils::policy::Policy;
-    use std::env;
+    use std::{env, error::Error};
     use veracruz_utils::platform::vm::{RuntimeManagerMessage, VMStatus};
 
     /// Delay to apply between launching the server and trying to contact the runtime manager
@@ -218,17 +218,20 @@ pub mod veracruz_server_nitro {
             ))
         }
 
-        fn close(&mut self) -> Result<bool, VeracruzServerError> {
+        fn shutdown_isolate(&mut self) -> Result<(), Box<dyn Error>> {
             // Don't do anything. The enclave gets shutdown when the
-            // `NitroEnclave` object is dropped
-            return Ok(true);
+            // `NitroEnclave` object inside `VeracruzServerNitro` is dropped
+            Ok(())
         }
     }
 
     impl Drop for VeracruzServerNitro {
         fn drop(&mut self) {
-            match self.close() {
-                Err(err) => println!("VeracruzServerNitro::drop failed in call to self.close:{:?}, we will persevere, though.", err),
+            match self.shutdown_isolate() {
+                Err(err) => println!(
+                    "VeracruzServerNitro::drop failed in call to self.shutdown_isolate:{:?}",
+                    err
+                ),
                 _ => (),
             }
         }

--- a/veracruz-test/src/main.rs
+++ b/veracruz-test/src/main.rs
@@ -417,8 +417,6 @@ mod tests {
             let program_data = read_binary_file(prog_path.as_path())?;
             info!("### program provider send binary.");
             client.send_program("/program/linear-regression.wasm", &program_data)?;
-            info!("### program provider request shutdown.");
-            client.request_shutdown()?;
             Ok::<(), VeracruzTestError>(())
         };
         let data_provider_handle = async {
@@ -546,13 +544,11 @@ mod tests {
                 info!("            Result of len: {:?}", result.len());
             }
 
-            for client_index in 0..client_configs.len() {
-                clients
-                    .get_mut(client_index)
-                    .ok_or(VeracruzTestError::ClientIndexError(client_index))?
-                    .request_shutdown()?;
-                info!("            Client {} disconnects", client_index);
-            }
+            clients
+                .get_mut(0)
+                .ok_or(VeracruzTestError::ClientIndexError(0))?
+                .request_shutdown()?;
+            info!("            Client 0 successfully issued shutdown command");
             Ok::<(), VeracruzTestError>(())
         };
         info!("            Server and clients threads execute.");

--- a/veracruz-utils/src/platform/vm.rs
+++ b/veracruz-utils/src/platform/vm.rs
@@ -99,6 +99,4 @@ pub enum RuntimeManagerMessage {
     /// - The TLS data, which may be empty.
     /// - A flag indicating if the TLS session is still alive.
     TLSData(Vec<u8>, bool),
-    /// A request to reset the enclave.
-    ResetEnclave,
 }


### PR DESCRIPTION
Fix for https://github.com/veracruz-project/veracruz/issues/389 and quick temporary fix for https://github.com/veracruz-project/veracruz/issues/393.

Allow any party to request an immediate shutdown of the enclave instead of waiting for all parties to reach a unanimous consensus. This is a temporary fix for https://github.com/veracruz-project/veracruz/issues/393: more cunning proposals are being devised.
Also includes a fix for Nitro's Runtime Manager which wouldn't break from the main loop upon receiving the `ResetEnclave` message.

TODO:
* ~Remove `ResetEnclave` message: the CI fails on Linux because the server tries to terminate the enclave a second time. Relates to https://github.com/veracruz-project/veracruz/issues/390~
* ~Adjust tests~