### PR TITLE
mini_grep rust-example added

### DIFF
--- a/sdk/rust-examples/string-search/Cargo.toml
+++ b/sdk/rust-examples/string-search/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "Searches for the given argument inside the input file"
+name = "string-search"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"

--- a/sdk/rust-examples/string-search/README.markdown
+++ b/sdk/rust-examples/string-search/README.markdown
@@ -1,0 +1,33 @@
+# A Simple mini version of grep, implemented using Veracruz freestanding execution engine (Case Sensitive, Only for ASCII)
+
+
+This simple version of grep lets you input query text as argument, and an input file. Then, it will print all the lines in the input file, where the query text occurs. It'll then output this result into `search_results.txt`
+
+# Steps
+
+1. Go to `sdk/freestanding-execution-engine` directory
+
+2. run `cp -r ../rust-examples/minigrep .`. This will copy the current directory to the Veracruz freestanding execution engine. 
+
+3. Inside `sdk/freestanding-execution-engine`, Create a directory called `input`, and another directory called `output`.
+
+4. Run the following command `cp -r ../../test-collateral/random_search_text input`, this will copy the Veracruz README file to the input directory to be our input to the program.
+
+5. Go to `mingrep` directory and run the following commands
+  ```
+  rustup target add wasm32-wasi
+  cargo build --target wasm32-wasi
+  ```
+The first command adds WebAssembly (WASM) as the compilation target, so the rust program can be compiled to WASM. The second command complies the code into WASM
+
+6. Inside `minigrep` directory, Run `cp target/wasm32-wasi/debug/minigrep.wasm .`. 
+  This will copy the WASM file to the root of the project to be accessed easily.
+
+7. Go back to `freestanding-execution-engine` directory and Run the following command
+```
+RUST_LOG="info" cargo run -- --arg "in" --input-source input --input-source minigrep --program minigrep/minigrep.wasm --output-source output -e -d -c
+```
+The string after `--arg` is the `search query` that you want to search for in the text file. Feel free to change it to whatever you want. Here, `in` is just an example of a common word, which is more likely to occur in different texts.  
+Use `"query text"` double quotes, when using multiple words for searching, to keep the formatting of whitespaces in the search query intact.
+
+8. You should have seen a very long log of information. Go to the `output` directory and you should see the `search_results.txt` file and it will contain all the lines where that word was seen.

--- a/sdk/rust-examples/string-search/README.markdown
+++ b/sdk/rust-examples/string-search/README.markdown
@@ -1,31 +1,31 @@
-# A Simple mini version of grep, implemented using Veracruz freestanding execution engine (Case Sensitive, Only for ASCII)
+# A simple string-search program, implemented using Veracruz freestanding execution engine (case sensitive, only for ASCII)
 
 
-This simple version of grep lets you input query text as argument, and an input file. Then, it will print all the lines in the input file, where the query text occurs. It'll then output this result into `search_results.txt`
+This simple version of search lets you input query text as argument, and an input file. Then, it will print all the lines in the input file, where the query text occurs. It'll then output this result into `search_results.txt`
 
 # Steps
 
 1. Go to `sdk/freestanding-execution-engine` directory
 
-2. run `cp -r ../rust-examples/minigrep .`. This will copy the current directory to the Veracruz freestanding execution engine. 
+2. run `cp -r ../rust-examples/string-search .`. This will copy the current directory to the Veracruz freestanding execution engine. 
 
 3. Inside `sdk/freestanding-execution-engine`, Create a directory called `input`, and another directory called `output`.
 
 4. Run the following command `cp -r ../../test-collateral/random_search_text input`, this will copy the Veracruz README file to the input directory to be our input to the program.
 
-5. Go to `mingrep` directory and run the following commands
+5. Go to `string-search` directory and run the following commands
   ```
   rustup target add wasm32-wasi
   cargo build --target wasm32-wasi
   ```
 The first command adds WebAssembly (WASM) as the compilation target, so the rust program can be compiled to WASM. The second command complies the code into WASM
 
-6. Inside `minigrep` directory, Run `cp target/wasm32-wasi/debug/minigrep.wasm .`. 
+6. Inside `string-search` directory, Run `cp target/wasm32-wasi/debug/string-search.wasm .`. 
   This will copy the WASM file to the root of the project to be accessed easily.
 
 7. Go back to `freestanding-execution-engine` directory and Run the following command
 ```
-RUST_LOG="info" cargo run -- --arg "in" --input-source input --input-source minigrep --program minigrep/minigrep.wasm --output-source output -e -d -c
+RUST_LOG="info" cargo run -- --arg "in" --input-source input --input-source string-search --program string-search/string-search.wasm --output-source output -e -d -c
 ```
 The string after `--arg` is the `search query` that you want to search for in the text file. Feel free to change it to whatever you want. Here, `in` is just an example of a common word, which is more likely to occur in different texts.  
 Use `"query text"` double quotes, when using multiple words for searching, to keep the formatting of whitespaces in the search query intact.

--- a/sdk/rust-examples/string-search/src/main.rs
+++ b/sdk/rust-examples/string-search/src/main.rs
@@ -14,20 +14,29 @@
 //! copyright information.
 
 use anyhow::{self, Ok};
-use std::{env, fs};
+use std::{env, fs, process};
 
 const INPUT_FILENAME: &'static str = "/input/random_search_text.txt";
 const OUTPUT_FILENAME: &'static str = "/output/search_results.txt";
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
-    let query: String = args.get(0).unwrap().to_string(); // Argument: To be searched for
+
+    if args.len() < 1 {
+        println!("Not enough arguments provided");
+        process::exit(1);
+    }
+
+    let query: String = args.get(0)
+        .expect("Couldn't read the argument.")
+        .to_string(); // Argument: To be searched for
 
     let file_vec: Vec<u8> = fs::read(INPUT_FILENAME)?;
 
     let filename: String = String::from_utf8_lossy(&file_vec).to_string(); // Input file: To be searched in
 
-    let res_vec: Vec<&str> = search(query.as_str(), &filename.as_str());
+    // let res_vec: Vec<&str> = search(query.as_str(), &filename.as_str());
+    let res_vec: Vec<&str> = search(&query, &filename);
 
     let mut ret: String = String::new();
 

--- a/sdk/rust-examples/string-search/src/main.rs
+++ b/sdk/rust-examples/string-search/src/main.rs
@@ -23,11 +23,11 @@ fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 1 {
-        println!("Not enough arguments provided");
         process::exit(1);
     }
 
-    let query: String = args.get(0)
+    let query: String = args
+        .get(0)
         .expect("Couldn't read the argument.")
         .to_string(); // Argument: To be searched for
 
@@ -35,7 +35,6 @@ fn main() -> anyhow::Result<()> {
 
     let filename: String = String::from_utf8_lossy(&file_vec).to_string(); // Input file: To be searched in
 
-    // let res_vec: Vec<&str> = search(query.as_str(), &filename.as_str());
     let res_vec: Vec<&str> = search(&query, &filename);
 
     let mut ret: String = String::new();

--- a/sdk/rust-examples/string-search/src/main.rs
+++ b/sdk/rust-examples/string-search/src/main.rs
@@ -1,0 +1,53 @@
+//! Mini Grep
+//!
+//! ## Context
+//!
+//! Searches for the argument inside the input file, and prints the result.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
+//! copyright information.
+
+use anyhow::{self, Ok};
+use std::{env, fs};
+
+const INPUT_FILENAME: &'static str = "/input/random_search_text.txt";
+const OUTPUT_FILENAME: &'static str = "/output/search_results.txt";
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let query: String = args.get(0).unwrap().to_string(); // Argument: To be searched for
+
+    let file_vec: Vec<u8> = fs::read(INPUT_FILENAME)?;
+
+    let filename: String = String::from_utf8_lossy(&file_vec).to_string(); // Input file: To be searched in
+
+    let res_vec: Vec<&str> = search(query.as_str(), &filename.as_str());
+
+    let mut ret: String = String::new();
+
+    for line in res_vec {
+        ret.push_str(line);
+    }
+
+    fs::write(OUTPUT_FILENAME, ret)?;
+
+    Ok(())
+}
+
+fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+    let mut results = Vec::new();
+
+    for line in contents.lines() {
+        if line.contains(query) {
+            results.push(line);
+        }
+    }
+
+    results
+}

--- a/test-collateral/random_search_text.txt
+++ b/test-collateral/random_search_text.txt
@@ -1,0 +1,159 @@
+The members of the kids, but not the homework layer, nor the desire to the layer around the world, but the vengeful great vehicle in laughter.
+No ferry land, a smile to decorate the bunny. Donec pellentesque leo eu nibh gravida iaculis. 
+Everyone needs to sit before the orcs to raise the lion who can decorate it. 
+Each one does not decorate the place. But the pain needs to be taken advantage of before. 
+Curabitur consequat convallis risus, eget pulvinar lorem vestibulum sit amet. 
+But either the ugly teenagers, or the ugly start, the annoyance than But the author takes the ball, and not just from the main time.
+
+We live a great pure life, the quiver is always in need of health, the pregnant football ugly. 
+The fear of the disease is now a nice place to start. 
+None of the players are wise, nor do they hate the easy, it becomes the skirt of the public. 
+Maybe just to improve some. It's a wise eros, one needs wise care, easy to improve the environment. 
+In the backyard of our customers, time is not now, the skirt itself. 
+The disease is now an element of the cat, and the frontiers of the elite and the arches. 
+Integer suscipit nec eget lorem posuere condimentum. In vengeful convenience, from the main. 
+Sed pellentesque enim et mauris mattis condimentum. 
+Life was fun. The pain of the torturer, the fear of the football element of life, it's just the end of the foul. 
+Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos
+
+
+The valley is not a running element. No sadness, the winner from the most exciting element, the urn of laughter was just, not the carton of the bow and the earth. 
+It's the earth that makes the bed, it's not just players to decorate either. Sometimes the hunger and the unbelievable hunger in front of him, especially in the throat. 
+From the fans and the mass of the sad Zen, and not even the cat. There is no earth lake, and some look at poisonous things, said not great. 
+Morbi feugiat hendrerit justo eu ullamcorper. 
+The pain is the torture, the arrows of life are the torturer, the members start planning. 
+The pregnant laughter needs to be aligned, not the protein itself annoying. 
+The want of the wise man to start, this valley hate Even from the bed, the protein needs the makeup of life, the end of the football patches. 
+For the pure, the sadness of life is the love of the kids The disease is just like a cat, but now it's Performance, that's what was said from the Olympics.
+Lack of desire to grab a ball of annoyance to improve. Even alcohol itself, just leaven to the end of life. 
+No planning, laughter is not a warm rod It's not a quiver of pain. 
+The gas layer, not to put down a quick start, the earth is free to pay the bills, the quiver wants itself from the fear of the couch. 
+But the mass of the players is nice to be successful, and the pain of the various players. 
+There is no need of a wise lion. 
+It is fun to be loved. Cras eleifend quis massa non placerat. 
+The disease, but the consequences of the lion, as the Oklahoma propaganda. 
+There's no lion, let's get pregnant, let's worry about life, but it ends up being fun. 
+He wants to ensure the free speech of the people. 
+To take medication for the medication, but only for the curse, and the leaven said no.
+There is no smooth traffic. 
+The film that my flats Phasellus a eros Aenean viverra, nibh in aliquam varius, 
+felis diam vulputate sem, at the casino hatred of the bed needs for. 
+Therefore the pregnant time than the non-collar. Integer and the price of the microphone. 
+It's not before, it's something that has been said, and the valley is easy. 
+Aenean ut nisi ligula. Maecenas sit amet faucibus dolor. Maecenas posuere id risus sed 
+pellentesque. 
+But from the very casino, the arrows are now not, my advantage. No time wants to look at 
+the vehicles.
+The film does not miss, the pregnant life is not the biggest, it's a great thing. 
+There is no mass nor, sad as before, any one, the bananas placed the vehicle. 
+Maecenas cursus libero in dui varius, but venenatis ipsum tempus. 
+It needs free eros. 
+Sometimes the pain is like the pain, and the members feel good. 
+It's venomous, pain and poverty has been said, for some erosion of the lake, 
+let it be a love of the valley, just the pain is a lot of eros. 
+To the couch but not to the bills. Integer congue volutpat diam at vehicula. 
+Some carols from the freestyle, the pure teenagers do not need to be versatile. 
+Maecenas posuere dictum porttitor.
+As an asset, now pregnant with trouble warm, the orcs for the want of desire, for the fear of the fringe, nor now. 
+For the football season of the cat. 
+Aenean sit amet nisi pretium, vehicula sapien ac, placerat erat. 
+Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. 
+It was a pain, of course it was only one, but it becomes a superhero.
+Curabitur gravida, lacus ut laoreet molestie, massa quam suscipit ipsum, in tempus ante tellus sed nisi. 
+Suspendisse at malesuada risus. It's in the vehicle of the public, the carton or the valley, 
+that's just an average person. 
+The film of the disgraceful vehicle, the Vikings from the throat of life, the bananas of the EU. 
+For life rather than freedom. Curabitur lobortis elementum porta. 
+As long as the memories of the propaganda are wise, it is important that some time is a lot of time. 
+Even and the cartoon ends.
+Suspendisse blandit eleifend volutpat. 
+The element of the keyboard The pain is great, but the budget is just teenagers. 
+It's time to feel good about the hardware, the vehicles or the vehicles, the annoying life 
+
+Maecenas turpis sem, vulputate eu tellus sodales, eleifend quiver tellus. 
+It's a course, which is always and sometimes, the lakes of the players ferment foul, 
+the convenience of the ugly and the ugly and the ugly. Proin lakes which, a lot of it is 
+important to need, but want. The pain of life is not complete. Even the environment of the 
+environment, sad from the frontiers of the film, is a great shot. Fusce sodales, nisl quis 
+rhoncus eleifend, sapien augue fringilla metus, dapibus varius massa orci eget ante. 
+Mauris tempus vitae magna sed sodales. But the economic makeup of the lake, and the price 
+of the football, raises it. Proin members of the immune system. 
+The disease of the arrows, the lake in the kids The fans will hate the couch, 
+but want the ugly laughter as much as possible. We live the laughter of the public, 
+the thermal gate of the backyard but, the time course of the bow.
+In fact, it takes the biggest propaganda, at least that's a nice lake to get pregnant. 
+As soft as possible. Live is a lot of memories. 
+But the torture and the pain cushion the door. And so there is no place to start, the 
+carton of the bills is important, but the laughter is targeted. Until the weekend lays 
+down the lake, and receives from the bureau of life. Cras dictum neque leo, eget malesuada 
+nibh dignissim a. It's the biggest quiver of the internet, and the kids are out of the gate. 
+The lake is a weekend of fun. There was also a torturer, arrows at the end of the season, 
+drink not laughter. The lion bears the makeup of the lion. Maybe the fear of the pain is 
+gonna be the pain of the makeup. The film from the sauce is not the arrows of the bow. 
+Vestibulum ultricies augue id pulvinar imperdiet. For members of the diseased lifestyle, 
+it is always necessary to miss the immune system.
+The disease bears the makeup of the gate. Until then, or drink the torturer. 
+Aeneas is pure as, the bureau does not need to be made, there is no consequences. 
+The disease needs a clinical cushion or an environment of chocolate. 
+Maecenas dapibus iaculis molestie. From the main customer's throat. 
+Cras ut massa quis sapien sodales ultricies borders ornare quam. 
+Duis imperdiet vel justo at imperdiet. 
+Live at free eu cat Aeneas's couch torture. 
+Until my kids were there, it was time to start playing football. 
+Maecenas placerat, ex in iaculis pellentesque, dui nulla commodo urna, eget elementum leo sem vitae augue.
+Everyone's just soft mourning. Even now and the game is not vengeful. 
+Integer in fringilla orci. Maybe one takes the cat. 
+But the quiver is not just a cushion to the price of this football. 
+Unfortunately, the biggest and most important thing to start is my football, not the casino. 
+Mauris pharetra sit amet metus sed rutrum. 
+Until the shameful need of time, the torturer and the memories, the compensation free. 
+Maybe you don't have any goals in the scenario.
+Even the want of the lake is not an arrows brush. There is no shame and no place to start. 
+To look at the environment in the region Just don't drink. 
+Curabitur lobortis odio ultricies felis suscipit, eu consectetur ligula egestas. 
+Integer laoreet hendrerit mauris, vel vehicula libero rhoncus pharetra. It's not time to feel good. 
+In this street was said to have dwelled. At the end of the ball is completed and complete.
+Even the consequences of life are ok. The couch, if not the life, was said to be a sinner. 
+Various orcs will be born, and the mountains will grow in their homes and with great gods, a ridiculous mouse will be born. 
+Of course, but it was wise, but the course of the vehicle. Mauris vitae arcu quis sapien pretium eleifend quis nec justo. 
+Phasellus congue leo in mauris volutpat volutpat. 
+Mauris feugiat lobortis libero vel ornare. In order to get some pressure on how to get scared. 
+But in bed or no range is easy. 
+Tomorrow there is no place to start, nor need any quiver Maybe that teenagers are wise, and don't follow that. 
+Each life should not be tortured to the ends of the ferry. In the free torturer, at the price and always, the main orcs.
+Actually in the garage that arc ends to drink bears need a lot. 
+Yes, but the torturer is incredibly The kids who dwell in the sickness of the sad old age, and the nets and the hunger and the ugly want. 
+How to upgrade the housing, any sadness. 
+In fact, from the beginning, it is always like a lot of people, and the moms start to push. 
+We live sometimes in the lake but in the television. Nam sit amet nibh sapien. 
+The disease at the cushion, the Zen before anyone, the pain of the court No consequences, for he needs to lay down some, the fear of the element of eros. 
+The pain itself is love, the main storage system. 
+Curabitur sit amet elementum urna.
+The advantages of the immune system are not to put up with just the consequences of it. 
+It was said that the ends of the Moors, such as the fear of a lot of protein being successful. 
+But the advantages of life are not the most flattering things. 
+But as fear and time vary. 
+Now neither from, lay any pure real estate, layer my memories. 
+You need not take advantage of the makeup. The curse of the lion Now don't miss the goals or the sauce. It is easy to drink. No easy financing pain, in the ferry lion valley is a lot.
+Until the sad tanks, the price of this eu throat. For to drink for free, that's a sadness from the Olympic lakes. Until there is a lot of pain and fear. At the present time the torturer will not stop and do not smile. The quiver flavor Pellentesque sollicitudin mi vel tincidunt mattis. Phasellus euismod tellus ac consequat venenatis. Phasellus in nisi metus. Everyone takes a sad face and not like the bow. Cras varius, enim a ultrices molestie, quam lacus elementum libero, sed blandit dui urna vitae lacus.
+Pellentesque eu tortor in tellus Maximus consequat eget at nisi. 
+Until the bills and the bow should always be available. The team members of the Zen do not have a lucky shot. Fusce ac odio tempor, arrow felis dapibus, hendrerit erat. There is no price for the disgraceful, no pure flattery and so much care. For not sad before. From the polar elite, and the mass bears always, there is no end to the hairstyle. Curabitur condimentum Zen to drink. No and no pain to start, nor do the lakes Or before that we hate to take advantage of the bears and the eu elite. Pellentesque non nisl sit amet massa egestas bibendum ac a dolor. For no vengeful element to push. The pain and the urn But the main thing is in the vehicle and the chocolate. For the pure words of the players, who miss before the homework of life. Even from the vehicle, the economics and the grid need not, any compensation is worth it.
+Phasellus ultricies est eu tortor tincidunt tincidunt. But every time, the bow of any venomous cartoon, is the bow of the great vehicles, which means that the lake should not miss the torture. He was not put to death. The arrows of the urn Aenean commodo ut nisi at scelerisque. Now sometimes, the author of a lot of football, except for the pregnant orcs, who will not want to mourn the laughter of the torturer. We live from the wise, but the throat of the lion Duis vulputate, diam eget pellentesque rhoncus, metus sapien rhoncus turpis, a cushion of a lion vehicle to decorate now. The headline of the couch Diseases of the surroundings. There's always a lot of fun from the casino. To start, just need an annoyance of the arches, the eros of the torturer incredibly No, not now at the earth's cartoon customers.
+There is no quiver itself. Mauris rutrum, lectus in dignissim lacinia, purus dolor suscipit orci, ut fringilla justo quam ac lorem. Maybe in the backyard at least it's easy and soft. Accordingly, a man becomes a smile, but an annoyance himself. No, neither is it worth it, nor the mass of the kids, and the arrows are said to be unconventional. But the bed is the entrance, so that it is always worth it to raise it. But always with a bow or an employee's bureau. That's some unconventional logo, not a gridiron. And it's just a bed.
+Until the pull of the valley eros At least not from the free-range for the life but wise Now and the pain of the free venenatis was the main price. This is what the arrows are but the cat's finch The fear of life is the biggest cushion of life from the propaganda. Curabitur tincidunt fermentum rutrum. In this street was said to have dwelled. It was easy to get some laughter and want. I wish to take some of the players, the lion's life and the superhero, some of my health. Phasellus lobortis risus in auctor blandit. The disease needs laughter In real estate Vestibulum and just the needs of the members of the teenagers. There's always a lot of fun to grab a hairstyle. But now at the banquet. Pellentesque fringilla arcu volutpat mauris porttitor, vitae aliquet mauris porta.
+Integer consequat quis lacus in egestas. Quisque venenatis euismod orci eu ornare. 
+Morbi sem mi, venenatis et metus vel, rutrum maximus mauris. Sed facilisis elementum est, ac congue quam hendrerit ut. Nam sed ipsum libero. Praesent maximus magna id nisi auctor, at laoreet enim tincidunt. Maecenas condimentum molestie dolor auctor imperdiet. Cras rhoncus luctus faucibus. Proin ornare massa consectetur, porttitor massa sed, porttitor arcu. Praesent vel erat nec lectus auctor elementum id eget sapien. Pellentesque sodales finibus urna, a malesuada purus dictum condimentum. Suspendisse ornare dictum enim. Mauris eu eleifend augue, eu suscipit risus. Suspendisse tempor nibh ex, a feugiat mauris suscipit vulputate.
+In the life of the vehicle at the place to start the consequences, no problems now. 
+Sometimes the hunger and the unbelievable hunger in front of him, especially in the throat. It is easy to put down any carton of eros. There is no vengeful, laughter that always drink, nor do the soft erosion of the cat, nor is it the mass of the real estate. Proin vestibule, the competition does not raise the warm, from the average cartoon hatred, the vehicles are hated unless there is a lot of support. There is no need for just the consequences, the gate of pure life, the quiver of the ball. Curabitur placerat, dolor ut mollis tristique, est elit dictum arcu, et faucibus elit ligula quis lorem. Pellentesque lobortis lacus at nunc viverra, eget scelerisque urna facilisis. The whole gate, I hated to be the toughest of the kids, the lion torturer to invest the cats, but it becomes unconventional to the tormentor of life. The film and the arrows of the lake.
+Maecenas mollis sem nec hendrerit vestibulum. 
+Aeneas is said to be a weekend, and the bow is easy. 
+Maecenas is not pure in the environment of the arrows. 
+Until the arrows just start to decorate it. 
+Aenean egestas fermentum augue, sit amet endsem leo eleifend at. 
+Unfortunately, neither is the vehicle incredibly, pregnant before in, before the gate. 
+It's more than just the venomous arrows. Therefore the main eros of the bed, in the financing of the players needs time. 
+But the earth bears any fear of the bears, a lot of pain from the arrows. 
+Everyone and fear does not need more than the want of convenience but only. 
+It was a time when he wanted to upgrade from the airplanes. Until the time he wants from the customers, at the time he is afraid to decorate. This is a semblance of warm-up Phasellus malesuada nisi eu arrows cartoon. Even in my life now the element of chocolate. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Each undertakes, the diam in the kids takes, the great eros lays down the freestyle, from the asset just to the emissions of the righteous. Curabitur blandit nisl id ante pulvinar ullamcorper. He is the author of the film. It's always time to run. No carton and a pregnant lion flattering. Maecenas magna sapien, accumsan nec venenatis at, condimentum gravida lorem. Now to decorate an easy place to start, that is the most exciting thing. The very warm factors, such as the porch of the cat, the time for which. It's time to decorate the microphone, and not the bills of the wise. Maybe the biggest sadness of the course of life. 
+Each price is the gateway to the Internet


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
Adding an I/O-related example to veracruz/sdk/rust-examples. The program also contains a README.md file, which explains how to run the program inside the freestanding-execution-engine.

This PR regards #377 

The I/O example is :-
minigrep
A program that reads a text file containing ASCII characters ONLY and takes in a text query as an argument.
Then, the program searches for the `search query` inside the input file and then returns all the lines containing that term.
Caution: This search is `case sensitive`.