### PR TITLE
Add "test-server" to "icecap" test and remove PROFILE=dev.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Running IceCap test script
         id: icecap-build
         run: |
-            make -C /work/veracruz/workspaces/icecap-host test-client veracruz-test veracruz-test PROFILE=dev
+            make -C /work/veracruz/workspaces/icecap-host test-client test-server veracruz-test PROFILE=dev
 
   # tests that the CLI_QUICKSTART.markdown is still up to date
   quickstart:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Running IceCap test script
         id: icecap-build
         run: |
-            make -C /work/veracruz/workspaces/icecap-host test-client test-server veracruz-test PROFILE=dev
+            VERACRUZ_TEST_TIMEOUT=2400 make -C /work/veracruz/workspaces/icecap-host test-client test-server veracruz-test
 
   # tests that the CLI_QUICKSTART.markdown is still up to date
   quickstart:


### PR DESCRIPTION
There was a typo:

    test-client veracruz-test veracruz-test

instead of:

    test-client test-server veracruz-test

But it turns out that `test-server` is very slow with `PROFILE=dev`, so this is removed, though it would be good to understand why it is so slow and perhaps put it back one day.