### PR TITLE
update rustls, ring, and webpki to the latest versions

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -40,7 +40,7 @@ postcard = { version = "0.7.2", features = [ "alloc", "use-std" ] }
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
 psa-crypto = { path = "../third-party/rust-psa-crypto/psa-crypto" }
-ring = { version = "0.16.11", optional = true }
+ring = { version = "0.16.20", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"
 typetag = "=0.1.6"

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 [features]
 default = []
 icecap = []
-nitro = ["nix", "aws-nitro-enclaves-nsm-api"]
+nitro = ["nix", "nsm_api", "nsm_lib"]
 std = ["getrandom", "nix"]
 
 [lib]
@@ -16,9 +16,8 @@ name = "platform_services"
 path = "./src/lib.rs"
 
 [dependencies]
-aws-nitro-enclaves-nsm-api = { version = "0.2.0", optional = true }
 cfg-if = "1"
 getrandom = { version = "0.1.14", optional = true }
 nix = { version = "0.22", optional = true }
-nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
-nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", tag = "v0.2.0", package = "aws-nitro-enclaves-nsm-api", optional = true }
+nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", tag = "v0.2.0", package = "nsm-lib", optional = true }

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 [features]
 default = []
 icecap = []
-nitro = ["nix", "nsm_api", "nsm_lib"]
+nitro = ["nix", "aws-nitro-enclaves-nsm-api"]
 std = ["getrandom", "nix"]
 
 [lib]
@@ -16,6 +16,7 @@ name = "platform_services"
 path = "./src/lib.rs"
 
 [dependencies]
+aws-nitro-enclaves-nsm-api = { version = "0.2.0", optional = true }
 cfg-if = "1"
 getrandom = { version = "0.1.14", optional = true }
 nix = { version = "0.22", optional = true }

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -20,7 +20,7 @@ err-derive = { version = "0.2", default-features = false }
 hex = { version = "0.4.2" }
 lexical-core = { version = "0.8.2", default-features = false }
 ring = "0.16.11"
-rustls = { version = "0.16", optional = true }
+rustls = { version = "0.20.4", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 wasi-types = { path = "../third-party/wasi-types" }

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -19,7 +19,7 @@ std = [
 err-derive = { version = "0.2", default-features = false }
 hex = { version = "0.4.2" }
 lexical-core = { version = "0.8.2", default-features = false }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = { version = "0.20.4", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }

--- a/policy-utils/src/error.rs
+++ b/policy-utils/src/error.rs
@@ -11,7 +11,7 @@
 
 use err_derive::Error;
 #[cfg(feature = "std")]
-use rustls::{CipherSuite, TLSError};
+use rustls::{CipherSuite, Error as TLSError};
 use std::{string::String, time::SystemTimeError};
 #[cfg(feature = "std")]
 use x509_parser::error::PEMError;
@@ -45,7 +45,7 @@ pub enum PolicyError {
     #[error(display = "PolicyError: TLSError: {:?}.", _0)]
     TLSError(#[error(source)] TLSError),
     #[error(display = "PolicyError: TLSError: invalid cyphersuite: {:?}.", _0)]
-    TLSInvalidCyphersuiteError(String),
+    TLSInvalidCiphersuiteError(String),
     #[error(display = "PolicyError: SystemTimeError: {:?}.", _0)]
     SystemTimeError(#[error(source)] SystemTimeError),
     #[error(display = "PolicyError: unauthorized client certificate: {}.", _0)]

--- a/policy-utils/src/policy.rs
+++ b/policy-utils/src/policy.rs
@@ -281,7 +281,7 @@ impl Policy {
         {
             let policy_ciphersuite = rustls::CipherSuite::lookup_value(self.ciphersuite())
                 .map_err(|_| {
-                    PolicyError::TLSInvalidCyphersuiteError(self.get_ciphersuite().to_string())
+                    PolicyError::TLSInvalidCiphersuiteError(self.get_ciphersuite().to_string())
                 })?;
             if !rustls::ALL_CIPHERSUITES
                 .iter()

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -55,7 +55,7 @@ percent-encoding = "2.1"
 psa-attestation = { path = "../psa-attestation" }
 rand = "0.7"
 ring = "0.16.11"
-rustls = "0.16"
+rustls = "0.20.4"
 serde_json = "1.0"
 stringreader = "0.1"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -54,7 +54,7 @@ openssl = "0.10.24"
 percent-encoding = "2.1"
 psa-attestation = { path = "../psa-attestation" }
 rand = "0.7"
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 serde_json = "1.0"
 stringreader = "0.1"

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -57,8 +57,7 @@ nitro = [
   "io-utils/nitro",
   "libc",
   "policy-utils/std",
-  "nsm_api",
-  "nsm_lib",
+  "aws-nitro-enclaves-nsm-api",
   "nix",
   "ring/nitro",
   "ring/std",
@@ -67,6 +66,7 @@ nitro = [
 ]
 
 [dependencies]
+aws-nitro-enclaves-nsm-api = { version = "0.2.0", optional = true }
 bincode = { version = "1.2.1", default-features = false, optional = true }
 clap = { version = "2.33", optional = true }
 env_logger = { version = "0.9.0", optional = true }
@@ -87,12 +87,11 @@ libc = { version = "0.2.108", optional = true }
 libm = { version = "0.2", optional = true }
 log = { version = "0.4.13", optional = true }
 nix = { version = "0.15", optional = true }
-nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
-nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
+
 policy-utils = { path = "../policy-utils" }
 protobuf = "=2.8.1"
 psa-attestation = { path = "../psa-attestation", optional = true }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = "1.0"

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -93,7 +93,7 @@ policy-utils = { path = "../policy-utils" }
 protobuf = "=2.8.1"
 psa-attestation = { path = "../psa-attestation", optional = true }
 ring = "0.16.11"
-rustls = "0.16"
+rustls = "0.20.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = "1.0"
 session-manager = { path = "../session-manager" }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -57,7 +57,8 @@ nitro = [
   "io-utils/nitro",
   "libc",
   "policy-utils/std",
-  "aws-nitro-enclaves-nsm-api",
+  "nsm_api",
+  "nsm_lib",
   "nix",
   "ring/nitro",
   "ring/std",
@@ -66,7 +67,6 @@ nitro = [
 ]
 
 [dependencies]
-aws-nitro-enclaves-nsm-api = { version = "0.2.0", optional = true }
 bincode = { version = "1.2.1", default-features = false, optional = true }
 clap = { version = "2.33", optional = true }
 env_logger = { version = "0.9.0", optional = true }
@@ -87,7 +87,8 @@ libc = { version = "0.2.108", optional = true }
 libm = { version = "0.2", optional = true }
 log = { version = "0.4.13", optional = true }
 nix = { version = "0.15", optional = true }
-
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", tag = "v0.2.0", package = "aws-nitro-enclaves-nsm-api", optional = true }
+nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", tag = "v0.2.0", package = "nsm-lib", optional = true }
 policy-utils = { path = "../policy-utils" }
 protobuf = "=2.8.1"
 psa-attestation = { path = "../psa-attestation", optional = true }

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -246,7 +246,7 @@ pub fn error_message(message: String, error_code: u32) {
 }
 
 /// Base function for printing messages outside of the enclave.  Note that this
-/// should only print something to *stdoout* on the host's machine if the debug
+/// should only print something to *stdout* on the host's machine if the debug
 /// configuration flag is set in the Veracruz global policy.
 fn print_message(#[allow(unused)] message: String, #[allow(unused)] code: u32) {
     #[cfg(feature = "linux")]

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -22,7 +22,7 @@ std = [
 [dependencies]
 err-derive = "0.2"
 policy-utils = { path = "../policy-utils" }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 rustls-pemfile = "0.3.0"
 veracruz-utils = { path = "../veracruz-utils" }

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -23,6 +23,8 @@ std = [
 err-derive = "0.2"
 policy-utils = { path = "../policy-utils" }
 ring = "0.16.11"
-rustls = "0.16"
-webpki = "=0.21.2"
-webpki-roots = "0.19.0"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
+veracruz-utils = { path = "../veracruz-utils" }
+webpki = "0.22"
+webpki-roots = "0.22"

--- a/session-manager/src/error.rs
+++ b/session-manager/src/error.rs
@@ -23,7 +23,7 @@ pub enum SessionManagerError {
     /// A TLS error originating in the `RusTLS` library occurred, with an
     /// accompanying error code.
     #[error(display = "Session manager: a TLS error occurred: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] rustls::Error),
     /// A generic, unspecified TLS error occurred.
     #[error(display = "Session manager: an unspecified or unknown TLS error occurred.")]
     TLSUnspecifiedError,
@@ -32,7 +32,7 @@ pub enum SessionManagerError {
         display = "Session manager: an invalid cyphersuite was requested in the TLS handshake: {:?}.",
         _0
     )]
-    TLSInvalidCyphersuiteError(std::string::String),
+    TLSInvalidCiphersuiteError(std::string::String),
     /// An unsupported ciphersuite was requested.
     #[error(
         display = "Session manager: an unsupported cyphersuite was requested in the TLS handshake: {:?}.",

--- a/session-manager/src/session.rs
+++ b/session-manager/src/session.rs
@@ -44,8 +44,7 @@ impl Session {
     /// Creates a new session from a server configuration and a list of
     /// principals.
     pub fn new(config: rustls::ServerConfig, principals: &Vec<Principal>) -> Result<Self, SessionManagerError> {
-        let mut tls_connection = ServerConnection::new(std::sync::Arc::new(config))?;
-        tls_connection.set_buffer_limit(Some(512 * 1024));
+        let tls_connection = ServerConnection::new(std::sync::Arc::new(config))?;
 
         Ok(Session {
             tls_connection: tls_connection,

--- a/test-collateral/generate-policy/Cargo.toml
+++ b/test-collateral/generate-policy/Cargo.toml
@@ -13,7 +13,7 @@ data-encoding = "2.3.2"
 env_logger = "0.9.0"
 log = "0.4.13"
 policy-utils = { path = "../../policy-utils", features = ["std"] }
-ring = "0.16.11"
+ring = "0.16.20"
 serde = { version = "1.0.115", features = ["std"] }
 serde_json = { version = "1.0", features = ["std"] }
 veracruz-utils = {path = "../../veracruz-utils", features = ["std"]}

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -30,13 +30,14 @@ rand = "0.7.0"
 reqwest = { version = "0.9", default-features = false }
 ring = "0.16.11"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
-rustls = "0.16"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
 serde_json = "1.0"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", features = ["std"] }
-webpki = "0.21.2"
-webpki-roots = "0.19.0"
+webpki = "0.22"
+webpki-roots = "0.22"
 x509-parser = "0.12.0"
 
 [dev-dependencies]

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.13"
 policy-utils = { path = "../policy-utils", features = ["std"] }
 rand = "0.7.0"
 reqwest = { version = "0.9", default-features = false }
-ring = "0.16.11"
+ring = "0.16.20"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 rustls = "0.20.4"
 rustls-pemfile = "0.3.0"

--- a/veracruz-client/src/error.rs
+++ b/veracruz-client/src/error.rs
@@ -27,7 +27,7 @@ pub enum VeracruzClientError {
     #[error(display = "VeracruzClient: IOError: {:?}.", _0)]
     IOError(#[error(source)] std::io::Error),
     #[error(display = "VeracruzClient: TLSError: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] rustls::Error),
     #[error(
         display = "VeracruzClient: TLSError: unsupported cyphersuite {:?}.",
         _0
@@ -36,7 +36,7 @@ pub enum VeracruzClientError {
     #[error(display = "VeracruzClient: TLSError: unspecified.")]
     TLSUnspecifiedError,
     #[error(display = "VeracruzClient: TLSError: invalid cyphersuite {:?}.", _0)]
-    TLSInvalidCyphersuiteError(std::string::String),
+    TLSInvalidCiphersuiteError(std::string::String),
     #[error(display = "VeracruzClient: RingError: {:?}", _0)]
     RingError(std::string::String),
     #[error(display = "VeracruzClient: SerdeJsonError: {:?}.", _0)]
@@ -47,8 +47,8 @@ pub enum VeracruzClientError {
     X509ParserError(String),
     #[error(display = "VeracruzClient: WebpkiError: {:?}.", _0)]
     WebpkiError(#[error(source)] webpki::Error),
-    #[error(display = "VeracruzClient: WebpkiError: {:?}.", _0)]
-    WebpkiDNSError(#[error(source)] webpki::InvalidDNSNameError),
+    #[error(display = "VeracruzClient: Invalid DNS Error: {:?}", _0)]
+    InvalidDnsNameError(#[error(source)] rustls::client::InvalidDnsNameError),
     #[error(display = "VeracruzClient: TryIntoError: {}.", _0)]
     TryIntoError(#[error(source)] std::num::TryFromIntError),
     #[error(display = "VeracruzClient: ParseIntError: {}.", _0)]

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -193,7 +193,7 @@ impl VeracruzClient {
 
         let enclave_name_as_server = rustls::ServerName::try_from(enclave_name)
             .map_err(|err| VeracruzClientError::InvalidDnsNameError(err))?;
-        let mut connection = ClientConnection::new(std::sync::Arc::new(client_config), enclave_name_as_server)?;
+        let connection = ClientConnection::new(std::sync::Arc::new(client_config), enclave_name_as_server)?;
         let client_cert_text = VeracruzClient::read_all_bytes_in_file(&client_cert_filename)?;
         let mut client_cert_raw = from_utf8(client_cert_text.as_slice())?.to_string();
         // erase some '\n' to match the format in policy file.

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -42,9 +42,10 @@ log = "0.4.13"
 policy-utils = { path = "../policy-utils", optional = true }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
 ring = "0.16.11"
-rustls = "0.16"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
 transport-protocol = { path = "../transport-protocol" }
 veracruz-server = { path = "../veracruz-server" }
 veracruz-utils = { path = "../veracruz-utils", optional = true }
-webpki = "=0.21.2"
-webpki-roots = "0.19.0"
+webpki = "0.22"
+webpki-roots = "0.22"

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4"
 log = "0.4.13"
 policy-utils = { path = "../policy-utils", optional = true }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 rustls-pemfile = "0.3.0"
 transport-protocol = { path = "../transport-protocol" }

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -348,11 +348,13 @@ mod tests {
             let client_cert_filename = trust_path("never_used_cert.pem");
             let client_key_filename = trust_path("client_rsa_key.pem");
 
-        let mut _client_connection = create_client_test_connection(
-            client_cert_filename.as_path(),
-            client_key_filename.as_path(),
-            &policy.ciphersuite(),
-        );
+
+            let mut _client_connection = create_client_test_connection(
+                client_cert_filename.as_path(),
+                client_key_filename.as_path(),
+                &policy.ciphersuite(),
+            );
+        });
     }
 
     #[test]

--- a/veracruz-server-test/src/main.rs
+++ b/veracruz-server-test/src/main.rs
@@ -945,7 +945,6 @@ mod tests {
         info!("             Enclave generated a self-signed certificate:");
 
         let mut client_connection = create_client_test_connection(client_cert_path, client_key_path, &policy.ciphersuite())?;
-        client_connection.set_buffer_limit(Some(512 * 1024));
         info!(
             "             Initialization time (μs): {}.",
             time_init.elapsed().as_micros()
@@ -1667,25 +1666,30 @@ mod tests {
         ticket: u32,
         send_data: &[u8],
     ) -> Result<Vec<u8>, VeracruzServerError> {
-        connection.writer().write_all(&send_data).map_err(|e| {
-            error!("Failed to send all data.  Error produced: {:?}.", e);
-            e
-        })?;
 
-        let mut output: std::vec::Vec<u8> = std::vec::Vec::new();
-
-        connection.write_tls(&mut output).map_err(|e| {
-            error!("Failed to write TLS.  Error produced: {:?}.", e);
-            e
-        })?;
-
-        tx.send((session_id, output)).map_err(|e| {
-            error!(
-                "Failed to send data on TX channel.  Error produced: {:?}.",
+        let mut start_index: usize = 0;
+        while start_index < send_data.len() {
+            let bytes_written = connection.writer().write(&send_data[start_index..]).map_err(|e| {
+                error!("Failed to send all data.  Error produced: {:?}.", e);
                 e
-            );
-            e
-        })?;
+            })?;
+            start_index += bytes_written;
+
+            let mut output: std::vec::Vec<u8> = std::vec::Vec::new();
+
+            connection.write_tls(&mut output).map_err(|e| {
+                error!("Failed to write TLS.  Error produced: {:?}.", e);
+                e
+            })?;
+
+            tx.send((session_id, output)).map_err(|e| {
+                error!(
+                    "Failed to send data on TX channel.  Error produced: {:?}.",
+                    e
+                );
+                e
+            })?;
+        }
 
         while *CONTINUE_FLAG_HASH
             .lock()

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -63,7 +63,7 @@ postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }
 ring = "0.16.11"
-rustls = "0.16"
+rustls = "0.20.4"
 serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 signal-hook = { version = "0.3.13", optional = true }
@@ -71,4 +71,4 @@ structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 tempfile = { version = "3.2.0", optional = true }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", optional = true }
-webpki = "=0.21.2"
+webpki = "0.22"

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -62,7 +62,7 @@ nix = { version = "0.15", optional = true }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -19,14 +19,16 @@ use err_derive::Error;
 #[cfg(feature = "nitro")]
 use io_utils::nitro::NitroError;
 use io_utils::{error::SocketError, http::HttpError};
+use rustls::Error as TLSError;
 use std::error::Error;
+
 
 pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 
 #[derive(Debug, Error)]
 pub enum VeracruzServerError {
     #[error(display = "VeracruzServer: TLSError: {:?}.", _0)]
-    TLSError(#[error(source)] rustls::TLSError),
+    TLSError(#[error(source)] TLSError),
     #[error(display = "VeracruzServer: HexError: {:?}.", _0)]
     HexError(#[error(source)] hex::FromHexError),
     #[error(display = "VeracruzServer: Utf8Error: {:?}.", _0)]
@@ -47,10 +49,12 @@ pub enum VeracruzServerError {
     Base64Error(#[error(source)] base64::DecodeError),
     #[error(display = "VeracruzServer: TLSError: unspecified.")]
     TLSUnspecifiedError,
+    #[error(display = "VeracruzServer: Invalid cipher suite: {:?}", _0)]
+    InvalidCiphersuiteError(String),
     #[error(display = "VeracruzServer: webpki: {:?}.", _0)]
     WebpkiError(#[error(source)] webpki::Error),
     #[error(display = "VeracruzServer: webpki: {:?}.", _0)]
-    WebpkiDNSNameError(#[error(source)] webpki::InvalidDNSNameError),
+    WebpkiDNSNameError(#[error(source)] rustls::client::InvalidDnsNameError),
     #[error(display = "VeracruzServer: Failed to obtain lock {:?}.", _0)]
     LockError(String),
     #[error(display = "VeracruzServer: TryIntoError: {}.", _0)]

--- a/veracruz-test/Cargo.toml
+++ b/veracruz-test/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.13"
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", features = ["std"] }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
-ring = "0.16.11"
+ring = "0.16.20"
 rustls = "0.20.4"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"

--- a/veracruz-test/Cargo.toml
+++ b/veracruz-test/Cargo.toml
@@ -38,7 +38,7 @@ postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", features = ["std"] }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
 ring = "0.16.11"
-rustls = "0.16"
+rustls = "0.20.4"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"
 transport-protocol = { path = "../transport-protocol" }

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -25,7 +25,7 @@ std = [
 [dependencies]
 bincode = { version = "1.2.1", default-features = false, optional = true }
 err-derive = "0.2"
-ring = "0.16.11"
+ring = "0.16.20"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 rustls = { version = "0.20.4" }
 serde = { version = "1.0.115", default-features = false, optional = true }

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -27,8 +27,8 @@ bincode = { version = "1.2.1", default-features = false, optional = true }
 err-derive = "0.2"
 ring = "0.16.11"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
-rustls = { version = "0.16", optional = true }
+rustls = { version = "0.20.4" }
 serde = { version = "1.0.115", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false }
-webpki = "=0.21.2"
+webpki = "0.22"
 x509-parser = { version = "0.7.0", optional = true }

--- a/veracruz-utils/src/lib.rs
+++ b/veracruz-utils/src/lib.rs
@@ -24,8 +24,23 @@ pub mod csr;
 /// Requests and responses for the Runtime Manager.
 pub mod runtime_manager_message;
 
+use rustls;
+
 /// The ID of the Veracruz Runtime Hash Extension.
 /// This value was made up, all can be changed to pretty much any valid
 /// ID as long as it doesn't collide with the ID of an extension in our
 /// certificates.
 pub static VERACRUZ_RUNTIME_HASH_EXTENSION_ID: [u8; 4] = [2, 5, 30, 1];
+
+pub fn lookup_ciphersuite(suite_string: &str) -> Option<rustls::SupportedCipherSuite> {
+    let ciphersuite_enum = match rustls::CipherSuite::lookup_value(suite_string) {
+        Ok(suite) => suite,
+        Err(_) => return None,
+    };
+    for this_supported_ciphersuite in rustls::ALL_CIPHER_SUITES {
+        if this_supported_ciphersuite.suite() == ciphersuite_enum {
+            return Some(this_supported_ciphersuite.clone());
+        }
+    }
+    return None;
+}

--- a/workspaces/host/Cargo.lock
+++ b/workspaces/host/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "libc",
  "log",
@@ -131,15 +131,6 @@ name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -684,6 +675,7 @@ dependencies = [
  "ctor",
  "err-derive",
  "lazy_static",
+ "log",
  "num",
  "num-derive",
  "num-traits",
@@ -1248,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "nsm-lib"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cbindgen",
@@ -1849,9 +1841,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
@@ -1904,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2637,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",

--- a/workspaces/host/Cargo.toml
+++ b/workspaces/host/Cargo.toml
@@ -44,5 +44,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -3206,13 +3206,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3254,9 +3262,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4226,6 +4234,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "serde_json",
  "structopt",
  "transport-protocol",
@@ -4284,6 +4293,7 @@ dependencies = [
  "proxy-attestation-server",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "transport-protocol",
  "veracruz-server",
  "veracruz-utils",
@@ -4481,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -4489,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/icecap-host/Cargo.toml
+++ b/workspaces/icecap-host/Cargo.toml
@@ -33,5 +33,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/icecap-runtime/Cargo.lock
+++ b/workspaces/icecap-runtime/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "libc",
  "log",
@@ -128,15 +128,6 @@ name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -713,6 +704,7 @@ dependencies = [
  "ctor",
  "err-derive",
  "lazy_static",
+ "log",
  "num",
  "num-derive",
  "num-traits",
@@ -1451,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "nsm-lib"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cbindgen",
@@ -1605,6 +1597,12 @@ checksum = "fe554cb2393bc784fd678c82c84cc0599c31ceadc7f03a594911f822cb8d1815"
 dependencies = [
  "der-parser 6.0.1",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1937,13 +1935,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.20"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cc",
- "lazy_static",
  "libc",
  "nsm-lib",
+ "once_cell",
  "spin 0.5.2",
  "untrusted",
  "web-sys",
@@ -2064,13 +2062,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2132,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2213,6 +2219,8 @@ dependencies = [
  "policy-utils",
  "ring",
  "rustls",
+ "rustls-pemfile",
+ "veracruz-utils",
  "webpki",
  "webpki-roots",
 ]
@@ -2906,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -2914,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/icecap-runtime/Cargo.toml
+++ b/workspaces/icecap-runtime/Cargo.toml
@@ -32,5 +32,5 @@ opt-level = 3
 [patch.crates-io]
 libc = { path = "crates/icecap/sysroot/libc" }
 ring = { path = "crates/third-party/ring" }
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -3206,13 +3206,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3254,9 +3262,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4226,6 +4234,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "serde_json",
  "structopt",
  "transport-protocol",
@@ -4284,6 +4293,7 @@ dependencies = [
  "proxy-attestation-server",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "transport-protocol",
  "veracruz-server",
  "veracruz-utils",
@@ -4481,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -4489,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/linux-host/Cargo.toml
+++ b/workspaces/linux-host/Cargo.toml
@@ -31,5 +31,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/linux-runtime/Cargo.lock
+++ b/workspaces/linux-runtime/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "libc",
  "log",
@@ -129,15 +129,6 @@ name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -714,6 +705,7 @@ dependencies = [
  "ctor",
  "err-derive",
  "lazy_static",
+ "log",
  "num",
  "num-derive",
  "num-traits",
@@ -1438,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "nsm-lib"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cbindgen",
@@ -1592,6 +1584,12 @@ checksum = "fe554cb2393bc784fd678c82c84cc0599c31ceadc7f03a594911f822cb8d1815"
 dependencies = [
  "der-parser 6.0.1",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1924,13 +1922,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.20"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cc",
- "lazy_static",
  "libc",
  "nsm-lib",
+ "once_cell",
  "spin 0.5.2",
  "untrusted",
  "web-sys",
@@ -2051,13 +2049,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2119,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2200,6 +2206,8 @@ dependencies = [
  "policy-utils",
  "ring",
  "rustls",
+ "rustls-pemfile",
+ "veracruz-utils",
  "webpki",
  "webpki-roots",
 ]
@@ -2864,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -2872,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/linux-runtime/Cargo.toml
+++ b/workspaces/linux-runtime/Cargo.toml
@@ -30,5 +30,5 @@ opt-level = 3
 
 [patch.crates-io]
 ring = { path = "crates/third-party/ring" }
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -3206,13 +3206,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3254,9 +3262,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4226,6 +4234,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "serde_json",
  "structopt",
  "transport-protocol",
@@ -4284,6 +4293,7 @@ dependencies = [
  "proxy-attestation-server",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "transport-protocol",
  "veracruz-server",
  "veracruz-utils",
@@ -4481,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -4489,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/nitro-host/Cargo.toml
+++ b/workspaces/nitro-host/Cargo.toml
@@ -33,5 +33,5 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }

--- a/workspaces/nitro-runtime/Cargo.lock
+++ b/workspaces/nitro-runtime/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "libc",
  "log",
@@ -128,15 +128,6 @@ name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -713,6 +704,7 @@ dependencies = [
  "ctor",
  "err-derive",
  "lazy_static",
+ "log",
  "num",
  "num-derive",
  "num-traits",
@@ -1437,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "nsm-lib"
 version = "0.2.0"
-source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?branch=main#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?tag=v0.2.0#915d87fb67d9956cb973d7e3edce7810c4ba70f1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cbindgen",
@@ -1591,6 +1583,12 @@ checksum = "fe554cb2393bc784fd678c82c84cc0599c31ceadc7f03a594911f822cb8d1815"
 dependencies = [
  "der-parser 6.0.1",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1923,13 +1921,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.20"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "cc",
- "lazy_static",
  "libc",
  "nsm-lib",
+ "once_cell",
  "spin 0.5.2",
  "untrusted",
  "web-sys",
@@ -2050,13 +2048,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.20.4"
 dependencies = [
- "base64 0.10.1",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2118,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2199,6 +2205,8 @@ dependencies = [
  "policy-utils",
  "ring",
  "rustls",
+ "rustls-pemfile",
+ "veracruz-utils",
  "webpki",
  "webpki-roots",
 ]
@@ -2863,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ring",
  "untrusted",
@@ -2871,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]

--- a/workspaces/nitro-runtime/Cargo.toml
+++ b/workspaces/nitro-runtime/Cargo.toml
@@ -30,5 +30,5 @@ opt-level = 3
 
 [patch.crates-io]
 ring = { path = "crates/third-party/ring" }
-rustls = { path = "crates/third-party/rustls" }
+rustls = { path = "crates/third-party/rustls/rustls" }
 webpki = { path = "crates/third-party/webpki" }


### PR DESCRIPTION


Updated rustls, webpki, and ring to the latest released versions.
This should have been fairly simple, since the rustls API didn't change. However, the behavior of the existing functions changed quite a bit, and required quite a lot of work to figure out.

As is, the changes we now require in rustls are very minimal: a convenience function. After this is done, I will investigate removing the need for a fork of rustls entirely.

The changes we now require in webpki are limited to support for unrecognized extensions. This would be a generally useful feature. I am going to see how difficult it would be to upstream this change. After that, we may no longer require a fork of webpki.

The changes for ring involve platform-specific support for random number generation. The platforms that we have added are not of general interest and therefore are unlikely to be upstreamed as-is. We have discussed changing the way it is done to make adding platform-specific support easier. If we were to do that, it could be upstreamed (but it's unclear how likely that would be to succeed).
