### PR TITLE
Add Clippy linting

### DIFF
--- a/veracruz-utils/src/csr.rs
+++ b/veracruz-utils/src/csr.rs
@@ -227,7 +227,8 @@ pub fn generate_csr(
     template: &CsrTemplate,
     private_key: &EcdsaKeyPair,
 ) -> Result<Vec<u8>, CertError> {
-    let public_key = private_key.public_key().as_ref().clone();
+    #[allow(clippy::clone_double_ref)]
+    let public_key =  private_key.public_key().as_ref().clone();
     let mut constructed_csr = template.template.to_vec();
     if public_key.len() != (template.public_key_location.1 - template.public_key_location.0) {
         return Err(CertError::InvalidLength {

--- a/veracruz-utils/src/csr.rs
+++ b/veracruz-utils/src/csr.rs
@@ -227,8 +227,7 @@ pub fn generate_csr(
     template: &CsrTemplate,
     private_key: &EcdsaKeyPair,
 ) -> Result<Vec<u8>, CertError> {
-    #[allow(clippy::clone_double_ref)]
-    let public_key =  private_key.public_key().as_ref().clone();
+    let public_key = private_key.public_key().as_ref();
     let mut constructed_csr = template.template.to_vec();
     if public_key.len() != (template.public_key_location.1 - template.public_key_location.0) {
         return Err(CertError::InvalidLength {

--- a/workspaces/Makefile
+++ b/workspaces/Makefile
@@ -48,6 +48,17 @@ linux-install: shared-install
 shared-install:
 	$(MAKE) -C host install
 
+linux-clippy:
+	make -C linux-runtime clippy
+	make -C linux-host clippy
+
+nitro-clippy:
+	make -C nitro-runtime clippy
+	make -C nitro-host clippy
+
+icecap-clippy:
+	make -C icecap-host clippy
+
 linux-clean:
 	$(MAKE) -C linux-host clean
 	$(MAKE) -C linux-runtime clean

--- a/workspaces/Makefile
+++ b/workspaces/Makefile
@@ -13,8 +13,8 @@ default:
 
 include common.mk
 
-.PHONY: all clean icecap icecap-clean linux linux-install linux-clean nitro \
-	nitro-clean shared shared-install shared-clean
+.PHONY: all clean icecap icecap-clippy icecap-clean linux linux-install linux-clippy \
+	linux-clean nitro-clippy nitro-clean shared shared-install shared-clean
 
 all: shared linux nitro icecap
 

--- a/workspaces/Makefile
+++ b/workspaces/Makefile
@@ -14,7 +14,7 @@ default:
 include common.mk
 
 .PHONY: all clean icecap icecap-clippy icecap-clean linux linux-install linux-clippy \
-	linux-clean nitro-clippy nitro-clean shared shared-install shared-clean
+	linux-clean nitro nitro-clippy nitro-clean shared shared-install shared-clean
 
 all: shared linux nitro icecap
 

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSING.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
 
-.PHONY: all build clean clean-cargo-lock default doc clippy fmt clippy \
+.PHONY: all build clean clean-cargo-lock default doc fmt clippy \
 	test-dependencies test-collateral test-server test-client veracruz-test \
 	tests
 

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -9,9 +9,9 @@
 # See the `LICENSING.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
 
-.PHONY: all build clean clean-cargo-lock default doc fmt \
-	test-dependencies test-collateral test-server test-client veracruz-test \
-	tests
+.PHONY: all build clean clean-cargo-lock default doc fmt clippy \
+				test-dependencies test-collateral test-server test-client veracruz-test \
+				tests
 
 default: build
 

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSING.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
 
-.PHONY: all build clean clean-cargo-lock default doc fmt clippy \
+.PHONY: all build clean clean-cargo-lock default doc clippy fmt clippy \
 				test-dependencies test-collateral test-server test-client veracruz-test \
 				tests
 
@@ -112,7 +112,7 @@ clippy:
 	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) \
 		-p proxy-attestation-server -p veracruz-client \
 		-p veracruz-server -p io-utils -p transport-protocol \
-		-p psa-attestation -p veracruz-utils  \
+		-p psa-attestation -p veracruz-utils \
 		--features proxy-attestation-server/icecap \
 		--features veracruz-client/icecap \
 		--features veracruz-server/icecap \

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -107,6 +107,13 @@ doc:
 fmt:
 	cargo fmt
 
+clippy:
+	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p proxy-attestation-server -- --no-deps
+	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-client -- --no-deps
+	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-server -- --no-deps
+	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-server-test -- --no-deps 
+	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-test -- --no-deps 
+
 clean:
 	cargo clean
 	rm -rf $(OUT_DIR)

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -10,8 +10,8 @@
 # licensing and copyright information.
 
 .PHONY: all build clean clean-cargo-lock default doc clippy fmt clippy \
-				test-dependencies test-collateral test-server test-client veracruz-test \
-				tests
+	test-dependencies test-collateral test-server test-client veracruz-test \
+	tests
 
 default: build
 

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -108,11 +108,14 @@ fmt:
 	cargo fmt
 
 clippy:
+	# workspace members
 	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p proxy-attestation-server -- --no-deps
 	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-client -- --no-deps
 	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-server -- --no-deps
 	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-server-test -- --no-deps 
 	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-test -- --no-deps 
+	# veracruz dependencies
+	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p io-utils -- --no-deps
 
 clean:
 	cargo clean

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -108,14 +108,25 @@ fmt:
 	cargo fmt
 
 clippy:
-	# workspace members
-	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p proxy-attestation-server -- --no-deps
-	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-client -- --no-deps
-	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p veracruz-server -- --no-deps
-	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-server-test -- --no-deps 
-	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests --features icecap -p veracruz-test -- --no-deps 
-	# veracruz dependencies
-	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) --features icecap -p io-utils -- --no-deps
+	# workspace members and relevant dependencies
+	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) \
+		-p proxy-attestation-server -p veracruz-client \
+		-p veracruz-server -p io-utils -p transport-protocol \
+		-p psa-attestation -p veracruz-utils  \
+		--features proxy-attestation-server/icecap \
+		--features veracruz-client/icecap \
+		--features veracruz-server/icecap \
+		--features transport-protocol/icecap \
+		--features io-utils/icecap \
+		--features psa-attestation/icecap \
+		--features veracruz-utils/icecap \
+		-- --no-deps
+	# workspace testing crates
+	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests \
+		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
+		--features veracruz-test/icecap \
+		--features veracruz-server-test/icecap \
+		-- --no-deps
 
 clean:
 	cargo clean

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -80,11 +80,15 @@ $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
 clippy: 
+	# workspace members
 	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-client -- --no-deps
 	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p proxy-attestation-server -- --no-deps
 	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server -- --no-deps
 	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-test -- --no-deps
 	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server-test -- --no-deps
+	# veracruz dependencies
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p io-utils -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p psa-attestation -- --no-deps
 
 doc:
 	cargo doc

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -10,8 +10,8 @@
 # licensing and copyright information.
 
 .PHONY: all build install clean clean-cargo-lock default doc fmt clippy \
-				test-dependencies test-collateral test-server test-client veracruz-test \
-				tests
+	test-dependencies test-collateral test-server test-client veracruz-test \
+	tests
 
 default: build
 

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -9,9 +9,9 @@
 # See the `LICENSING.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
 
-.PHONY: all build install clean clean-cargo-lock default doc fmt \
-	test-dependencies test-collateral test-server test-client veracruz-test \
-	tests
+.PHONY: all build install clean clean-cargo-lock default doc fmt clippy \
+				test-dependencies test-collateral test-server test-client veracruz-test \
+				tests
 
 default: build
 
@@ -78,6 +78,13 @@ veracruz-test: test-dependencies
 
 $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
+
+clippy: 
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-client -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p proxy-attestation-server -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-test -- --no-deps
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server-test -- --no-deps
 
 doc:
 	cargo doc

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -80,15 +80,27 @@ $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
 clippy: 
-	# workspace members
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-client -- --no-deps
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p proxy-attestation-server -- --no-deps
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server -- --no-deps
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-test -- --no-deps
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) cargo clippy --tests $(PROFILE_FLAG) $(V_FLAG) --features linux -p veracruz-server-test -- --no-deps
-	# veracruz dependencies
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p io-utils -- --no-deps
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features linux -p psa-attestation -- --no-deps
+	# workspace members and relevant dependencies
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) \
+	$(CC) \
+		cargo clippy $(PROFILE_FLAG) $(V_FLAG) \
+		-p proxy-attestation-server -p veracruz-client \
+		-p veracruz-server -p io-utils -p transport-protocol \
+		-p psa-attestation -p veracruz-utils  \
+		--features proxy-attestation-server/linux \
+		--features veracruz-client/linux \
+		--features veracruz-server/linux \
+		--features io-utils/linux \
+		--features psa-attestation/linux \
+		--features veracruz-utils/linux \
+		-- --no-deps
+	# workspace testing crates
+	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) $(CC) $(TEST_PARAMETERS) \
+		cargo clippy --tests \
+		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
+		--features veracruz-test/linux \
+		--features veracruz-server-test/linux \
+		-- --no-deps
 
 doc:
 	cargo doc

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -27,6 +27,17 @@ runtime-manager-enclave:
 doc:
 	cargo doc
 
+clippy:
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) \
+		-p runtime_manager_enclave -p execution-engine \
+		-p session-manager -p policy-utils -p platform-services \
+		--features runtime_manager_enclave/linux \
+		--features execution-engine/std \
+		--features session-manager/std \
+		--features policy-utils/std \
+		--features platform-services/std \
+		-- --no-deps 
+
 fmt:
 	cargo fmt
 

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz root director for licensing
 # and copyright information.
 
-.PHONY: all clean clean-cargo-lock doc fmt linux runtime-manager-enclave
+.PHONY: all clean clean-cargo-lock doc fmt clippy linux runtime-manager-enclave
 
 default: all
 

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -70,19 +70,24 @@ fmt:
 	cargo fmt
 
 clippy: 
-	# workspace members
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-client -- --no-deps
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p proxy-attestation-server -- --no-deps
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-server -- --no-deps
-	RUNTIME_MANAGER_EIF_PATH=/work/veracruz/workspaces/nitro-runtime/runtime_manager.eif \
-		cargo clippy --tests $(PROFILE_FLAG) --features nitro \
-		-p veracruz-test -- \
-		--no-deps
-	RUNTIME_MANAGER_EIF_PATH=$(EIF_PATH) \
-		cargo clippy --tests $(PROFILE_FLAG) --features nitro  -p veracruz-server-test -- --no-deps
-	# veracruz dependencies
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p io-utils -- --no-deps
-	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p psa-attestation -- --no-deps
+	# workspace members and relevant dependencies
+	$(CC) cargo clippy $(PROFILE_FLAG) $(V_FLAG) \
+		-p proxy-attestation-server -p veracruz-client \
+		-p veracruz-server -p io-utils -p transport-protocol \
+		-p psa-attestation -p veracruz-utils  \
+		--features proxy-attestation-server/nitro\
+		--features veracruz-client/nitro \
+		--features veracruz-server/nitro \
+		--features io-utils/nitro \
+		--features psa-attestation/nitro \
+		--features veracruz-utils/nitro \
+		-- --no-deps
+	# workspace testing crates
+	RUNTIME_MANAGER_EIF_PATH=$(EIF_PATH) $(CC) $(TEST_PARAMETERS) cargo clippy --tests \
+		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
+		--features veracruz-test/nitro \
+		--features veracruz-server-test/nitro \
+		-- --no-deps
 
 clean:
 	cargo clean

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSING.markdown` file in the Veracruz root directory for
 # licensing and copyright information.
 
-.PHONY: all build clean clean-cargo-lock doc fmt \
+.PHONY: all build clean clean-cargo-lock doc fmt clippy \
 	test-client test-collateral test-dependencies test-server veracruz-test
 
 default: build

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -69,6 +69,20 @@ doc:
 fmt:
 	cargo fmt
 
+clippy: 
+	# source code
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-client -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p proxy-attestation-server -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-server -- --no-deps
+	# veracruz-test 
+	RUNTIME_MANAGER_EIF_PATH=/work/veracruz/workspaces/nitro-runtime/runtime_manager.eif \
+		cargo clippy --tests $(PROFILE_FLAG) --features nitro \
+		-p veracruz-test -- \
+		--no-deps
+	# veracruz-server-test
+	RUNTIME_MANAGER_EIF_PATH=$(EIF_PATH) \
+		cargo clippy --tests $(PROFILE_FLAG) --features nitro  -p veracruz-server-test -- --no-deps
+
 clean:
 	cargo clean
 	rm -rf $(OUT_DIR)

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -70,18 +70,19 @@ fmt:
 	cargo fmt
 
 clippy: 
-	# source code
+	# workspace members
 	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-client -- --no-deps
 	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p proxy-attestation-server -- --no-deps
 	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p veracruz-server -- --no-deps
-	# veracruz-test 
 	RUNTIME_MANAGER_EIF_PATH=/work/veracruz/workspaces/nitro-runtime/runtime_manager.eif \
 		cargo clippy --tests $(PROFILE_FLAG) --features nitro \
 		-p veracruz-test -- \
 		--no-deps
-	# veracruz-server-test
 	RUNTIME_MANAGER_EIF_PATH=$(EIF_PATH) \
 		cargo clippy --tests $(PROFILE_FLAG) --features nitro  -p veracruz-server-test -- --no-deps
+	# veracruz dependencies
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p io-utils -- --no-deps
+	cargo clippy $(PROFILE_FLAG) $(V_FLAG) --features nitro -p psa-attestation -- --no-deps
 
 clean:
 	cargo clean

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -45,6 +45,20 @@ runtime-manager-enclave:
 doc:
 	cargo doc
 
+clippy:
+	rustup target add $(ARCH)-unknown-linux-musl
+	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
+	cargo clippy --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
+		-p runtime_manager_enclave -p execution-engine \
+		-p session-manager -p policy-utils -p platform-services \
+		--features runtime_manager_enclave/nitro  \
+		--features execution-engine/nitro  \
+		--features session-manager/nitro \
+		--features policy-utils/std \
+		--features platform-services/nitro \
+		-- --no-deps
+
+
 fmt:
 	cargo fmt
 

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -9,7 +9,7 @@
 # See the `LICENSE_MIT.markdown` file in the Veracruz root director for licensing
 # and copyright information.
 
-.PHONY: all clean clean-cargo-lock default doc fmt nitro test-collateral runtime-manager-enclave
+.PHONY: all clean clean-cargo-lock default doc fmt clippy nitro test-collateral runtime-manager-enclave
 
 default: all
 
@@ -51,13 +51,12 @@ clippy:
 	cargo clippy --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
 		-p runtime_manager_enclave -p execution-engine \
 		-p session-manager -p policy-utils -p platform-services \
-		--features runtime_manager_enclave/nitro  \
+		--features runtime_manager_enclave/nitro \
 		--features execution-engine/nitro  \
 		--features session-manager/nitro \
 		--features policy-utils/std \
 		--features platform-services/nitro \
 		-- --no-deps
-
 
 fmt:
 	cargo fmt


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

```

Add `clippy` target to Veracruz `Makefile`.  This links to #37 . I also provided a [proposal](https://github.com/veracruz-project/veracruz/issues/37#issuecomment-1107194941) for my working plan. I would really appreciate everyone's input while I am working on this
 
This PR is not mainly for fixing `clippy` warnings, but for providing a project wide `clippy` configurations and targets. I think after that I would start fixing these warnings crate-by-crate.

### workspaces covered so far

 `linux-host` , `nitro-host` , `icecap-host` , `linux-runtime` , `nitro-runtime`

### crates covered so far
`veracruz-client` , `veracruz-server` , `proxy-attestation-server` , `veracruz-test` , `veracruz-server-test` , `io-utils` , `psa-attestation` , `veracruz-utils` , `transport-protocol` , `runtime-manager` , `execution-engine` , `session-manager` , `policy-utils` , `platform-services` 