### PR TITLE
fixed the left out changes in /rust-examples/huffman-encoding

### DIFF
--- a/sdk/rust-examples/huffman-encoding/src/main.rs
+++ b/sdk/rust-examples/huffman-encoding/src/main.rs
@@ -50,14 +50,16 @@ fn new_node(freq: u32, ch: Option<char>) -> Node {
 }
 
 /// Count the frequency of occurence of each unique ASCII character in the input string
-fn frequency(s: &str) -> HashMap<char, u32> {
-    let mut hm = HashMap::new();
-    for ch in s.chars() {
-        let count = hm.entry(ch).or_insert(0);
-        *count += 1;
+fn frequency<A>(s: A) -> HashMap<char, u32>
+where
+    A: AsRef<str>,
+{
+    let mut h = HashMap::new();
+    for ch in s.as_ref().chars() {
+        let counter = h.entry(ch).or_insert(0);
+        *counter += 1;
     }
-
-    hm
+    h
 }
 
 /// Assign the binary codes to each unique ASCII character in the input string
@@ -121,9 +123,8 @@ fn main() -> anyhow::Result<()> {
     let file_vec = fs::read(INPUT_FILENAME)?;
 
     let msg = String::from_utf8_lossy(&file_vec).to_string();
-    let msg = msg.as_str();
 
-    let hm = frequency(msg);
+    let hm = frequency(&msg);
 
     let mut p: Vec<Box<Node>> = hm
         .iter()
@@ -147,7 +148,7 @@ fn main() -> anyhow::Result<()> {
 
     assign_codes(&root, &mut hm, String::new());
 
-    let enc = encode_string(msg, &hm);
+    let enc = encode_string(&msg, &hm);
     let dec = decode_string(&enc, &root);
 
     let mut ret = String::new();

--- a/sdk/rust-examples/huffman-encoding/src/main.rs
+++ b/sdk/rust-examples/huffman-encoding/src/main.rs
@@ -54,12 +54,12 @@ fn frequency<A>(s: A) -> HashMap<char, u32>
 where
     A: AsRef<str>,
 {
-    let mut h = HashMap::new();
+    let mut hm = HashMap::new();
     for ch in s.as_ref().chars() {
-        let counter = h.entry(ch).or_insert(0);
+        let counter = hm.entry(ch).or_insert(0);
         *counter += 1;
     }
-    h
+    hm
 }
 
 /// Assign the binary codes to each unique ASCII character in the input string


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
Fixed the changes that were left out when merging PR #401 
(Changes to frequency function, and function calls of encode and decode function)