### PR TITLE
Improved error msg when a certificate is not found

### DIFF
--- a/test-collateral/generate-policy/src/main.rs
+++ b/test-collateral/generate-policy/src/main.rs
@@ -632,7 +632,8 @@ fn serialize_identities(arguments: &Arguments) -> Vec<Identity<String>> {
 
             values.push(Identity::new(certificates, id as u32, file_permissions));
         } else {
-            abort_with("Could not open certificate file.");
+            let error_msg = format!("Could not open certificate file {:?}.", cert);
+            abort_with(error_msg);
         }
     }
     values


### PR DESCRIPTION
When generating policies using `vc-pgen` if a certificate is not found this error was generated:

> Could not open certificate file.

This PR adds the certificate path to the error message. The result is something like:

> Could not open certificate file "example/example-program-cert.pem".