### PR TITLE
Fix Clippy lints: veracruz-server and veracruz-client

### DIFF
--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -162,7 +162,7 @@ impl VeracruzClient {
             let certs_pem = policy.proxy_service_cert();
             let certs = rustls_pemfile::certs(&mut certs_pem.as_bytes()).map_err(|_| {
                 VeracruzClientError::X509ParserError(
-                    "rustls_pemfile::certs found not certificates".to_string()
+                    "rustls_pemfile::certs found not certificates".to_string(),
                 )
             })?;
             certs[0].clone()
@@ -232,9 +232,7 @@ impl VeracruzClient {
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => Ok(()),
-            _ => {
-                Err(VeracruzClientError::ResponseError("send_program", status))
-            }
+            _ => Err(VeracruzClientError::ResponseError("send_program", status)),
         }
     }
 
@@ -260,9 +258,7 @@ impl VeracruzClient {
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => Ok(()),
-            _ => {
-                Err(VeracruzClientError::ResponseError("send_data", status))
-            }
+            _ => Err(VeracruzClientError::ResponseError("send_data", status)),
         }
     }
 
@@ -351,12 +347,10 @@ impl VeracruzClient {
                     Ok(())
                 }
             }
-            _ => {
-                Err(VeracruzClientError::ResponseError(
-                    "check_policy_hash",
-                    parsed_response.status,
-                ))
-            }
+            _ => Err(VeracruzClientError::ResponseError(
+                "check_policy_hash",
+                parsed_response.status,
+            )),
         }
     }
 
@@ -380,9 +374,7 @@ impl VeracruzClient {
     /// Request the hash of the remote veracruz runtime and check if it matches.
     fn check_runtime_hash(&self) -> Result<(), VeracruzClientError> {
         match self.tls_connection.peer_certificates() {
-            None => {
-                Err(VeracruzClientError::NoPeerCertificatesError)
-            }
+            None => Err(VeracruzClientError::NoPeerCertificatesError),
             Some(certs) => {
                 let ee_cert = webpki::EndEntityCert::try_from(certs[0].as_ref())?;
                 let ues = ee_cert.unrecognized_extensions();
@@ -423,7 +415,7 @@ impl VeracruzClient {
                             Err(err) => {
                                 error!("Runtime hash mismatch: {}.", err);
 
-                               Err(err)
+                                Err(err)
                             }
                         }
                     }

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -22,7 +22,6 @@ use io_utils::{error::SocketError, http::HttpError};
 use rustls::Error as TLSError;
 use std::error::Error;
 
-
 pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 
 #[derive(Debug, Error)]

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -198,7 +198,7 @@ impl error::ResponseError for VeracruzServerError {
     }
     fn status_code(&self) -> StatusCode {
         match self {
-            VeracruzServerError::DirectMessageError(_, e) => e.clone(),
+            VeracruzServerError::DirectMessageError(_, e) => *e,
             VeracruzServerError::UnimplementedRequestError
             | VeracruzServerError::UnknownAttestationTokenError => StatusCode::NOT_IMPLEMENTED,
             VeracruzServerError::UnsupportedRequestError => StatusCode::NOT_FOUND,

--- a/veracruz-server/src/veracruz_server_icecap.rs
+++ b/veracruz-server/src/veracruz_server_icecap.rs
@@ -63,12 +63,10 @@ const VERACRUZ_ICECAP_QEMU_CONSOLE_FLAGS_DEFAULT: &[&str] = &[
     "-device",
     "virtconsole,chardev=charconsole0,id=console0",
 ];
-const VERACRUZ_ICECAP_QEMU_IMAGE_FLAGS_DEFAULT: &[&str] =
-    &["-kernel", "{image_path}"];
+const VERACRUZ_ICECAP_QEMU_IMAGE_FLAGS_DEFAULT: &[&str] = &["-kernel", "{image_path}"];
 
 // Include image at compile time
-const VERACRUZ_ICECAP_QEMU_IMAGE: &[u8] =
-    include_bytes!(env!("VERACRUZ_ICECAP_QEMU_IMAGE"));
+const VERACRUZ_ICECAP_QEMU_IMAGE: &[u8] = include_bytes!(env!("VERACRUZ_ICECAP_QEMU_IMAGE"));
 
 // TODO is this needed?
 const FIRMWARE_VERSION: &str = "0.3.0";
@@ -126,7 +124,8 @@ impl IceCapRealm {
                 }
                 Err(_) => Err(IceCapError::InvalidEnvironmentVariableValue {
                     variable: var.to_owned(),
-                }.into()),
+                }
+                .into()),
             }
         }
 

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -45,8 +45,7 @@ pub mod veracruz_server_linux {
     ////////////////////////////////////////////////////////////////////////////
 
     /// The Runtime Manager binary (the enclave), included at compile time
-    const RUNTIME_ENCLAVE_BINARY_IMAGE: &[u8] =
-        include_bytes!(env!("RUNTIME_ENCLAVE_BINARY_PATH"));
+    const RUNTIME_ENCLAVE_BINARY_IMAGE: &[u8] = include_bytes!(env!("RUNTIME_ENCLAVE_BINARY_PATH"));
     /// Spawn delay to apply (in seconds) between spawning the Runtime Manager enclave and trying
     /// to contact it.
     const RUNTIME_ENCLAVE_SPAWN_DELAY: u64 = 2;

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -45,20 +45,20 @@ pub mod veracruz_server_linux {
     ////////////////////////////////////////////////////////////////////////////
 
     /// The Runtime Manager binary (the enclave), included at compile time
-    const RUNTIME_ENCLAVE_BINARY_IMAGE: &'static [u8] =
+    const RUNTIME_ENCLAVE_BINARY_IMAGE: &[u8] =
         include_bytes!(env!("RUNTIME_ENCLAVE_BINARY_PATH"));
     /// Spawn delay to apply (in seconds) between spawning the Runtime Manager enclave and trying
     /// to contact it.
     const RUNTIME_ENCLAVE_SPAWN_DELAY: u64 = 2;
     /// IP address to use when communicating with the Runtime Manager enclave.
-    const RUNTIME_MANAGER_ENCLAVE_ADDRESS: &'static str = "127.0.0.1";
+    const RUNTIME_MANAGER_ENCLAVE_ADDRESS: &str = "127.0.0.1";
     /// Port to communicate with the Runtime Manager enclave on.
-    const RUNTIME_MANAGER_ENCLAVE_PORT: &'static str = "6000";
+    const RUNTIME_MANAGER_ENCLAVE_PORT: &str = "6000";
 
     /// The protocol to use with the proxy attestation server.
-    const PROXY_ATTESTATION_PROTOCOL: &'static str = "psa";
+    const PROXY_ATTESTATION_PROTOCOL: &str = "psa";
     /// The firmware version to use when communicating with the proxy attestation server.
-    const FIRMWARE_VERSION: &'static str = "0.0";
+    const FIRMWARE_VERSION: &str = "0.0";
 
     /// A struct capturing all the metadata needed to start and communicate with
     /// the Linux root enclave.

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -240,10 +240,12 @@ pub mod veracruz_server_nitro {
 
     impl Drop for VeracruzServerNitro {
         fn drop(&mut self) {
-            if let Err(err) = self.shutdown_isolate() { println!(
-                "VeracruzServerNitro::drop failed in call to self.shutdown_isolate:{:?}",
-                err
-            )}
+            if let Err(err) = self.shutdown_isolate() {
+                println!(
+                    "VeracruzServerNitro::drop failed in call to self.shutdown_isolate:{:?}",
+                    err
+                )
+            }
         }
     }
 
@@ -273,7 +275,7 @@ pub mod veracruz_server_nitro {
     ) -> Result<Vec<Vec<u8>>, VeracruzServerError> {
         let serialized_nitro_attestation_doc_request =
             transport_protocol::serialize_nitro_attestation_doc(att_doc, challenge_id)
-                .map_err( VeracruzServerError::TransportProtocol)?;
+                .map_err(VeracruzServerError::TransportProtocol)?;
         let encoded_str = base64::encode(&serialized_nitro_attestation_doc_request);
         let url = format!("{:}/Nitro/AttestationToken", proxy_attestation_server_url);
         println!(
@@ -294,8 +296,7 @@ pub mod veracruz_server_nitro {
             received_body
         );
 
-        let body_vec =
-            base64::decode(&received_body).map_err(VeracruzServerError::Base64Decode)?;
+        let body_vec = base64::decode(&received_body).map_err(VeracruzServerError::Base64Decode)?;
         let response = transport_protocol::parse_proxy_attestation_server_response(None, &body_vec)
             .map_err(VeracruzServerError::TransportProtocol)?;
 
@@ -305,10 +306,7 @@ pub mod veracruz_server_nitro {
         } else {
             return Err(VeracruzServerError::InvalidProtoBufMessage);
         };
-        let cert_chain: Vec<Vec<u8>> = vec![
-            re_cert.to_vec(),
-            ca_cert.to_vec()
-        ];
+        let cert_chain: Vec<Vec<u8>> = vec![re_cert.to_vec(), ca_cert.to_vec()];
         Ok(cert_chain)
     }
 }

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -57,7 +57,7 @@ pub mod veracruz_server_nitro {
 
             println!("VeracruzServerNitro::new instantiating Runtime Manager");
             let runtime_manager_eif_path = env::var("RUNTIME_MANAGER_EIF_PATH")
-                .unwrap_or(RUNTIME_MANAGER_EIF_PATH.to_string());
+                .unwrap_or_else(|_| RUNTIME_MANAGER_EIF_PATH.to_string());
             #[cfg(feature = "debug")]
             let runtime_manager_enclave = {
                 println!("Starting Runtime Manager enclave in debug mode");
@@ -78,7 +78,7 @@ pub mod veracruz_server_nitro {
                     false,
                     *policy.max_memory_mib(),
                 )
-                .map_err(|err| VeracruzServerError::NitroError(err))?
+                .map_err(VeracruzServerError::NitroError)?
             };
             println!("VeracruzServerNitro::new NitroEnclave::new returned");
             let meta = Self {
@@ -129,14 +129,14 @@ pub mod veracruz_server_nitro {
                 _ => return Err(VeracruzServerError::Status(status)),
             }
             println!("VeracruzServerNitro::new complete. Returning");
-            return Ok(meta);
+            Ok(meta)
         }
 
         fn plaintext_data(
             &mut self,
             _data: Vec<u8>,
         ) -> Result<Option<Vec<u8>>, VeracruzServerError> {
-            return Err(VeracruzServerError::UnimplementedError);
+            Err(VeracruzServerError::UnimplementedError)
         }
 
         fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
@@ -155,7 +155,7 @@ pub mod veracruz_server_nitro {
                     ))
                 }
             };
-            return Ok(session_id);
+            Ok(session_id)
         }
 
         fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
@@ -167,11 +167,11 @@ pub mod veracruz_server_nitro {
             let received_buffer: Vec<u8> = self.enclave.receive_buffer()?;
 
             let received_message: RuntimeManagerResponse = bincode::deserialize(&received_buffer)?;
-            return match received_message {
+            match received_message {
                 RuntimeManagerResponse::Status(_status) => Ok(()),
 
                 _ => Err(VeracruzServerError::Status(Status::Fail)),
-            };
+            }
         }
 
         fn tls_data(
@@ -223,7 +223,7 @@ pub mod veracruz_server_nitro {
 
             Ok((
                 active_flag,
-                if ret_array.len() > 0 {
+                if !ret_array.is_empty() {
                     Some(ret_array)
                 } else {
                     None
@@ -240,13 +240,10 @@ pub mod veracruz_server_nitro {
 
     impl Drop for VeracruzServerNitro {
         fn drop(&mut self) {
-            match self.shutdown_isolate() {
-                Err(err) => println!(
-                    "VeracruzServerNitro::drop failed in call to self.shutdown_isolate:{:?}",
-                    err
-                ),
-                _ => (),
-            }
+            if let Err(err) = self.shutdown_isolate() { println!(
+                "VeracruzServerNitro::drop failed in call to self.shutdown_isolate:{:?}",
+                err
+            )}
         }
     }
 
@@ -264,7 +261,7 @@ pub mod veracruz_server_nitro {
                 RuntimeManagerResponse::TlsDataNeeded(needed) => needed,
                 _ => return Err(VeracruzServerError::Status(Status::Fail)),
             };
-            return Ok(tls_data_needed);
+            Ok(tls_data_needed)
         }
     }
 
@@ -276,7 +273,7 @@ pub mod veracruz_server_nitro {
     ) -> Result<Vec<Vec<u8>>, VeracruzServerError> {
         let serialized_nitro_attestation_doc_request =
             transport_protocol::serialize_nitro_attestation_doc(att_doc, challenge_id)
-                .map_err(|err| VeracruzServerError::TransportProtocol(err))?;
+                .map_err( VeracruzServerError::TransportProtocol)?;
         let encoded_str = base64::encode(&serialized_nitro_attestation_doc_request);
         let url = format!("{:}/Nitro/AttestationToken", proxy_attestation_server_url);
         println!(
@@ -298,9 +295,9 @@ pub mod veracruz_server_nitro {
         );
 
         let body_vec =
-            base64::decode(&received_body).map_err(|err| VeracruzServerError::Base64Decode(err))?;
+            base64::decode(&received_body).map_err(VeracruzServerError::Base64Decode)?;
         let response = transport_protocol::parse_proxy_attestation_server_response(None, &body_vec)
-            .map_err(|err| VeracruzServerError::TransportProtocol(err))?;
+            .map_err(VeracruzServerError::TransportProtocol)?;
 
         let (re_cert, ca_cert) = if response.has_cert_chain() {
             let cert_chain = response.get_cert_chain();
@@ -308,9 +305,10 @@ pub mod veracruz_server_nitro {
         } else {
             return Err(VeracruzServerError::InvalidProtoBufMessage);
         };
-        let mut cert_chain: Vec<Vec<u8>> = Vec::new();
-        cert_chain.push(re_cert.to_vec());
-        cert_chain.push(ca_cert.to_vec());
-        return Ok(cert_chain);
+        let cert_chain: Vec<Vec<u8>> = vec![
+            re_cert.to_vec(),
+            ca_cert.to_vec()
+        ];
+        Ok(cert_chain)
     }
 }

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -106,9 +106,10 @@ doc:
 fmt:
 	cargo fmt
 
-clippy:
+clippy: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 	# workspace members and relevant dependencies
-	$(BUILD_PARAMETERS) $(COMPILERS) cargo clippy $(PROFILE_FLAG) \
+	$(BUILD_PARAMETERS) $(COMPILERS) \
+	cargo clippy $(PROFILE_FLAG) \
 		-p proxy-attestation-server -p veracruz-client \
 		-p veracruz-server -p io-utils -p transport-protocol \
 		-p psa-attestation -p veracruz-utils \

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -78,9 +78,9 @@ veracruz-test: test-dependencies
 $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
-clippy: 
+clippy: $(RUNTIME_ENCLAVE_BINARY_PATH)
 	# workspace members and relevant dependencies
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) \
+	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) \
 	$(CC) \
 		cargo clippy $(PROFILE_FLAG) $(V_FLAG) \
 		-p proxy-attestation-server -p veracruz-client \
@@ -94,7 +94,7 @@ clippy:
 		--features veracruz-utils/linux \
 		-- --no-deps
 	# workspace testing crates
-	RUNTIME_ENCLAVE_BINARY_PATH=$(ENCLAVE_BINARY_PATH) $(CC) $(TEST_PARAMETERS) \
+	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) $(CC) $(TEST_PARAMETERS) \
 		cargo clippy --tests \
 		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
 		--features veracruz-test/linux \


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

## Major changes :
- Fix clippy warnings for `veracruz-server` and `veracruz-client`
- Almost all of the fixes relates to styling, useless extra code, slight performance improvement.

### Unhandled lints
There are two clippy warnings that I left. 
- The first one [here](https://github.com/veracruz-project/veracruz/blob/1252ad094f0b87fdf026747bd2545583b3fb0778/veracruz-server/src/veracruz_server_linux.rs#L463), clippy warns that this is a very complex type and it needs to be refactored into `type` definitions. If we followed clippy this will lead to change the [trait function](https://github.com/veracruz-project/veracruz/blob/1252ad094f0b87fdf026747bd2545583b3fb0778/veracruz-server/src/veracruz_server.rs#L222) which will require multiple changes inside `veracruz-server`
- The second one [here](https://github.com/veracruz-project/veracruz/blob/1252ad094f0b87fdf026747bd2545583b3fb0778/veracruz-server/src/veracruz_server_linux.rs#L13), clippy complains that naming the module `veracruz_server_linux` inside `veracruz_server_linux.rs` is a bad styling. Changing this will require multiple changes inside `veracruz-server` also. This is also generated inside `veracruz_server_nitro` .

Unless you think we should change the remaining warnings, I am thinking of project-wide suppressing for those two rules `clippy::module_inception` and `clippy::type_complexty`.

## Minor changes
I updated the clippy targets inside `linux-host/Makefile` and `icecap-host` to be synced with the changes in the `build` targets. 