### PR TITLE
WIP: Add ML native module (inference)

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -30,6 +30,7 @@ cfg-if = "1"
 # ctor is not used by this crate, but we must prevent other crates from
 # picking up a newer version of this crate which does not work with IceCap:
 ctor = "=0.1.16"
+darknet = "0.3.4"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 num = { version = "0.4", default-features = false }

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -16,7 +16,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::native_modules::{aes::AesCounterModeService, postcard::PostcardService};
+use crate::native_modules::{aes::AesCounterModeService, ml::MlInferenceService, postcard::PostcardService};
 use policy_utils::{
     principal::{FileRights, Principal, RightsTable},
     CANONICAL_STDERR_FILE_PATH, CANONICAL_STDIN_FILE_PATH, CANONICAL_STDOUT_FILE_PATH,
@@ -818,9 +818,13 @@ impl FileSystem {
             "/services/postcard_string.dat",
             Arc::new(Mutex::new(service)),
         ));
+		println!("registering native modules...");
         let service: Box<dyn Service> = Box::new(AesCounterModeService::new());
         services.push(("/services/aesctr.dat", Arc::new(Mutex::new(service))));
+        let service = Box::new(MlInferenceService::new());
+        services.push(("/services/mlinf.dat", Arc::new(Mutex::new(service))));
         rst.install_services(services)?;
+		println!("registered native modules");
         Ok(rst)
     }
 

--- a/execution-engine/src/native_modules/ml.rs
+++ b/execution-engine/src/native_modules/ml.rs
@@ -1,0 +1,101 @@
+//! A native module for ML inference.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Licensing and copyright notice
+//!
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
+//! information on licensing and copyright.
+
+use crate::fs::{FileSystem, FileSystemResult, Service};
+use darknet::{BBox, Image, Network};
+use serde::Deserialize;
+use std::path::PathBuf;
+use wasi_types::ErrNo;
+
+/// The interface between of the Counter mode AES module.
+#[derive(Deserialize, Debug)]
+pub(crate) struct MlInferenceService {
+    /// Path to the input to be passed through the model
+    input_path: PathBuf,
+    /// Path to the model. TODO: do we expect a format?
+    model_path: PathBuf,
+    /// Path to the result file.
+    output_path: PathBuf,
+}
+
+impl Service for MlInferenceService {
+    /// Return the name of this service
+    fn name(&self) -> &str {
+        "Machine Learning Inference Service"
+    }
+
+    /// Triggers the service. The details of the service can be found in function
+    /// `encryption_decryption`.
+    /// Here is the enter point. It also erase the state unconditionally afterwards.
+    fn serve(&mut self, fs: &mut FileSystem, _input: &[u8]) -> FileSystemResult<()> {
+        // when reaching here, the `input` bytes are already parsed.
+        let result = self.infer(fs);
+        // NOTE: erase all the states.
+        self.reset();
+        result
+    }
+
+    /// For the purpose of demonstration, we always return true. In reality,
+    /// this function may check validity of the `input`, and even buffer the result
+    /// for further uses.
+    fn try_parse(&mut self, input: &[u8]) -> FileSystemResult<bool> {
+        let deserialized_input: MlInferenceService =
+            match postcard::from_bytes(&input).map_err(|_| ErrNo::Canceled) {
+                Ok(o) => o,
+                Err(_) => return Ok(false),
+            };
+        *self = deserialized_input;
+        Ok(true)
+    }
+}
+
+impl MlInferenceService {
+    /// Create a new service, with empty internal state.
+    pub fn new() -> Self {
+        Self {
+            input_path: PathBuf::new(),
+            model_path: PathBuf::new(),
+            output_path: PathBuf::new(),
+        }
+    }
+
+    /// The core service. It encrypts or decrypts, depending on the flag `is_encryption`, the input read
+    /// from the path `input_path` using the `key` and `iv`, and writes the result to the file at `output_path`.
+    fn infer(&mut self, fs: &mut FileSystem) -> FileSystemResult<()> {
+        println!("<<infer");
+        let MlInferenceService {
+            input_path,
+            model_path,
+            output_path,
+        } = self;
+
+        println!("{:?}", input_path);
+        println!("{:?}", model_path);
+        println!("{:?}", output_path);
+        let mut net = Network::load(input_path.clone(), Some(model_path), false).map_err(|_| ErrNo::Canceled)?;
+
+        // Read the input. The service must have the permission.
+        let input = fs.read_file_by_absolute_path(&input_path)?;
+
+        // Write result. The result is resized to the actual size 
+        // returned by AES call, to avoid leaking sensitive information.
+        let mut output = vec![0; input.len()];
+        //output.resize(length, 0);
+        fs.write_file_by_absolute_path(&output_path, output, true)
+    }
+
+    /// Reset the state, and erase the sensitive information.
+    fn reset(&mut self) {
+        self.input_path = PathBuf::new();
+        self.model_path = PathBuf::new();
+        self.output_path = PathBuf::new();
+    }
+}

--- a/execution-engine/src/native_modules/mod.rs
+++ b/execution-engine/src/native_modules/mod.rs
@@ -10,4 +10,5 @@
 //! information on licensing and copyright.
 
 pub(crate) mod aes;
+pub(crate) mod ml;
 pub(crate) mod postcard;

--- a/sdk/rust-examples/ml-inference-native/Cargo.toml
+++ b/sdk/rust-examples/ml-inference-native/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "The test program for calling the Machine Learning Inference module."
+name = "ml-inference-native"
+version = "0.3.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.14"
+postcard = { version = "0.7.2", features = [ "alloc", "use-std" ] }
+serde = { version = "1.0.3", features = ["derive"] }

--- a/sdk/rust-examples/ml-inference-native/Makefile
+++ b/sdk/rust-examples/ml-inference-native/Makefile
@@ -1,0 +1,26 @@
+# Example Makefile
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT AND LICENSING
+#
+# See the `LICENSING.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
+.PHONY: all doc clean fmt
+
+all:
+	cargo build --target wasm32-wasi --release
+
+doc:
+	cargo doc
+
+fmt:
+	cargo fmt
+
+clean: 
+	cargo clean
+	rm -f Cargo.lock
+

--- a/sdk/rust-examples/ml-inference-native/src/main.rs
+++ b/sdk/rust-examples/ml-inference-native/src/main.rs
@@ -1,0 +1,61 @@
+//! An example program to call the Machine Learning Inference module.
+//!
+//! ## Context
+//!
+//! It calls the module mounted at path `/services/mlinf.dat`, via the postcard encoding of
+//! the interface,
+//! ```
+//! pub struct AesCtrInput {
+//!     key: [u8; 16],
+//!     iv: [u8; 16],
+//!     input_path: PathBuf,
+//!     output_path: PathBuf,
+//!     is_encryption: bool,
+//! }
+//! ```
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSE_MIT.markdown` in the Veracruz root directory for licensing
+//! and copyright information.
+
+use serde::Serialize;
+use std::{
+    fs::{read, write, File},
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+/// The interface between Counter mode AES service
+#[derive(Serialize, Debug)]
+pub struct MlInferenceInput {
+    input_path: PathBuf,
+    model_path: PathBuf,
+    output_path: PathBuf,
+}
+
+/// Example to invoke the Counter mode AES service. Encrypt `data.dat` and then 
+/// decrypt it using the `key.dat` and iv.dat`.
+fn main() -> anyhow::Result<()> {
+    println!("main");
+    let ml_inference_input = MlInferenceInput {
+        input_path: PathBuf::from("/input/data.dat"),
+        model_path: PathBuf::from("/input/model.weights"),
+        output_path: PathBuf::from("/output/prediction.dat"),
+    };
+    std::process::exit(0);
+    let result = read(&ml_inference_input.input_path)?;
+    println!("data input {:x?}", result);
+    println!("service input {:x?}", ml_inference_input);
+    let ml_inference_input_bytes = postcard::to_allocvec(&ml_inference_input)?;
+    println!("prepare the enc bytes {:x?}", ml_inference_input_bytes);
+    write("/services/mlinf.dat", ml_inference_input_bytes)?;
+    let result = read(ml_inference_input.output_path)?;
+    println!("prediction result {:x?}", result);
+    println!("service return");
+    Ok(())
+}

--- a/workspaces/applications/Cargo.toml
+++ b/workspaces/applications/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "crates/sdk/rust-examples/intersection-set-sum",
   "crates/sdk/rust-examples/linear-regression",
   "crates/sdk/rust-examples/logistic-regression",
+  "crates/sdk/rust-examples/ml-inference-native",
   "crates/sdk/rust-examples/moving-average-convergence-divergence",
   "crates/sdk/rust-examples/nop",
   "crates/sdk/rust-examples/number-stream-accumulation",

--- a/workspaces/shared.mk
+++ b/workspaces/shared.mk
@@ -35,7 +35,8 @@ WASM_PROG_LIST = random-source.wasm \
 				read-file.wasm \
 				shamir-secret-sharing.wasm \
 				fd-create.wasm \
-				aesctr-native.wasm
+				aesctr-native.wasm \
+				ml-inference-native.wasm
 
 WASM_PROG_FILES = $(patsubst %.wasm, $(OUT_DIR)/%.wasm, $(WASM_PROG_LIST))
 


### PR DESCRIPTION
Add a ML native module.
To make things easier we are focusing on inference for now, as the API for training is a little different.
The ML framework currently used is `darknet` to ease integration with the video object detection use case and be able to measure the performance increase compared to the WASM equivalent. We might change that in the future.

The native module will take a model (weighted graph) and an array (input to the model) as input and output a prediction (result of the inference). The parameters are passed via `/services/mlinf.dat`.