### PR TITLE
removed reference to make sdk

### DIFF
--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -16,11 +16,6 @@ this part you need to specify which Trusted Execution Environment (TEE) you are
 using. So for example, if you are running Veracruz on Linux, you would
 run `make -C workspaces linux-install`.
 
-We're also going to need a WebAssembly toolchain to build our example binary.
-This can be built using `make sdk`. Fortunately, you can combine these two
-rules, allowing you to maximize the time you have to get coffee while the code
-is compiling:
-
 ``` bash
 $ make -C workspaces linux-install
 ...


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
This is in reference to issue #395.
After discussion with mentor Shale Xiong, and when I faced this issue myself. We came to the conclusion that the 'make sdk' step is incorrect, and shouldn't be included in the CLI_QUICKSTART.markdown file.
(Since I hadn't done a lot of discussion with all the authors on this topic, I'm really sorry if I've made mistakes with the PR.)
I'm looking forward to learn more on this PR if that is the case.