### PR TITLE
Update IceCap RealmOS and make tests more reliable

### DIFF
--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -341,6 +341,6 @@ If we are done running computations, we can take down the Veracruz servers
 with a pkill command:
 
 ``` bash
-$ pkill vc-server
-$ pkill vc-pas
+$ pkill vc-server || true
+$ pkill vc-pas || true
 ```

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -24,7 +24,10 @@ cli = ["structopt"]
 # a feature to enable PSA native attestation.
 # Note: Final attestation is always PSA. This is just to enable platforms
 # that use PSA for their native attestation.
-icecap = ["psa-attestation/icecap"]
+icecap = [
+  "psa-attestation/icecap",
+  "openssl/vendored",
+]
 linux = ["psa-attestation/linux"]
 nitro = [
   "nitro-enclave-attestation-document",
@@ -47,6 +50,7 @@ err-derive = "0.2"
 hex = "0.4.2"
 http = "=0.2.4"
 lazy_static = "1.3"
+libsqlite3-sys = { version = "*", features = ["bundled"] }
 log = "0.4.13"
 nb-connect = "1.0.3"
 nitro-enclave-attestation-document = { path = "../third-party/nitro-enclave-attestation-document", optional = true }

--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -36,6 +36,7 @@ icecap = [
   "transport-protocol/icecap",
   "veracruz-utils/icecap",
 ]
+icecap-lkvm = []
 icecap-qemu = []
 linux = [
   "bincode",

--- a/scripts/icecap-git-reset.sh
+++ b/scripts/icecap-git-reset.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $(dirname $(realpath $0)))
+
+git submodule update --init --recursive
+
+(cd icecap/icecap ; git stash ; git fetch ; git checkout realmos ; git branch -M backup-$(date +%Y-%m-%d-%H%M%S) ; git checkout -B realmos origin/realmos)
+(cd workspaces/icecap-runtime/deps/seL4 ; git stash ; git fetch ; git checkout realmos ; git branch -M backup-$(date +%Y-%m-%d-%H%M%S) ; git checkout -B realmos origin/realmos)
+(cd workspaces/icecap-runtime/deps/seL4_tools ; git stash ; git fetch ; git checkout realmos ; git branch -M backup-$(date +%Y-%m-%d-%H%M%S) ; git checkout -B realmos origin/realmos)

--- a/scripts/icecap-git-reset.sh
+++ b/scripts/icecap-git-reset.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+#
+# Development script to update IceCap/seL4 git submodules.
+#
+## Authors
+#
+# The Veracruz Development Team.
+#
+## Licensing and copyright notice
+#
+# See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
+# information on licensing and copyright.
 
 set -e
 

--- a/veracruz-server-test/Cargo.toml
+++ b/veracruz-server-test/Cargo.toml
@@ -18,6 +18,8 @@ icecap = [
   "veracruz-server/icecap",
   "veracruz-utils/icecap",
 ]
+icecap-lkvm = ["veracruz-server/icecap-lkvm"]
+icecap-qemu = ["veracruz-server/icecap-qemu"]
 linux = [
   "policy-utils/std",
   "proxy-attestation-server/linux",

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -28,6 +28,7 @@ icecap = [
   "signal-hook",
   "veracruz-utils/icecap",
 ]
+icecap-lkvm = []
 icecap-qemu = []
 linux = [
   "data-encoding",

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -2052,6 +2052,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2471,6 +2472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2489,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2777,6 +2788,7 @@ dependencies = [
  "hex",
  "http 0.2.4",
  "lazy_static",
+ "libsqlite3-sys",
  "log",
  "nb-connect",
  "nitro-enclave-attestation-document",

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -30,9 +30,11 @@ include $(WORKSPACE_DIR)/shared.mk
 # NOTE this file must define:
 #  variables:
 #   - host_feature_flags
+#  rules:
+#   - rustup-plat
 include mk/$(icecap_plat).mk
 
-COMPILERS = CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc
+COMPILERS ?= CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc
 
 VERACRUZ_ICECAP_QEMU_IMAGE = $(WORKSPACE_DIR)/icecap-runtime/build/$(icecap_plat)/disposable/cmake/elfloader/build/elfloader
 
@@ -46,7 +48,7 @@ TEST_PARAMETERS = VERACRUZ_ICECAP_QEMU_IMAGE=$(VERACRUZ_ICECAP_QEMU_IMAGE) \
 
 all: build test-collateral
 
-build: $(VERACRUZ_ICECAP_QEMU_IMAGE)
+build: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 	$(COMPILERS) $(BUILD_PARAMETERS) \
 		cargo build $(PROFILE_FLAG) \
 		-p proxy-attestation-server \

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -60,6 +60,23 @@ build: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 		$(host_feature_flags) \
 		$(V_FLAG)
 
+build-veracruz-server-test: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
+	$(COMPILERS) $(BUILD_PARAMETERS) \
+		cargo test --no-run $(PROFILE_FLAG) \
+		-p veracruz-server-test \
+		--features icecap \
+		$(host_feature_flags) \
+		$(V_FLAG)
+	cp $$( \
+		$(COMPILERS) $(BUILD_PARAMETERS) \
+			cargo test --no-run $(PROFILE_FLAG) \
+			-p veracruz-server-test \
+			--features icecap \
+			$(host_feature_flags) \
+			$(V_FLAG) \
+			--message-format=json | jq -r '.executable | select(.)' \
+		) target/release/veracruz-server-test
+
 .PHONY: $(MEASUREMENT_FILE)
 $(MEASUREMENT_FILE):
 	$(MAKE) -C ../icecap-runtime elfloader css-icecap.bin ICECAP_PLAT=$(ICECAP_PLAT)

--- a/workspaces/icecap-host/mk/lkvm.mk
+++ b/workspaces/icecap-host/mk/lkvm.mk
@@ -10,7 +10,8 @@
 
 host_feature_flags := --features icecap-lkvm --target aarch64-unknown-linux-gnu
 
-COMPILERS = CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+COMPILERS = CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+	    RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-feature=+crt-static"
 
 rustup-plat:
 	rustup target add aarch64-unknown-linux-gnu

--- a/workspaces/icecap-host/mk/lkvm.mk
+++ b/workspaces/icecap-host/mk/lkvm.mk
@@ -13,5 +13,6 @@ host_feature_flags := --features icecap-lkvm --target aarch64-unknown-linux-gnu
 COMPILERS = CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
 	    RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-feature=+crt-static"
 
+.PHONY: rustup-plat
 rustup-plat:
 	rustup target add aarch64-unknown-linux-gnu

--- a/workspaces/icecap-host/mk/lkvm.mk
+++ b/workspaces/icecap-host/mk/lkvm.mk
@@ -7,4 +7,10 @@
 # See the `LICENSE.markdown` file in the Veracruz root directory for licensing
 # and copyright information.
 
-host_feature_flags := --features icecap-lkvm
+
+host_feature_flags := --features icecap-lkvm --target aarch64-unknown-linux-gnu
+
+COMPILERS = CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+
+rustup-plat:
+	rustup target add aarch64-unknown-linux-gnu

--- a/workspaces/icecap-host/mk/qemu.mk
+++ b/workspaces/icecap-host/mk/qemu.mk
@@ -8,3 +8,7 @@
 # and copyright information.
 
 host_feature_flags := --features icecap-qemu
+
+.PHONY: rustup-plat
+
+rustup-plat:

--- a/workspaces/icecap-runtime/Makefile
+++ b/workspaces/icecap-runtime/Makefile
@@ -89,7 +89,6 @@ none:
 #  variables:
 #   - sel4_kernel_platform
 #   - sel4_dts_path
-#   - runtime_feature_flags
 #  rules:
 #   - clean-plat
 include mk/$(icecap_plat).mk
@@ -99,6 +98,7 @@ include mk/$(icecap_plat).mk
 #   - manifest_path
 #   - cdl_script_path
 #   - icedl_components
+#   - project_feature_flags
 include $(PROJECT)/icecap.mk
 
 mk_dirs := $(sel4_build_dir) $(elfloader_build_dir) $(misc_build_dir)
@@ -233,10 +233,10 @@ icecap_rustflags := \
 rust-project: $(now) sysroot-install userspace_c sel4
 	RUST_TARGET_PATH=$(abspath icecap/src/rust/support/targets) \
 		cargo tree \
-			--manifest-path Cargo.toml --target $(rust_target) \
+			--manifest-path $(manifest_path) --target $(rust_target) \
 			-v --charset ascii -f "{p} {f}" \
 			$(foreach x,$(icedl_components),-p $(x)) \
-			 --features icecap > $(build_dir)/tree.txt ; \
+			$(project_feature_flags) > $(build_dir)/tree.txt ; \
 	RUST_TARGET_PATH=$(abspath icecap/src/rust/support/targets) \
 	$(call cargo_target_config_prefix,$(rust_target))RUSTFLAGS="$(icecap_rustflags)" \
 	$(call cargo_target_config_prefix,$(rust_target))LINKER="$(LD)" \
@@ -244,10 +244,10 @@ rust-project: $(now) sysroot-install userspace_c sel4
 	BINDGEN_EXTRA_CLANG_ARGS="$(icecap_c_include_flags) -I$(compiler_some_libc_include) -I/usr/aarch64-linux-gnu/include" \
 		cargo build \
 			-Z unstable-options \
-			--manifest-path Cargo.toml \
+			--manifest-path $(manifest_path) \
 			--target $(rust_target) \
+			$(project_feature_flags) \
 			$(foreach x,$(icedl_components),-p $(x)) \
-			--features icecap $(runtime_feature_flags) \
 			$(PROFILE_FLAG) $(V_FLAG) \
 			-j$$(nproc) \
 			--target-dir $(target_dir) \

--- a/workspaces/icecap-runtime/cdl/composition.py
+++ b/workspaces/icecap-runtime/cdl/composition.py
@@ -4,11 +4,16 @@ import os
 
 from icecap_framework import BaseComposition
 from runtime_manager import RuntimeManager
-from virtio_console_server import VirtioConsoleServer
+from virtio_console_server import QemuVirtioConsoleServer, LkvmVirtioConsoleServer
 
 class Composition(BaseComposition):
     def compose(self):
-        self.virtio_console_server = self.component(VirtioConsoleServer, 'virtio_console_server')
+        if self.plat == 'qemu':
+            self.virtio_console_server = self.component(QemuVirtioConsoleServer, 'virtio_console_server')
+        elif self.plat == 'lkvm':
+            self.virtio_console_server = self.component(LkvmVirtioConsoleServer, 'virtio_console_server')
+        else:
+            raise Exception("Unsupported platform '%s'" % (self.plat))
         self.component(RuntimeManager, 'runtime_manager')
 
 parser = ArgumentParser()
@@ -39,7 +44,6 @@ config = {
                 "full": os.path.join(components_path, "virtio-console-server.full.elf"),
                 "min": os.path.join(components_path, "virtio-console-server.min.elf"),
             }
-
         },
     }
 }

--- a/workspaces/icecap-runtime/cdl/composition.py
+++ b/workspaces/icecap-runtime/cdl/composition.py
@@ -4,16 +4,11 @@ import os
 
 from icecap_framework import BaseComposition
 from runtime_manager import RuntimeManager
-from virtio_console_server import QemuVirtioConsoleServer, LkvmVirtioConsoleServer
+from virtio_console_server import VirtioConsoleServer
 
 class Composition(BaseComposition):
     def compose(self):
-        if self.plat == 'qemu':
-            self.virtio_console_server = self.component(QemuVirtioConsoleServer, 'virtio_console_server')
-        elif self.plat == 'lkvm':
-            self.virtio_console_server = self.component(LkvmVirtioConsoleServer, 'virtio_console_server')
-        else:
-            raise Exception("Unsupported platform '%s'" % (self.plat))
+        self.virtio_console_server = self.component(VirtioConsoleServer, 'virtio_console_server')
         self.component(RuntimeManager, 'runtime_manager')
 
 parser = ArgumentParser()
@@ -44,6 +39,7 @@ config = {
                 "full": os.path.join(components_path, "virtio-console-server.full.elf"),
                 "min": os.path.join(components_path, "virtio-console-server.min.elf"),
             }
+
         },
     }
 }

--- a/workspaces/icecap-runtime/cdl/virtio_console_server.py
+++ b/workspaces/icecap-runtime/cdl/virtio_console_server.py
@@ -10,13 +10,13 @@ MMIO_BLOCK_SIZE = 512
 VIRTIO_PARAMS = {
     "qemu": {
         "paddr": 0xa000000,
-        "irq": 0x20 + 0x10,
+        "irq": 0x10 + 0x20,
         "count": 32,
         "poolsize": 32 * 4096,
     },
     "lkvm": {
         "paddr": 0x10000,
-        "irq": 0x20 + 0x10,
+        "irq": 0x10 + 0x4,
         "count": 32,
         "poolsize": 32 * 4096,
     }

--- a/workspaces/icecap-runtime/cdl/virtio_console_server.py
+++ b/workspaces/icecap-runtime/cdl/virtio_console_server.py
@@ -10,14 +10,14 @@ MMIO_BLOCK_SIZE = 512
 VIRTIO_PARAMS = {
     "qemu": {
         "paddr": 0xa000000,
-        "irq": 0x10 + 0x20,
+        "irq": 0x20 + 0x10,
         "count": 32,
         "poolsize": 32 * 4096,
     },
     "lkvm": {
         "paddr": 0x10000,
-        "irq": 0x10 + 0x4,
-        "count": 32,
+        "irq": 0x20 + 0x4,
+        "count": 1,
         "poolsize": 32 * 4096,
     }
 }

--- a/workspaces/icecap-runtime/icecap.mk
+++ b/workspaces/icecap-runtime/icecap.mk
@@ -3,4 +3,7 @@ manifest_path = $(abspath $(PROJECT)/Cargo.toml)
 cdl_script_path = $(abspath $(PROJECT)/cdl/composition.py)
 
 icedl_components := \
-	runtime_manager_enclave virtio-console-server
+	runtime_manager_enclave \
+	virtio-console-server
+
+project_feature_flags := --features icecap --features icecap-$(icecap_plat)

--- a/workspaces/icecap-runtime/mk/lkvm.mk
+++ b/workspaces/icecap-runtime/mk/lkvm.mk
@@ -11,7 +11,7 @@ sel4_kernel_platform := lkvm
 
 sel4_dts_path := $(sel4_src)/tools/dts/lkvm.dts
 
-runtime_feature_flags := --features icecap-qemu
+runtime_feature_flags := --features icecap-lkvm
 
 .PHONY: clean-plat
 clean-plat:

--- a/workspaces/icecap-runtime/mk/lkvm.mk
+++ b/workspaces/icecap-runtime/mk/lkvm.mk
@@ -11,8 +11,6 @@ sel4_kernel_platform := lkvm
 
 sel4_dts_path := $(sel4_src)/tools/dts/lkvm.dts
 
-runtime_feature_flags := --features icecap-lkvm
-
 .PHONY: clean-plat
 clean-plat:
 

--- a/workspaces/icecap-runtime/mk/qemu.mk
+++ b/workspaces/icecap-runtime/mk/qemu.mk
@@ -13,8 +13,6 @@ system := $(disposable_dir)/system
 
 sel4_dts_path := $(sel4_src)/tools/dts/virt.dts
 
-runtime_feature_flags := --features icecap-qemu
-
 .PHONY: clean-plat
 clean-plat:
 	rm -f $(sel4_dts_path)

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -129,6 +129,12 @@ pub unsafe extern "C" fn virtio_virt_to_phys(vaddr: usize) -> usize {
 
 // entry point
 fn main(config: Config) -> Fallible<()> {
+    // FIXME: Yield 10 times to let the runtime start before the console server
+    for i in 1..10 {
+        // debug_println!("Yield {}", i);
+        icecap_core::sel4::yield_();
+    }
+
     // setup the virtio pool
     unsafe {
         VIRTIO_POOL = Some(VirtioPool::new(

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -130,8 +130,7 @@ pub unsafe extern "C" fn virtio_virt_to_phys(vaddr: usize) -> usize {
 // entry point
 fn main(config: Config) -> Fallible<()> {
     // FIXME: Yield 10 times to let the runtime start before the console server
-    for i in 1..10 {
-        // debug_println!("Yield {}", i);
+    for _i in 1..10 {
         icecap_core::sel4::yield_();
     }
 

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -2052,6 +2052,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2471,6 +2472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2489,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2777,6 +2788,7 @@ dependencies = [
  "hex",
  "http 0.2.4",
  "lazy_static",
+ "libsqlite3-sys",
  "log",
  "nb-connect",
  "nitro-enclave-attestation-document",

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -2052,6 +2052,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2471,6 +2472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2489,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2777,6 +2788,7 @@ dependencies = [
  "hex",
  "http 0.2.4",
  "lazy_static",
+ "libsqlite3-sys",
  "log",
  "nb-connect",
  "nitro-enclave-attestation-document",


### PR DESCRIPTION
- Include latest IceCap RealmOS updates
- Work-around for runtime-manager/console-server race-condition (#429)
- Fix for `pkill` status code in `quickstart` GitHub Actions job