### PR TITLE
pipline example added

### DIFF
--- a/sdk/rust-examples/binary-subarray/README.markdown
+++ b/sdk/rust-examples/binary-subarray/README.markdown
@@ -1,0 +1,37 @@
+# Binary Subarrays
+
+This program provides an example of executing multiple programs sequentially inside Veracruz `freestanding-execution-engine`, where each program's input depends on the previous' output.   This is similar to piping commands in Linux `command1 | command2`.  
+  
+This is a two-step program where the first step provides its output to the second program. The final output consists of three subarrays: 1. The longest alternating subarray(010101..), 2. The longest subarray containing only 0s, and 3. The longest subarray containing only 1s.   
+  
+1. `ascii-to-bin`: this program converts ASCII characters to binary 0s and 1s using the Huffman Encoding algorithm.  
+2. `longest-subarrays`: this takes the output provided by the previous program, and outputs the three subarrays mentioned above.
+
+Here are the steps for running these two programs inside Veracruz `freestanding-execution-engine`
+
+## Steps  
+
+1. You have to build the WASM binary for each program by running the following commands in each directory:
+  ```
+  rustup target add wasm32-wasi
+  cargo build --target wasm32-wasi
+  ```
+
+2. You will find the `.wasm` file in `target/wasm32-wasi/debug/` path inside each program. Copy the two `.wasm` files to `sdk/freestanding-execution-engine`.
+
+3. Inside `sdk/freestanding-execution-engine`, create three directories, called `input`, `output` and another directory called `program`. 
+
+4. Run the following command :
+```
+cp ../../test-collateral/huffman_example_input.txt input
+```
+This will copy the "Veracruz README file" to the input directory. This will be our input to the program 1, `ascii-to-bin`.
+
+5. Move the two `.wasm` files inside the `program` directory.
+
+6. Run the following command
+```
+RUST_LOG="info" cargo run -- --input-source input --input-source program --program program/ascii-to-bin.wasm program/longest-subarrays.wasm --output-source output -e -d -c
+```
+
+7. After the long log of information, you should see a file called `output.txt` inside the output directory. This file should contain `the three subarrays` mentioned above, in the same order as mentioned above.

--- a/sdk/rust-examples/binary-subarray/ascii-to-bin/Cargo.toml
+++ b/sdk/rust-examples/binary-subarray/ascii-to-bin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "Reads a file, and then compresses it using the huffman encoding algorithm. Finally, writes the output into another text file"
+name = "ascii-to-bin"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"

--- a/sdk/rust-examples/binary-subarray/ascii-to-bin/src/main.rs
+++ b/sdk/rust-examples/binary-subarray/ascii-to-bin/src/main.rs
@@ -1,0 +1,133 @@
+//! ASCII to Binary
+//!
+//! ## Context
+//!
+//! Reads user input, and then encodes the file to binary format to compress it and save space.
+//! And then, it prints the encoded file.
+//! WARNING: Program is only desinged for ASCII characters, not UTF-8 encoding !!
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
+//! copyright information.
+
+use anyhow::{self, Ok};
+use std::{collections::HashMap, fs};
+
+const INPUT_FILENAME: &'static str = "/input/huffman_example_input.txt";
+const OUTPUT_FILENAME: &'static str = "/output/output.txt";
+
+type Link = Option<Box<Node>>;
+
+#[derive(Debug)]
+
+/// A Binary Tree Node is represented here
+struct Node {
+    /// Each Node, must represent a character, and its frequency in the input string
+    freq: u32,
+    ch: Option<char>,
+
+    /// The nodes for left and right children of the node
+    left: Link,
+    right: Link,
+}
+
+/// Function to create a new node, (ike a Constructor function)
+#[inline]
+fn new_node(freq: u32, ch: Option<char>) -> Node {
+    Node {
+        freq: freq,
+        ch: ch,
+
+        left: None,
+        right: None,
+    }
+}
+
+/// Count the frequency of occurence of each unique ASCII character in the input string
+fn frequency<A>(s: A) -> HashMap<char, u32> 
+where
+    A: AsRef<str>,
+{
+    let mut hm = HashMap::new();
+    for ch in s.as_ref().chars() {
+        let count = hm.entry(ch).or_insert(0);
+        *count += 1;
+    }
+
+    hm
+}
+
+/// Assign the binary codes to each unique ASCII character in the input string
+fn assign_codes(p: &Node, hm: &mut HashMap<char, String>, s: String) {
+    if let Some(ch) = p.ch {
+        hm.insert(ch, s);
+    } else {
+        if let Some(ref l) = p.left {
+            assign_codes(l, hm, s.clone() + "0");
+        }
+        if let Some(ref r) = p.right {
+            assign_codes(r, hm, s.clone() + "1");
+        }
+    }
+}
+
+/// Takes the huffman tree and input string, to return the encoded string
+fn encode_string<A>(s: A, hm: &HashMap<char, String>) -> String
+where
+    A: AsRef<str>,
+{
+    let mut r = String::new();
+    let mut t: Option<&String>;
+
+    for ch in s.as_ref().chars() {
+        t = hm.get(&ch);
+        r.push_str(t.expect("couldn't push into the string 'r' inside 'encode_string()'"));
+    }
+
+    r
+}
+
+fn main() -> anyhow::Result<()> {
+    let file_vec = fs::read(INPUT_FILENAME)?;
+
+    let msg = String::from_utf8_lossy(&file_vec).to_string();
+
+    let hm = frequency(&msg);
+
+    let mut p: Vec<Box<Node>> = hm
+        .iter()
+        .map(|x| Box::new(new_node(*(x.1), Some(*(x.0)))))
+        .collect();
+
+    while p.len() > 1 {
+        p.sort_by(|a, b| (&(b.freq)).cmp(&(a.freq)));
+        let a = p.pop().expect("error occured inside main while loop");
+        let b = p.pop().expect("error occured inside main while loop");
+        let mut c = Box::new(new_node(a.freq + b.freq, None));
+        c.left = Some(a);
+        c.right = Some(b);
+        p.push(c);
+    }
+
+    let root = p
+        .pop()
+        .expect("error occured during building of binary tree using &Box<Node>");
+    let mut hm: HashMap<char, String> = HashMap::new();
+
+    assign_codes(&root, &mut hm, String::new());
+
+    let enc = encode_string(&msg, &hm);
+
+    let mut ret = String::new();
+
+    ret.push_str(enc.as_str());
+
+    fs::write(OUTPUT_FILENAME, ret)?;
+
+    Ok(())
+}

--- a/sdk/rust-examples/binary-subarray/longest-subarrays/Cargo.toml
+++ b/sdk/rust-examples/binary-subarray/longest-subarrays/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "Reads the input file containing 0s and 1s, and prints out the three longest subarrays: (Alternating, 0s, 1s)"
+name = "longest-subarrays"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"

--- a/sdk/rust-examples/binary-subarray/longest-subarrays/src/main.rs
+++ b/sdk/rust-examples/binary-subarray/longest-subarrays/src/main.rs
@@ -17,164 +17,161 @@
 //! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
 //! copyright information.
 
-use std::{fs, process};
 use anyhow;
+use std::{fs, process};
 
-const FILENAME: &'static str = "/output/output.txt"; 
+const FILENAME: &'static str = "/output/output.txt";
 
 fn main() -> anyhow::Result<()> {
-
     let file_vec: Vec<u8> = fs::read(FILENAME)?;
     let content: String = String::from_utf8_lossy(&file_vec).to_string();
-    // let content = String::from_utf8(fs::read(FILENAME)?)?;
 
-    // let my_vec: Vec<char> = content.chars().collect();
-
-    if content.len() < 3 {
+    if content.len() < 1 {
         process::exit(1);
     }
 
-    let alter_string_ends: (usize, usize)  = longest_alternating_subarray(&content);
-    let zero_string_ends: (usize, usize)  = longest_zero_subarray(&content);
+    let alter_string_ends: (usize, usize) = longest_alternating_subarray(&content);
+    let zero_string_ends: (usize, usize) = longest_zero_subarray(&content);
     let one_string_ends: (usize, usize) = longest_one_subarray(&content);
 
-    let mut ret = String::new() ;
+    let mut ret = String::new();
 
-    let start: usize = alter_string_ends.0 ;
-    let end: usize = alter_string_ends.1 - alter_string_ends.0 ;
-    let alter_string: &str = &content[start..end] ;
+    let start: usize = alter_string_ends.0;
+    let end: usize = alter_string_ends.1 - alter_string_ends.0;
+    let alter_string: &str = &content[start..end];
 
-    let start: usize = zero_string_ends.0 ;
-    let end: usize = zero_string_ends.1 - zero_string_ends.0 ;
-    let mut zero_string: &str = &content[start..end] ;
+    let start: usize = zero_string_ends.0;
+    let end: usize = zero_string_ends.1 - zero_string_ends.0;
+    let mut zero_string: &str = &content[start..end];
+
+    let start: usize = one_string_ends.0;
+    let end: usize = one_string_ends.1 - one_string_ends.0;
+    let mut one_string: &str = &content[start..end];
 
     if zero_string == "" {
-        zero_string = "0";
+        if content.len() != one_string.len() {
+            zero_string = "0";
+        }
     }
-
-    let start: usize = one_string_ends.0 ;
-    let end: usize = one_string_ends.1 - one_string_ends.0 ;
-    let mut one_string: &str = &content[start..end] ;
 
     if one_string == "" {
-        one_string = "1";
+        if content.len() != zero_string.len() {
+            one_string = "1";
+        }
     }
 
-    ret.push_str(alter_string) ;
-    ret.push_str("\n") ;
-    ret.push_str(zero_string) ;
-    ret.push_str("\n") ;
-    ret.push_str(one_string) ;
-    ret.push_str("\n") ;
+    ret.push_str(alter_string);
+    ret.push_str("\n");
+    ret.push_str(zero_string);
+    ret.push_str("\n");
+    ret.push_str(one_string);
+    ret.push_str("\n");
 
     fs::write(FILENAME, ret)?;
 
     Ok(())
 }
 
-// fn longest_alternating_subarray( arr: &String ) -> String {
-    fn longest_alternating_subarray( s: &String ) -> (usize,usize) {
-        let bytes: &[u8] = s.as_bytes();
-    
-        let mut start: usize = 0;
-        let mut res: usize = 1;
-        let mut temp: usize = 1;
-    
-        for (i, &item) in bytes.iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if (item == b'1' && bytes[i-1] == b'0') || (item == b'0' && bytes[i-1] == b'1') {
-                temp += 1;
+fn longest_alternating_subarray(s: &String) -> (usize, usize) {
+    let bytes: &[u8] = s.as_bytes();
+
+    let mut start: usize = 0;
+    let mut res: usize = 1;
+    let mut temp: usize = 1;
+
+    for (i, &item) in bytes.iter().enumerate() {
+        if i == 0 {
+            continue;
+        }
+        if (item == b'1' && bytes[i - 1] == b'0') || (item == b'0' && bytes[i - 1] == b'1') {
+            temp += 1;
+        } else {
+            if res < temp {
+                res = temp;
+                start = i - res;
             } else {
-                if res < temp {
-                    res = temp;
-                    start = i-res ;
-                } else {
-                    temp = 1 ;
-                }
+                temp = 1;
             }
         }
-    
-        if res < temp {
-            res = temp;
-            start = s.len()-res ;
-        }
-    
-        if res == 1 {
-            return (0,0)
-        }
-        (start,start+res)
     }
-    
-    // fn longest_zero_subarray( arr: &String ) -> String {
-    fn longest_zero_subarray( s: &String ) -> (usize,usize) {
-        let bytes: &[u8] = s.as_bytes();
-    
-        let mut start: usize = 0;
-        let mut res: usize = 1;
-        let mut temp: usize = 1;
-    
-        for (i, &item) in bytes.iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if item == b'0' && bytes[i-1] == b'0' {
-                temp += 1;
+
+    if res < temp {
+        res = temp;
+        start = s.len() - res;
+    }
+
+    if res == 1 {
+        return (0, 0);
+    }
+    (start, start + res)
+}
+
+fn longest_zero_subarray(s: &String) -> (usize, usize) {
+    let bytes: &[u8] = s.as_bytes();
+
+    let mut start: usize = 0;
+    let mut res: usize = 1;
+    let mut temp: usize = 1;
+
+    for (i, &item) in bytes.iter().enumerate() {
+        if i == 0 {
+            continue;
+        }
+        if item == b'0' && bytes[i - 1] == b'0' {
+            temp += 1;
+        } else {
+            if res < temp {
+                res = temp;
+                start = i - res;
             } else {
-                if res < temp {
-                    res = temp;
-                    start = i-res ;
-                } else {
-                    temp = 1 ;
-                }
+                temp = 1;
             }
         }
-    
-        if res < temp {
-            res = temp;
-            start = s.len() - res ;
-        }
-        
-        if res == 1 {
-            return (0,0)
-        }
-    
-        (start,start+res)
     }
-    
-    // fn longest_one_subarray( arr: &String ) -> String {
-    fn longest_one_subarray( s: &String ) -> (usize,usize) {
-        let bytes: &[u8] = s.as_bytes();
-    
-        let mut start: usize = 0;
-        let mut res: usize = 1;
-        let mut temp: usize = 1;
-    
-        for (i, &item) in bytes.iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if item == b'1' && bytes[i-1] == b'1' {
-                temp += 1;
+
+    if res < temp {
+        res = temp;
+        start = s.len() - res;
+    }
+
+    if res == 1 {
+        return (0, 0);
+    }
+
+    (start, start + res)
+}
+
+fn longest_one_subarray(s: &String) -> (usize, usize) {
+    let bytes: &[u8] = s.as_bytes();
+
+    let mut start: usize = 0;
+    let mut res: usize = 1;
+    let mut temp: usize = 1;
+
+    for (i, &item) in bytes.iter().enumerate() {
+        if i == 0 {
+            continue;
+        }
+        if item == b'1' && bytes[i - 1] == b'1' {
+            temp += 1;
+        } else {
+            if res < temp {
+                res = temp;
+                start = i - res;
             } else {
-                if res < temp {
-                    res = temp;
-                    start = i-res ;
-                } else {
-                    temp = 1 ;
-                }
+                temp = 1;
             }
         }
-    
-        if res < temp {
-            res = temp;
-            start = s.len() - res ;
-        }
-    
-        if res == 1 {
-            return (0,0)
-        }
-    
-        (start,start+res)
     }
+
+    if res < temp {
+        res = temp;
+        start = s.len() - res;
+    }
+
+    if res == 1 {
+        return (0, 0);
+    }
+
+    (start, start + res)
+}

--- a/sdk/rust-examples/binary-subarray/longest-subarrays/src/main.rs
+++ b/sdk/rust-examples/binary-subarray/longest-subarrays/src/main.rs
@@ -1,0 +1,180 @@
+//! Longest Subarrays
+//!
+//! ## Context
+//!
+//! Reads user input, and then find the:-
+//! 1. Longest Alternating Subarray
+//! 2. Longest Zero Subarray
+//! 3. Longest One Subaray
+//! And then prints the output.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
+//! copyright information.
+
+use std::{fs, process};
+use anyhow;
+
+const FILENAME: &'static str = "/output/output.txt"; 
+
+fn main() -> anyhow::Result<()> {
+
+    let file_vec: Vec<u8> = fs::read(FILENAME)?;
+    let content: String = String::from_utf8_lossy(&file_vec).to_string();
+    // let content = String::from_utf8(fs::read(FILENAME)?)?;
+
+    // let my_vec: Vec<char> = content.chars().collect();
+
+    if content.len() < 3 {
+        process::exit(1);
+    }
+
+    let alter_string_ends: (usize, usize)  = longest_alternating_subarray(&content);
+    let zero_string_ends: (usize, usize)  = longest_zero_subarray(&content);
+    let one_string_ends: (usize, usize) = longest_one_subarray(&content);
+
+    let mut ret = String::new() ;
+
+    let start: usize = alter_string_ends.0 ;
+    let end: usize = alter_string_ends.1 - alter_string_ends.0 ;
+    let alter_string: &str = &content[start..end] ;
+
+    let start: usize = zero_string_ends.0 ;
+    let end: usize = zero_string_ends.1 - zero_string_ends.0 ;
+    let mut zero_string: &str = &content[start..end] ;
+
+    if zero_string == "" {
+        zero_string = "0";
+    }
+
+    let start: usize = one_string_ends.0 ;
+    let end: usize = one_string_ends.1 - one_string_ends.0 ;
+    let mut one_string: &str = &content[start..end] ;
+
+    if one_string == "" {
+        one_string = "1";
+    }
+
+    ret.push_str(alter_string) ;
+    ret.push_str("\n") ;
+    ret.push_str(zero_string) ;
+    ret.push_str("\n") ;
+    ret.push_str(one_string) ;
+    ret.push_str("\n") ;
+
+    fs::write(FILENAME, ret)?;
+
+    Ok(())
+}
+
+// fn longest_alternating_subarray( arr: &String ) -> String {
+    fn longest_alternating_subarray( s: &String ) -> (usize,usize) {
+        let bytes: &[u8] = s.as_bytes();
+    
+        let mut start: usize = 0;
+        let mut res: usize = 1;
+        let mut temp: usize = 1;
+    
+        for (i, &item) in bytes.iter().enumerate() {
+            if i == 0 {
+                continue;
+            }
+            if (item == b'1' && bytes[i-1] == b'0') || (item == b'0' && bytes[i-1] == b'1') {
+                temp += 1;
+            } else {
+                if res < temp {
+                    res = temp;
+                    start = i-res ;
+                } else {
+                    temp = 1 ;
+                }
+            }
+        }
+    
+        if res < temp {
+            res = temp;
+            start = s.len()-res ;
+        }
+    
+        if res == 1 {
+            return (0,0)
+        }
+        (start,start+res)
+    }
+    
+    // fn longest_zero_subarray( arr: &String ) -> String {
+    fn longest_zero_subarray( s: &String ) -> (usize,usize) {
+        let bytes: &[u8] = s.as_bytes();
+    
+        let mut start: usize = 0;
+        let mut res: usize = 1;
+        let mut temp: usize = 1;
+    
+        for (i, &item) in bytes.iter().enumerate() {
+            if i == 0 {
+                continue;
+            }
+            if item == b'0' && bytes[i-1] == b'0' {
+                temp += 1;
+            } else {
+                if res < temp {
+                    res = temp;
+                    start = i-res ;
+                } else {
+                    temp = 1 ;
+                }
+            }
+        }
+    
+        if res < temp {
+            res = temp;
+            start = s.len() - res ;
+        }
+        
+        if res == 1 {
+            return (0,0)
+        }
+    
+        (start,start+res)
+    }
+    
+    // fn longest_one_subarray( arr: &String ) -> String {
+    fn longest_one_subarray( s: &String ) -> (usize,usize) {
+        let bytes: &[u8] = s.as_bytes();
+    
+        let mut start: usize = 0;
+        let mut res: usize = 1;
+        let mut temp: usize = 1;
+    
+        for (i, &item) in bytes.iter().enumerate() {
+            if i == 0 {
+                continue;
+            }
+            if item == b'1' && bytes[i-1] == b'1' {
+                temp += 1;
+            } else {
+                if res < temp {
+                    res = temp;
+                    start = i-res ;
+                } else {
+                    temp = 1 ;
+                }
+            }
+        }
+    
+        if res < temp {
+            res = temp;
+            start = s.len() - res ;
+        }
+    
+        if res == 1 {
+            return (0,0)
+        }
+    
+        (start,start+res)
+    }


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
This example is with respect to the 2nd point in #377 issue.

The example consists of two programs:

1. binary-to-ascii: converts ascii input to binary output
2. longest-subarray: reads the binary output to find the longest subarrays: 1. alternating(0101) 2. zeroes(000) 3. ones(111)

I know there can be many errors in this, and I will work on each of them. This is to start the process of learning this type of examples.