### PR TITLE
Parameter for calling multiple programs in FEE.

### DIFF
--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -68,7 +68,7 @@ struct CommandLineOptions {
     input_sources: Vec<String>,
     /// The list of file names passed as ouput.
     output_sources: Vec<String>,
-    /// The pathes passed as the WASM programs to be executed (in order).
+    /// The paths passed as the WASM programs to be executed (in order).
     program_sources: Vec<String>,
     /// The execution strategy to use when performing the computation.
     execution_strategy: ExecutionStrategy,
@@ -123,7 +123,7 @@ fn parse_command_line() -> Result<CommandLineOptions, Box<dyn Error>> {
                 .short("p")
                 .long("program")
                 .value_name("FILE")
-                .help("Pathes to the WASM binary to be executed. It executes in order.")
+                .help("Paths to the WASM binary to be executed. It executes in order.")
                 .multiple(true)
                 .required(true),
         )
@@ -309,10 +309,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut cmdline = parse_command_line()?;
     info!("Command line read successfully.");
 
-    // Convert the program pathes to absolute if needed.
+    // Convert the program paths to absolute if needed.
     cmdline.program_sources.iter_mut().for_each(|e| {
         if !e.starts_with("/") {
-            e.insert(0,'/');
+            e.insert(0, '/');
         }
     });
 
@@ -344,9 +344,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Insert the file right for all programs
     for prog_path in &cmdline.program_sources {
-        let program_id = Principal::Program(
-            prog_path.to_string(),
-        );
+        let program_id = Principal::Program(prog_path.to_string());
         right_table.insert(program_id.clone(), file_table.clone());
     }
     info!("The final right tables: {:?}", right_table);
@@ -356,7 +354,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     load_input_sources(&cmdline.input_sources, &mut vfs)?;
     info!("Data sources loaded.");
 
-    info!("Invoking programs on in order {:?}.", cmdline.program_sources);
+    info!("Invoking programs in order {:?}.", cmdline.program_sources);
 
     for prog_path in &cmdline.program_sources {
         let main_time = Instant::now();
@@ -375,7 +373,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             options,
         )?;
         info!("return code of {}: {:?}", prog_path, return_code);
-        info!("time on {}: {} micro seconds", prog_path, main_time.elapsed().as_micros());
+        info!(
+            "time on {}: {} micro seconds",
+            prog_path,
+            main_time.elapsed().as_micros()
+        );
 
         // Dump contents of stdout
         if cmdline.dump_stdout {

--- a/sdk/rust-examples/random-u32-list/Cargo.toml
+++ b/sdk/rust-examples/random-u32-list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+name = "random-u32-list"
 authors = ["The Veracruz Development Team"]
-description = "Reading a file contains and unsorted numbers, sort them and write the output into a text file"
-name = "sort-numbers"
+description = "Samples 32 random u32 numbers and output as a comma-seperated string."
 version = "0.3.0"
 edition = "2018"
 
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.14"
+rand = "0.8.0"
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust-examples/random-u32-list/Makefile
+++ b/sdk/rust-examples/random-u32-list/Makefile
@@ -1,0 +1,33 @@
+# Example Makefile
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT AND LICENSING
+#
+# See the `LICENSING.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
+VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)
+
+.PHONY: all doc clean quick-clean fmt fmt-check
+
+all:
+	cargo build --target wasm32-wasi --release
+
+doc:
+	cargo doc
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt -- --check
+
+clean:
+	cargo clean
+	rm -f Cargo.lock
+
+quick-clean:
+	cargo clean

--- a/sdk/rust-examples/random-u32-list/src/main.rs
+++ b/sdk/rust-examples/random-u32-list/src/main.rs
@@ -1,0 +1,26 @@
+//! Test of the trusted random source platform service.
+//!
+//! ## Context
+//!
+//! Test program for generate comma-separated random u32 numbers.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing
+//! and copyright information.
+
+use anyhow;
+use rand::Rng;
+use std::fs;
+
+fn main() -> anyhow::Result<()> {
+    let output = "/input/unsorted_numbers.txt";
+    let bytes = rand::thread_rng().gen::<[u32; 32]>().iter().map(|n| n.to_string()).collect::<Vec<String>>().join(",");
+    println!("{}", bytes);
+    fs::write(output, bytes)?;
+    Ok(())
+}

--- a/sdk/rust-examples/sort-numbers/Makefile
+++ b/sdk/rust-examples/sort-numbers/Makefile
@@ -1,0 +1,33 @@
+# Example Makefile
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT AND LICENSING
+#
+# See the `LICENSING.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
+VERACRUZ_TARGET_PATH = $(shell cd ../../../ && pwd)
+
+.PHONY: all doc clean quick-clean fmt fmt-check
+
+all:
+	cargo build --target wasm32-wasi --release
+
+doc:
+	cargo doc
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt -- --check
+
+clean:
+	cargo clean
+	rm -f Cargo.lock
+
+quick-clean:
+	cargo clean


### PR DESCRIPTION
Modify the freestanding execution engine, allowing multiple values in the program parameter. All programs will be called in order. E.g.
```
./freestand-execution-engine -i input programs -o output -p program/FIRST.wasm program/SECOND.wasm ...
```
the engine will execute `FIRST.wasm`, then `SECOND.wasm` and so on. The latter can observe any result of the former if they have permission.
 
Minors:
- Add makefile to `sort-numbers` rust example
- Add a new `random-u32-list` example that generates the expected input for the `sort-numbers`. This is for testing calling of multiple programs

Request changes of #396 and #377 