### PR TITLE
IceCap: Improve ring buffer stability

### DIFF
--- a/runtime-manager/src/runtime_manager_icecap.rs
+++ b/runtime-manager/src/runtime_manager_icecap.rs
@@ -98,7 +98,7 @@ impl RuntimeManager {
             let badge = self.event.wait();
             if badge & self.virtio_console_server_rx_badge != 0 {
                 self.process()?;
-                self.rb.ring_buffer().enable_notify_write();
+                self.rb.rx_callback();
 
                 if !self.active {
                     return Ok(());
@@ -107,7 +107,6 @@ impl RuntimeManager {
 
             // always handle tx operations
             self.rb.tx_callback();
-            self.rb.ring_buffer().enable_notify_read();
         }
     }
 

--- a/runtime-manager/src/runtime_manager_icecap.rs
+++ b/runtime-manager/src/runtime_manager_icecap.rs
@@ -84,8 +84,6 @@ impl RuntimeManager {
         virtio_console_server_tx_badge: Badge,
         virtio_console_server_rx_badge: Badge,
     ) -> Self {
-        rb.enable_notify_read();
-        rb.enable_notify_write();
         Self {
             rb: BufferedRingBuffer::new(rb),
             event: event,

--- a/workspaces/icecap-runtime/cdl/runtime_manager.py
+++ b/workspaces/icecap-runtime/cdl/runtime_manager.py
@@ -13,7 +13,8 @@ from capdl import ObjectType
 from icecap_framework.components.generic import GenericElfComponent
 from icecap_framework.utils import PAGE_SIZE_BITS, BLOCK_SIZE
 
-BADGE_VIRTIO_CONSOLE_SERVER_RING_BUFFER = 1 << 2
+BADGE_VIRTIO_CONSOLE_SERVER_TX = 1 << 3
+BADGE_VIRTIO_CONSOLE_SERVER_RX = 1 << 4
 
 class RuntimeManager(GenericElfComponent):
 
@@ -22,20 +23,30 @@ class RuntimeManager(GenericElfComponent):
 
         event_nfn = self.alloc(ObjectType.seL4_NotificationObject, name='event_nfn')
 
-        virtio_console_server_rb_objs, virtio_console_server_kick_nfn_cap = self.composition.virtio_console_server.register_client(self, event_nfn, BADGE_VIRTIO_CONSOLE_SERVER_RING_BUFFER)
+        (
+            virtio_console_server_rb_objs,
+            virtio_console_server_kick_tx_cap,
+            virtio_console_server_kick_rx_cap,
+        ) = self.composition.virtio_console_server.register_client(
+            self,
+            event_nfn,
+            BADGE_VIRTIO_CONSOLE_SERVER_TX,
+            BADGE_VIRTIO_CONSOLE_SERVER_RX,
+        )
 
         self._arg = {
             'event_nfn': self.cspace().alloc(event_nfn, read=True),
             'virtio_console_server_ring_buffer': {
                 'ring_buffer': self.map_ring_buffer(virtio_console_server_rb_objs),
                 'kicks': {
-                    'read': virtio_console_server_kick_nfn_cap,
-                    'write': virtio_console_server_kick_nfn_cap,
-                    },
+                    'read': virtio_console_server_kick_tx_cap,
+                    'write': virtio_console_server_kick_rx_cap,
                 },
+            },
             'badges': {
-                'virtio_console_server_ring_buffer': BADGE_VIRTIO_CONSOLE_SERVER_RING_BUFFER,
-                },
+                'virtio_console_server_tx': BADGE_VIRTIO_CONSOLE_SERVER_TX,
+                'virtio_console_server_rx': BADGE_VIRTIO_CONSOLE_SERVER_RX,
+            },
         }
 
     def static_heap_size(self):

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -207,11 +207,9 @@ fn main(config: Config) -> Fallible<()> {
                 }
             }
             rb.rx_callback();
-            rb.ring_buffer().enable_notify_write();
         }
 
         // always handle tx operations
         rb.tx_callback();
-        rb.ring_buffer().enable_notify_read();
     }
 }

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -179,8 +179,6 @@ fn main(config: Config) -> Fallible<()> {
             &config.client_ring_buffer,
         )
     );
-    rb.ring_buffer().enable_notify_read();
-    rb.ring_buffer().enable_notify_write();
     let send_page = unsafe { VIRTIO_POOL.as_mut() }.unwrap().alloc(virtio_drivers::PAGE_SIZE)?;
 
     loop {

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -5,14 +5,14 @@ use core::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-use icecap_start_generic::declare_generic_main;
 use icecap_core::config::*;
 use icecap_core::prelude::*;
 use icecap_core::ring_buffer::{BufferedRingBuffer, RingBuffer};
+use icecap_start_generic::declare_generic_main;
 
+use virtio_drivers::DeviceType;
 use virtio_drivers::VirtIOConsole;
 use virtio_drivers::VirtIOHeader;
-use virtio_drivers::DeviceType;
 
 declare_generic_main!(main);
 
@@ -35,8 +35,6 @@ struct Badges {
     rx: Badge,
 }
 
-
-
 // Pool to manage pages which are accessible by both the guest and the host
 struct VirtioPool {
     pool: &'static mut [u8],
@@ -47,16 +45,14 @@ struct VirtioPool {
 impl VirtioPool {
     fn new(vaddr: usize, paddr: usize, len: usize) -> VirtioPool {
         VirtioPool {
-            pool: unsafe {
-                core::slice::from_raw_parts_mut(vaddr as *mut u8, len)
-            },
+            pool: unsafe { core::slice::from_raw_parts_mut(vaddr as *mut u8, len) },
             paddr: paddr,
             mark: 0,
         }
     }
 
     fn alloc<'a>(&'a mut self, size: usize) -> Fallible<&'a mut [u8]> {
-        let count = (size+virtio_drivers::PAGE_SIZE-1) / virtio_drivers::PAGE_SIZE;
+        let count = (size + virtio_drivers::PAGE_SIZE - 1) / virtio_drivers::PAGE_SIZE;
         let ppages = unsafe { virtio_dma_alloc(count) };
         if ppages == 0 {
             bail!("virtio_pool: out of pages");
@@ -75,7 +71,7 @@ impl VirtioPool {
         unsafe {
             virtio_dma_dealloc(
                 virtio_virt_to_phys(pages.as_ptr() as usize),
-                pages.len() / virtio_drivers::PAGE_SIZE
+                pages.len() / virtio_drivers::PAGE_SIZE,
             )
         };
     }
@@ -86,10 +82,15 @@ static mut VIRTIO_POOL: Option<VirtioPool> = None;
 // virtio pool page mappings for virtio-drivers
 #[no_mangle]
 pub unsafe extern "C" fn virtio_dma_alloc(pages: usize) -> usize {
-    debug_println!("virtio_pool: allocating {}x{} pages", pages, virtio_drivers::PAGE_SIZE);
+    debug_println!(
+        "virtio_pool: allocating {}x{} pages",
+        pages,
+        virtio_drivers::PAGE_SIZE
+    );
     let pool = VIRTIO_POOL.as_mut().unwrap();
-    if pool.mark + pages*virtio_drivers::PAGE_SIZE > pool.pool.len() {
-        debug_println!("virtio_pool: out of pages ({}/{})!",
+    if pool.mark + pages * virtio_drivers::PAGE_SIZE > pool.pool.len() {
+        debug_println!(
+            "virtio_pool: out of pages ({}/{})!",
             pool.pool.len() / virtio_drivers::PAGE_SIZE,
             pool.pool.len() / virtio_drivers::PAGE_SIZE
         );
@@ -97,9 +98,14 @@ pub unsafe extern "C" fn virtio_dma_alloc(pages: usize) -> usize {
     }
 
     let old_mark = pool.mark;
-    pool.mark += pages*virtio_drivers::PAGE_SIZE;
+    pool.mark += pages * virtio_drivers::PAGE_SIZE;
     let p = &mut pool.pool[old_mark] as *mut _ as usize;
-    debug_println!("virtio_pool: allocating {}x{} pages -> {:012x}", pages, virtio_drivers::PAGE_SIZE, virtio_virt_to_phys(p as usize));
+    debug_println!(
+        "virtio_pool: allocating {}x{} pages -> {:012x}",
+        pages,
+        virtio_drivers::PAGE_SIZE,
+        virtio_virt_to_phys(p as usize)
+    );
     virtio_virt_to_phys(p as usize)
 }
 
@@ -107,26 +113,35 @@ pub unsafe extern "C" fn virtio_dma_alloc(pages: usize) -> usize {
 pub unsafe extern "C" fn virtio_dma_dealloc(paddr: usize, _pages: usize) -> i32 {
     debug_println!("virtio_pool: deallocating {:012x}", paddr);
     let pool = VIRTIO_POOL.as_mut().unwrap();
-    debug_assert!(pool.pool.as_ptr_range().contains(&(virtio_phys_to_virt(paddr) as *const u8)));
+    debug_assert!(pool
+        .pool
+        .as_ptr_range()
+        .contains(&(virtio_phys_to_virt(paddr) as *const u8)));
     0
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn virtio_phys_to_virt(paddr: usize) -> usize {
     let pool = VIRTIO_POOL.as_mut().unwrap();
-    debug_assert!(paddr >= pool.paddr && paddr < pool.paddr + pool.pool.len(),
-        "virtio_pool: invalid paddr {:012x}", paddr);
+    debug_assert!(
+        paddr >= pool.paddr && paddr < pool.paddr + pool.pool.len(),
+        "virtio_pool: invalid paddr {:012x}",
+        paddr
+    );
     paddr - pool.paddr + (pool.pool.as_ptr() as usize)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn virtio_virt_to_phys(vaddr: usize) -> usize {
     let pool = VIRTIO_POOL.as_mut().unwrap();
-    debug_assert!(vaddr >= pool.pool.as_ptr() as usize && vaddr < pool.pool.as_ptr() as usize + pool.pool.len(),
-        "virtio_pool: invalid vaddr {:012x}", vaddr);
+    debug_assert!(
+        vaddr >= pool.pool.as_ptr() as usize
+            && vaddr < pool.pool.as_ptr() as usize + pool.pool.len(),
+        "virtio_pool: invalid vaddr {:012x}",
+        vaddr
+    );
     vaddr - (pool.pool.as_ptr() as usize) + pool.paddr
 }
-
 
 // entry point
 fn main(config: Config) -> Fallible<()> {
@@ -140,23 +155,27 @@ fn main(config: Config) -> Fallible<()> {
     }
 
     // find a virtio driver that reports as a console device
-    let (virtio_i, virtio_mmio, virtio_irq_handler) = match
-        config.virtio_region.clone()
-            .step_by(512)
-            .zip(&config.virtio_irq_handlers)
-            .enumerate()
-            .find(|(_, (mmio, _))| {
-                let id = unsafe { core::ptr::read_volatile((mmio+8) as *const u32) };
-                id == DeviceType::Console as u32
-            })
-    {
+    let (virtio_i, virtio_mmio, virtio_irq_handler) = match config
+        .virtio_region
+        .clone()
+        .step_by(512)
+        .zip(&config.virtio_irq_handlers)
+        .enumerate()
+        .find(|(_, (mmio, _))| {
+            let id = unsafe { core::ptr::read_volatile((mmio + 8) as *const u32) };
+            id == DeviceType::Console as u32
+        }) {
         Some((i, (mmio, irq_handler))) => (i, mmio, irq_handler),
         None => {
             bail!("virtio-console-server: could not find a virtio-console");
         }
     };
 
-    debug_println!("found virtio-console at virtio{}@{:012x}", virtio_i, virtio_mmio);
+    debug_println!(
+        "found virtio-console at virtio{}@{:012x}",
+        virtio_i,
+        virtio_mmio
+    );
     let header = unsafe { &mut *(virtio_mmio as *mut VirtIOHeader) };
     let mut console = VirtIOConsole::new(header)?;
 
@@ -169,12 +188,12 @@ fn main(config: Config) -> Fallible<()> {
     }
 
     // begin processing requests
-    let mut rb = BufferedRingBuffer::new(
-        RingBuffer::unmanaged_from_config(
-            &config.client_ring_buffer,
-        )
-    );
-    let send_page = unsafe { VIRTIO_POOL.as_mut() }.unwrap().alloc(virtio_drivers::PAGE_SIZE)?;
+    let mut rb = BufferedRingBuffer::new(RingBuffer::unmanaged_from_config(
+        &config.client_ring_buffer,
+    ));
+    let send_page = unsafe { VIRTIO_POOL.as_mut() }
+        .unwrap()
+        .alloc(virtio_drivers::PAGE_SIZE)?;
 
     loop {
         let badge = config.event_nfn.wait();
@@ -194,7 +213,6 @@ fn main(config: Config) -> Fallible<()> {
         }
 
         if badge & config.badges.rx != 0 {
-            //debug_println!("virtio-console-server: rx!");
             if let Some(chars) = rb.rx() {
                 for chunk in chars.chunks(virtio_drivers::PAGE_SIZE) {
                     send_page[..chunk.len()].copy_from_slice(chunk);

--- a/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
+++ b/workspaces/icecap-runtime/src/virtio-console-server/src/main.rs
@@ -130,11 +130,6 @@ pub unsafe extern "C" fn virtio_virt_to_phys(vaddr: usize) -> usize {
 
 // entry point
 fn main(config: Config) -> Fallible<()> {
-    // FIXME: Yield 10 times to let the runtime start before the console server
-    for _i in 1..10 {
-        icecap_core::sel4::yield_();
-    }
-
     // setup the virtio pool
     unsafe {
         VIRTIO_POOL = Some(VirtioPool::new(


### PR DESCRIPTION
This includes a number of changes to improve the stability of the ring-buffers used to communicate between domains. As it was it was easy to lose notifications and cause applications to lock up.

The commits have more details, but here are the high-level changes:

1. RingBuffer is changed to enabled notifications by default, avoiding a race-condition during domain bringup.
2. Fixed an issue in BufferedRingBuffer where >ring-buffer sized messages could hang the ring-buffer if multiple messages are in the queue.
3. Reworked the virtio-console-server example a bit to use the BufferedRingBuffer more correctly.

This depends on https://gitlab.com/arm-research/security/icecap/icecap/-/merge_requests/22, which is depended on in several places in the commit history (and is already broken by a rebase needed there). So I will wait to fix the submodule and make this a non-draft until that is merged.

This should resolve https://github.com/veracruz-project/veracruz/issues/429, resolve https://github.com/veracruz-project/veracruz/issues/443, and fix the main hanging problem we are currently seeing in IceCap in CI.