### PR TITLE
Fix clippy lints: host workspaces 

### DIFF
--- a/io-utils/src/http.rs
+++ b/io-utils/src/http.rs
@@ -148,9 +148,10 @@ where
                 received_body.push_str(from_utf8(buf).unwrap_or_else(|_| {
                     panic!("{}", {
                         trace!(
-                        "Error converting data {:?} from UTF-8.  Continuing with default value.",
-                        buf
-                    );
+                            "Error converting data {:?} from UTF-8.  Continuing with default value.",
+                            buf
+                        );
+
                         &format!("Error converting data {:?} from UTF-8.", buf)
                     })
                 }));
@@ -173,9 +174,9 @@ where
                 received_header.push_str(from_utf8(buf).unwrap_or_else(|_| {
                     panic!("{}", {
                         trace!(
-                        "Error converting data {:?} from UTF-8.  Continuing with default value.",
-                        buf
-                    );
+                            "Error converting data {:?} from UTF-8.  Continuing with default value.",
+                            buf
+                        );
 
                         &format!("Error converting data {:?} from UTF-8", buf)
                     })

--- a/io-utils/src/http.rs
+++ b/io-utils/src/http.rs
@@ -145,13 +145,15 @@ where
 
         transfer
             .write_function(|buf| {
-                received_body.push_str(from_utf8(buf).unwrap_or_else(|_| panic!("{}", {
-                    trace!(
+                received_body.push_str(from_utf8(buf).unwrap_or_else(|_| {
+                    panic!("{}", {
+                        trace!(
                         "Error converting data {:?} from UTF-8.  Continuing with default value.",
                         buf
                     );
-                    &format!("Error converting data {:?} from UTF-8.", buf)
-                })));
+                        &format!("Error converting data {:?} from UTF-8.", buf)
+                    })
+                }));
 
                 Ok(buf.len())
             })
@@ -168,14 +170,16 @@ where
 
         transfer
             .header_function(|buf| {
-                received_header.push_str(from_utf8(buf).unwrap_or_else(|_| panic!("{}", {
-                    trace!(
+                received_header.push_str(from_utf8(buf).unwrap_or_else(|_| {
+                    panic!("{}", {
+                        trace!(
                         "Error converting data {:?} from UTF-8.  Continuing with default value.",
                         buf
                     );
 
-                    &format!("Error converting data {:?} from UTF-8", buf)
-                })));
+                        &format!("Error converting data {:?} from UTF-8", buf)
+                    })
+                }));
 
                 true
             })

--- a/io-utils/src/http.rs
+++ b/io-utils/src/http.rs
@@ -145,14 +145,13 @@ where
 
         transfer
             .write_function(|buf| {
-                received_body.push_str(from_utf8(buf).expect({
+                received_body.push_str(from_utf8(buf).unwrap_or_else(|_| panic!("{}", {
                     trace!(
                         "Error converting data {:?} from UTF-8.  Continuing with default value.",
                         buf
                     );
-
                     &format!("Error converting data {:?} from UTF-8.", buf)
-                }));
+                })));
 
                 Ok(buf.len())
             })
@@ -169,14 +168,14 @@ where
 
         transfer
             .header_function(|buf| {
-                received_header.push_str(from_utf8(buf).expect({
+                received_header.push_str(from_utf8(buf).unwrap_or_else(|_| panic!("{}", {
                     trace!(
                         "Error converting data {:?} from UTF-8.  Continuing with default value.",
                         buf
                     );
 
                     &format!("Error converting data {:?} from UTF-8", buf)
-                }));
+                })));
 
                 true
             })

--- a/io-utils/src/nitro.rs
+++ b/io-utils/src/nitro.rs
@@ -132,19 +132,19 @@ impl NitroEnclave {
             vsocksocket: crate::vsocket::VsockSocket::connect(cid, VERACRUZ_PORT)?,
             nitro_cli_path: nitro_cli_path.to_string(),
         };
-        return Ok(enclave);
+        Ok(enclave)
     }
 
     /// send a buffer of data to the enclave
-    pub fn send_buffer(&self, buffer: &Vec<u8>) -> Result<(), NitroError> {
+    pub fn send_buffer(&self, buffer: &[u8]) -> Result<(), NitroError> {
         crate::raw_fd::send_buffer(self.vsocksocket.as_raw_fd(), buffer)
-            .map_err(|err| NitroError::VeracruzSocketError(err))
+            .map_err(NitroError::VeracruzSocketError)
     }
 
     /// receive a buffer of data from the enclave
     pub fn receive_buffer(&self) -> Result<Vec<u8>, NitroError> {
         crate::raw_fd::receive_buffer(self.vsocksocket.as_raw_fd())
-            .map_err(|err| NitroError::VeracruzSocketError(err))
+            .map_err(NitroError::VeracruzSocketError)
     }
 }
 

--- a/io-utils/src/raw_fd.rs
+++ b/io-utils/src/raw_fd.rs
@@ -26,7 +26,7 @@ use std::{os::unix::io::RawFd, vec::Vec};
 
 /// Send a buffer of data (using a length, buffer protocol) to the file
 /// descriptor `fd`
-pub fn send_buffer(fd: RawFd, buffer: &Vec<u8>) -> Result<(), SocketError> {
+pub fn send_buffer(fd: RawFd, buffer: &[u8]) -> Result<(), SocketError> {
     let len = buffer.len();
     // first, send the length of the buffer
     {
@@ -56,7 +56,7 @@ pub fn send_buffer(fd: RawFd, buffer: &Vec<u8>) -> Result<(), SocketError> {
             sent_bytes += size;
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 /// Read a buffer of data (using a length, buffer protocol) from the file
@@ -94,5 +94,5 @@ pub fn receive_buffer(fd: RawFd) -> Result<Vec<u8>, SocketError> {
             }
         }
     }
-    return Ok(buffer);
+    Ok(buffer)
 }

--- a/io-utils/src/vsocket.rs
+++ b/io-utils/src/vsocket.rs
@@ -94,7 +94,7 @@ impl Drop for VsockSocket {
     /// do anything else (it could fail because it's not connected).
     fn drop(&mut self) {
         // Do nothing on failure. It's non fatal and a warning message is just confusing
-        shutdown(self.socket_fd, Shutdown::Both).unwrap_or_else(|_| ());
+        shutdown(self.socket_fd, Shutdown::Both).unwrap_or(());
         close(self.socket_fd).unwrap_or_else(|e| eprintln!("Failed to close io: {:?}", e));
     }
 }

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -36,8 +36,7 @@ pub fn load_ca_certificate<P>(pem_cert_path: P) -> Result<(), ProxyAttestationSe
 where
     P: AsRef<path::Path>,
 {
-    let mut f = std::fs::File::open(pem_cert_path)
-        .map_err(ProxyAttestationServerError::IOError)?;
+    let mut f = std::fs::File::open(pem_cert_path).map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer)?;
     let cert = openssl::x509::X509::from_pem(&buffer)?;
@@ -66,8 +65,7 @@ pub fn load_ca_key<P>(pem_key_path: P) -> Result<(), ProxyAttestationServerError
 where
     P: AsRef<path::Path>,
 {
-    let mut f = std::fs::File::open(pem_key_path)
-        .map_err(ProxyAttestationServerError::IOError)?;
+    let mut f = std::fs::File::open(pem_key_path).map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer)?;
     let key = openssl::pkey::PKey::private_key_from_pem(&buffer)?;

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -23,8 +23,6 @@ use std::{
 };
 use veracruz_utils::VERACRUZ_RUNTIME_HASH_EXTENSION_ID;
 
-use openssl;
-
 lazy_static! {
     static ref DEVICE_ID: AtomicI32 = AtomicI32::new(1);
     static ref CA_CERT_DER: std::sync::Mutex<Option<Vec<u8>>> = std::sync::Mutex::new(None);
@@ -39,7 +37,7 @@ where
     P: AsRef<path::Path>,
 {
     let mut f = std::fs::File::open(pem_cert_path)
-        .map_err(|err| ProxyAttestationServerError::IOError(err))?;
+        .map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer)?;
     let cert = openssl::x509::X509::from_pem(&buffer)?;
@@ -51,14 +49,14 @@ where
             *ccd_guard = Some(der);
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 fn get_ca_certificate() -> Result<Vec<u8>, ProxyAttestationServerError> {
     let ccd_guard = CA_CERT_DER.lock()?;
     match &*ccd_guard {
-        None => return Err(ProxyAttestationServerError::BadStateError),
-        Some(der) => return Ok(der.clone()),
+        None => Err(ProxyAttestationServerError::BadStateError),
+        Some(der) => Ok(der.clone()),
     }
 }
 
@@ -69,7 +67,7 @@ where
     P: AsRef<path::Path>,
 {
     let mut f = std::fs::File::open(pem_key_path)
-        .map_err(|err| ProxyAttestationServerError::IOError(err))?;
+        .map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer)?;
     let key = openssl::pkey::PKey::private_key_from_pem(&buffer)?;
@@ -80,15 +78,15 @@ where
             *guard = Some(key);
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 fn get_ca_key() -> Result<openssl::pkey::PKey<openssl::pkey::Private>, ProxyAttestationServerError>
 {
     let guard = CA_KEY_PKEY.lock()?;
     match &*guard {
-        None => return Err(ProxyAttestationServerError::BadStateError),
-        Some(key) => return Ok(key.clone()),
+        None => Err(ProxyAttestationServerError::BadStateError),
+        Some(key) => Ok(key.clone()),
     }
 }
 

--- a/proxy-attestation-server/src/attestation/nitro.rs
+++ b/proxy-attestation-server/src/attestation/nitro.rs
@@ -88,7 +88,7 @@ pub fn start(firmware_version: &str, device_id: i32) -> ProxyAttestationServerRe
 
     let attestation_context = NitroAttestationContext {
         firmware_version: firmware_version.to_string(),
-        challenge: challenge.clone(),
+        challenge,
     };
     {
         let mut ac_hash = ATTESTATION_CONTEXT.lock()?;
@@ -122,7 +122,7 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
         ));
     }
     let (att_doc_data, device_id) =
-        transport_protocol::parse_nitro_attestation_doc(&parsed.get_nitro_attestation_doc());
+        transport_protocol::parse_nitro_attestation_doc(parsed.get_nitro_attestation_doc());
 
     let attestation_document =
         AttestationDocument::authenticate(&att_doc_data, &AWS_NITRO_ROOT_CERTIFICATE).map_err(
@@ -206,5 +206,5 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
 
     let response_b64 = base64::encode(&response_bytes);
 
-    return Ok(response_b64);
+    Ok(response_b64)
 }

--- a/proxy-attestation-server/src/attestation/psa.rs
+++ b/proxy-attestation-server/src/attestation/psa.rs
@@ -54,7 +54,7 @@ pub fn start(firmware_version: &str, device_id: i32) -> ProxyAttestationServerRe
 
     let attestation_context = PsaAttestationContext {
         firmware_version: firmware_version.to_string(),
-        challenge: challenge.clone(),
+        challenge,
     };
     {
         let mut ac_hash = ATTESTATION_CONTEXT.lock()?;
@@ -76,7 +76,7 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
         ));
     }
     let (token, csr, device_id) = transport_protocol::parse_native_psa_attestation_token(
-        &parsed.get_native_psa_attestation_token(),
+        parsed.get_native_psa_attestation_token(),
     );
 
     let attestation_context = {
@@ -187,5 +187,5 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
         ac_hash.remove(&device_id);
     }
 
-    return Ok(response_b64);
+    Ok(response_b64)
 }

--- a/proxy-attestation-server/src/error.rs
+++ b/proxy-attestation-server/src/error.rs
@@ -101,7 +101,7 @@ impl error::ResponseError for ProxyAttestationServerError {
     }
     fn status_code(&self) -> StatusCode {
         match self {
-            ProxyAttestationServerError::DirectMessageError(_, e) => e.clone(),
+            ProxyAttestationServerError::DirectMessageError(_, e) => *e,
             ProxyAttestationServerError::UnimplementedRequestError
             | ProxyAttestationServerError::UnknownAttestationTokenError => {
                 StatusCode::NOT_IMPLEMENTED

--- a/psa-attestation/build.rs
+++ b/psa-attestation/build.rs
@@ -37,7 +37,7 @@ fn main() {
     let c_src_dir = format!("{:}/c_src/", project_dir);
     let make_status = Command::new("make")
         .env("CC", &cc)
-        .current_dir(c_src_dir.clone())
+        .current_dir(c_src_dir)
         .args(&["all", outdir_arg.as_str()])
         .status()
         .unwrap();

--- a/transport-protocol/src/custom.rs
+++ b/transport-protocol/src/custom.rs
@@ -115,7 +115,7 @@ fn handle_protocol_buffer(session_id: Option<u32>, mut input: &[u8]) -> Transpor
     // If not, we assume this is the first chunk of the protocol buffer.
     if incoming_buffer_hash.get(&session_id).is_none() {
         // Extract the protocol buffer's total length
-        let (expected_length, input_unprefixed) = get_length_prefix(session_id, &mut input)?;
+        let (expected_length, input_unprefixed) = get_length_prefix(session_id, input)?;
 
         // Insert the expected length in the hash table
         incoming_buffer_hash.insert(session_id, (expected_length, Vec::new()));
@@ -141,7 +141,7 @@ fn handle_protocol_buffer(session_id: Option<u32>, mut input: &[u8]) -> Transpor
     // might be the case or if it is hopeless and we could just error out.
 
     if incoming_buffer.len() < *expected_length as usize {
-        return Err(TransportProtocolError::PartialBuffer(session_id));
+        Err(TransportProtocolError::PartialBuffer(session_id))
     } else {
         let incoming_buffer = incoming_buffer.to_vec();
         incoming_buffer_hash.remove(&session_id);
@@ -518,7 +518,7 @@ pub fn serialize_result(
     if let Some(ref data) = data_opt {
         let mut result = transport_protocol::Result::new();
         result.data.resize(data.len(), 0);
-        result.data.copy_from_slice(&data);
+        result.data.copy_from_slice(data);
         response.set_result(result);
     }
 

--- a/veracruz-utils/src/csr.rs
+++ b/veracruz-utils/src/csr.rs
@@ -75,7 +75,7 @@ pub fn generate_csr(private_key_der: &[u8]) -> Result<Vec<u8>, CertError> {
         .signature_hash(mbedtls::hash::Type::Sha256)
         .write_der_vec(&mut rng)
         .unwrap();
-    return Ok(csr);
+    Ok(csr)
 }
 
 pub fn generate_utc_time(

--- a/veracruz-utils/src/lib.rs
+++ b/veracruz-utils/src/lib.rs
@@ -27,8 +27,6 @@ pub mod runtime_manager_message;
 /// SHA256 function.
 pub mod sha256;
 
-use rustls;
-
 /// The ID of the Veracruz Runtime Hash Extension.
 /// This value was made up, all can be changed to pretty much any valid
 /// ID as long as it doesn't collide with the ID of an extension in our
@@ -42,8 +40,8 @@ pub fn lookup_ciphersuite(suite_string: &str) -> Option<rustls::SupportedCipherS
     };
     for this_supported_ciphersuite in rustls::ALL_CIPHER_SUITES {
         if this_supported_ciphersuite.suite() == ciphersuite_enum {
-            return Some(this_supported_ciphersuite.clone());
+            return Some(*this_supported_ciphersuite);
         }
     }
-    return None;
+    None
 }

--- a/veracruz-utils/src/sha256.rs
+++ b/veracruz-utils/src/sha256.rs
@@ -17,6 +17,6 @@ use psa_crypto::types::algorithm::Hash;
 pub fn sha256(x: &[u8]) -> Vec<u8> {
     psa_crypto::init().unwrap();
     let mut hash = vec![0; Hash::Sha256.hash_length()];
-    hash::hash_compute(Hash::Sha256, &x, &mut hash).unwrap();
+    hash::hash_compute(Hash::Sha256, x, &mut hash).unwrap();
     hash
 }

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -106,6 +106,8 @@ doc:
 fmt:
 	cargo fmt
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
+
 clippy: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 	# workspace members and relevant dependencies
 	$(BUILD_PARAMETERS) $(COMPILERS) \
@@ -120,13 +122,13 @@ clippy: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 		--features io-utils/icecap \
 		--features psa-attestation/icecap \
 		--features veracruz-utils/icecap \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 	# workspace testing crates
 	$(COMPILERS) $(TEST_PARAMETERS) cargo clippy --tests \
 		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
 		--features veracruz-test/icecap \
 		--features veracruz-server-test/icecap \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 
 clean:
 	cargo clean

--- a/workspaces/icecap-host/Makefile
+++ b/workspaces/icecap-host/Makefile
@@ -45,6 +45,8 @@ TEST_PARAMETERS = VERACRUZ_ICECAP_QEMU_IMAGE=$(VERACRUZ_ICECAP_QEMU_IMAGE) \
 	VERACRUZ_PROGRAM_DIR=$(OUT_DIR) \
 	VERACRUZ_DATA_DIR=$(OUT_DIR)
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
+
 all: build test-collateral
 
 build: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
@@ -105,8 +107,6 @@ doc:
 
 fmt:
 	cargo fmt
-
-CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
 
 clippy: rustup-plat $(VERACRUZ_ICECAP_QEMU_IMAGE)
 	# workspace members and relevant dependencies

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -33,6 +33,8 @@ TEST_PARAMETERS = VERACRUZ_POLICY_DIR=$(OUT_DIR) \
 	VERACRUZ_DATA_DIR=$(OUT_DIR) \
 	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH)
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
+
 all: build test-collateral
 
 build:
@@ -77,8 +79,6 @@ veracruz-test: test-dependencies
 
 $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
-
-CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
 
 clippy: $(RUNTIME_ENCLAVE_BINARY_PATH)
 	# workspace members and relevant dependencies

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -78,6 +78,8 @@ veracruz-test: test-dependencies
 $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception
+
 clippy: $(RUNTIME_ENCLAVE_BINARY_PATH)
 	# workspace members and relevant dependencies
 	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) \
@@ -92,14 +94,14 @@ clippy: $(RUNTIME_ENCLAVE_BINARY_PATH)
 		--features io-utils/linux \
 		--features psa-attestation/linux \
 		--features veracruz-utils/linux \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 	# workspace testing crates
 	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) $(CC) $(TEST_PARAMETERS) \
 		cargo clippy --tests \
 		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
 		--features veracruz-test/linux \
 		--features veracruz-server-test/linux \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 
 doc:
 	cargo doc

--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -78,7 +78,7 @@ veracruz-test: test-dependencies
 $(RUNTIME_ENCLAVE_BINARY_PATH):
 	$(MAKE) -C ../linux-runtime linux
 
-CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
 
 clippy: $(RUNTIME_ENCLAVE_BINARY_PATH)
 	# workspace members and relevant dependencies

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -67,6 +67,8 @@ doc:
 fmt:
 	cargo fmt
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
+
 clippy: 
 	# workspace members and relevant dependencies
 	$(CC) cargo clippy $(PROFILE_FLAG) $(V_FLAG) \
@@ -79,13 +81,13 @@ clippy:
 		--features io-utils/nitro \
 		--features psa-attestation/nitro \
 		--features veracruz-utils/nitro \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 	# workspace testing crates
 	RUNTIME_MANAGER_EIF_PATH=$(EIF_PATH) $(CC) $(TEST_PARAMETERS) cargo clippy --tests \
 		$(PROFILE_FLAG) -p veracruz-test -p veracruz-server-test \
 		--features veracruz-test/nitro \
 		--features veracruz-server-test/nitro \
-		-- --no-deps
+		-- $(CLIPPY_OPTIONS)
 
 clean:
 	cargo clean

--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -29,6 +29,8 @@ TEST_PARAMETERS = VERACRUZ_POLICY_DIR=$(OUT_DIR) \
 	VERACRUZ_PROGRAM_DIR=$(OUT_DIR) \
 	VERACRUZ_DATA_DIR=$(OUT_DIR) \
 
+CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
+
 all: build test-collateral
 
 build:
@@ -66,8 +68,6 @@ doc:
 
 fmt:
 	cargo fmt
-
-CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
 
 clippy: 
 	# workspace members and relevant dependencies


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- Fix clippy lints in `proxy-attestation-server` , `veracruz-utils` , `io-utils` , `transport-protocol` , `psa-attestation` .

- Add CLIPPY_OPTIONS variable to linux/nitro/icecap-host/Makefile to factor out the desired clippy options. The current options are :
  - skip dependencies .
  -  allow `clippy::module_inception` and `clippy::type_complexty` rules.
  -  deny warnings, which will be understandable when adding clippy to the CI.