### PR TITLE
Ignore example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.swo
 *.bin
 *.png
+/example/**
 **/target/**
 test-collateral/*.dat
 test-collateral/*.json


### PR DESCRIPTION
In the [Quickstart file](https://github.com/veracruz-project/veracruz/blob/main/CLI_QUICKSTART.markdown) the files created by the user are put in the `example` folder. I'm not sure if this folder has a special meaning and it's always supposed to be used for the examples. If that's the case it might be useful to put it into the `.gitignore` file.