### PR TITLE
Bump versions of library dependencies to fix security vulnerabilities identified by dependabot

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0"
 typetag = "=0.1.6"
 wasi-types = { path = "../third-party/wasi-types" }
 wasmi = { path = "../third-party/wasmi" }
-wasmtime = { version = "0.27", optional = true }
+wasmtime = { version = "0.34.2", optional = true }
 
 [lib]
 name = "execution_engine"

--- a/io-utils/Cargo.toml
+++ b/io-utils/Cargo.toml
@@ -20,7 +20,7 @@ curl = "0.4.43"
 socket2 = "=0.4.2"
 err-derive = "0.2"
 log = "0.4.13"
-nix = { version = "0.15", optional = true }
+nix = { version = "0.22.2", optional = true }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true }
 stringreader = "0.1"

--- a/platform-services/Cargo.toml
+++ b/platform-services/Cargo.toml
@@ -18,6 +18,6 @@ path = "./src/lib.rs"
 [dependencies]
 cfg-if = "1"
 getrandom = { version = "0.1.14", optional = true }
-nix = { version = "0.22", optional = true }
+nix = { version = "0.22.2", optional = true }
 nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -86,7 +86,7 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libc = { version = "0.2.108", optional = true }
 libm = { version = "0.2", optional = true }
 log = { version = "0.4.13", optional = true }
-nix = { version = "0.15", optional = true }
+nix = { version = "0.22.2", optional = true }
 nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "aws-nitro-enclaves-nsm-api", optional = true }
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-lib", optional = true }
 policy-utils = { path = "../policy-utils" }

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -58,7 +58,7 @@ hex = "0.4.2"
 io-utils = { path = "../io-utils", optional = true }
 lazy_static = "1.4"
 log = "0.4.13"
-nix = { version = "0.15", optional = true }
+nix = { version = "0.22.2", optional = true }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }


### PR DESCRIPTION
Fixed all problematic libraries that we rely on *directly*, and which dependabot identified as having issues.  All other issues seem to be caused by transitive dependencies which I'll fix in another PR.