### PR TITLE
fixed typo in fee README.md

### DIFF
--- a/sdk/freestanding-execution-engine/README.md
+++ b/sdk/freestanding-execution-engine/README.md
@@ -15,7 +15,7 @@ IMPORTANT: This exercise assume some familiarity with reading **Rust syntax** an
   ```
 The first command adds WebAssembly (WASM) as the compilation target, so the rust program can be compiled to WASM. The second command complies the code that is inside src, which is usually a file named `main.rs`, into WASM. Once the second command has been run you should expect to see a WASM file inside the directory `read-file/target/wasm32-wasi/debug/read-file.wasm`.
   
-5. Copy `read-file.wasm` into the directory `veracruz/sdk/freestanding-execution-environment`
+5. Copy `read-file.wasm` into the directory `veracruz/sdk/freestanding-execution-engine`
 6. If you read what was inside main.rs in `read-file/src` you will have noticed that the program has an input file called `input.txt` and two outputs; a file called `output` and a directory called `a/b/c/d/e.txt`. We need to create `input.txt` to feed into the program; so create `input.txt` inside the freestanding-execution-engine directory and write in anything to the contents of the file. We also need to create the directory `a/b/c/d` inside the freestanding-execution-engine directory.
 7. Now you are setup to run the main command that executes the WASM program inside the Veracruz engine! Below is the command, it is a long one, but we will break down.
 ```


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
I found this typo error in sdk/freestanding-execution-engine/README.md.
5. Copy `read-file.wasm` into the directory `veracruz/sdk/freestanding-execution-environment`
5. Copy `read-file.wasm` into the directory `veracruz/sdk/freestanding-execution-engine`