### PR TITLE
WIP: Add Clippy linting 

### DIFF
--- a/sdk/rust-examples/prime-numbers-generator/README.markdown
+++ b/sdk/rust-examples/prime-numbers-generator/README.markdown
@@ -1,0 +1,30 @@
+# Prime Numbers Generator
+
+This program provides an example of executing multiple programs sequentially inside Veracruz `freestanding-execution-engine`, where each program's input depends on the previous' output. This is similar to the Linux pipeline `command1 | command2 | command3`. 
+
+This is a two-step program where the first step provides its output to the second program. The final output is the prime numbers between 2 and `upper_limit`, which you will specify . This is an implementation of the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes) algorithms. 
+
+- `generate-set`: this program generates all numbers from 2 to `upper_limit` 
+- `keep-primes`: this takes the set provided by the previous program, applies Sieve of Eratosthenes algorithms, and keeps only prime numbers
+
+Here are the steps for running these two programs inside Veracruz `freestanding-execution-engine`
+
+## Steps 
+1. You have to build the WASM binary for each program by running the following commands in each directory:
+  ```
+  rustup target add wasm32-wasi
+  cargo build --target wasm32-wasi
+  ```
+
+2. You will find the `.wasm` file in `target/wasm32-wasi/debug/` path inside each program. Copy the two `.wasm` files to `sdk/freestanding-execution-engine`.
+
+3. Inside `sdk/freestanding-execution-engine`, create a directory called `output` and another directory called `program`. 
+4. Move the two `.wasm` files inside the `program` directory.
+
+5. Run the following command
+```
+RUST_LOG="info" cargo run -- --arg 1000 --input-source program --program program/generate-set.wasm program/keep-primes.wasm --output-source output -e -d -c
+```
+you can change the number after `--arg` to change the `upper_limit` value.
+
+6. After the long log of information, you should see a file called `number-set.txt` inside the output directory. This file should contain all prime numbers between 2 and `upper_limit` .

--- a/sdk/rust-examples/prime-numbers-generator/generate-set/Cargo.toml
+++ b/sdk/rust-examples/prime-numbers-generator/generate-set/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "Generate all numbers from 2 to a specified upper limit and write them to a text file"
+name = "generate-set"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"
+

--- a/sdk/rust-examples/prime-numbers-generator/generate-set/src/main.rs
+++ b/sdk/rust-examples/prime-numbers-generator/generate-set/src/main.rs
@@ -1,0 +1,43 @@
+//! Prime Numbers Generator: Generate the number set
+//!
+//! ## Context
+//!
+//! Generate all numbers from 2 to the specified upper limit
+//! 
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
+//! copyright information.
+
+use std::fs;
+use anyhow;
+
+const OUTPUT_FILENAME: &'static str = "/output/number-set.txt";
+
+fn main() -> anyhow::Result<()> {
+    let mut set: Vec<u32> = Vec::new();
+
+    let args: Vec<String> = std::env::args().collect();
+
+    let upper_limit = args.get(0).unwrap_or(&String::from("100")).to_owned().parse::<u32>()?;
+
+    for i in 2..=upper_limit {
+        set.push(i);
+    }
+
+    let mut set_str: String = set
+        .iter()
+        .map(|num| num.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    set_str.push('\n');
+
+    fs::write(OUTPUT_FILENAME, set_str)?;
+
+    Ok(())
+}

--- a/sdk/rust-examples/prime-numbers-generator/keep-primes/Cargo.toml
+++ b/sdk/rust-examples/prime-numbers-generator/keep-primes/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "Remove all non-prime numbers from the number-set"
+name = "keep-primes"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"

--- a/sdk/rust-examples/prime-numbers-generator/keep-primes/src/main.rs
+++ b/sdk/rust-examples/prime-numbers-generator/keep-primes/src/main.rs
@@ -1,0 +1,75 @@
+//! Prime Numbers Generator : Remove all non-prime numbers
+//!
+//! ## Context
+//!
+//! Remove all non-prime numbers from the number-set
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSING.markdown` in the Veracruz root directory for licensing and
+//! copyright information.
+
+use std::fs;
+use anyhow;
+
+const FILENAME: &'static str = "/output/number-set.txt"; 
+
+fn main() -> anyhow::Result<()>{
+
+    let content = String::from_utf8(fs::read(FILENAME)?)?;
+    let mut num_vec = vec![];
+
+    for x in content.trim().split(",") {
+        if let Ok(n) = x.parse::<u32>() {
+            num_vec.push(n);
+        } else {
+            anyhow::bail!("Unable to parse {} as u32.", x);
+        }
+    }
+
+    sieve_of_eratosthenes(&mut num_vec)?;
+        
+    let mut content: String = num_vec
+        .iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(","); 
+   
+    // remove last comma, add end of line character
+    content.push('\n');
+
+    fs::write(FILENAME, content)?;
+    
+    Ok(())
+}
+
+// implements sieve_of_eratosthenes algorithm, and retain only prime numbers from nums
+fn sieve_of_eratosthenes(nums: &mut Vec<u32>) -> anyhow::Result<()> {
+    let n = (nums[nums.len() - 1] + 1) as usize;
+    let mut is_prime = vec![true; n];
+
+    let mut p: usize = 2;
+
+    while p * p <= n {
+        if is_prime[p] {
+            let mut i = p * 2;
+            while i < n {
+                is_prime[i] = false;
+                i += p;
+            } 
+        }
+        p += 1;
+    }
+
+    // exclude 0 and 1 
+    is_prime[0] = false;
+    is_prime[1] = false;
+
+    nums.retain(|&x| is_prime[x as usize]);
+
+    Ok(())
+}

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -91,5 +91,12 @@ clean:
 	cargo clean
 	rm -rf $(OUT_DIR)
 
+clippy: 
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-client -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p proxy-attestation-server -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-test -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server-test -- --no-deps
+
 clean-cargo-lock:
 	rm -f Cargo.lock


### PR DESCRIPTION
Add `clippy` target to Veracruz `Makefile`.  This links to #37 . I also provided a [proposal](https://github.com/veracruz-project/veracruz/issues/37#issuecomment-1107194941) for my working plan. I would really appreciate everyone's input on this.
 
This PR is not for fixing `clippy` warnings, but for providing a project wide `clippy` configurations and targets. I think after that I would start fixing these warnings crate-by-crate.

### Progress so far

- [x] added `clippy` target to `workspaces/linux-host`, with warnings generated only from its members.