### PR TITLE
Make veracruz_server_linux a bit more reliable.

### DIFF
--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -63,6 +63,7 @@ nix = { version = "0.20.2", optional = true }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 psa-attestation = { path = "../psa-attestation", optional = true }
+rand = "0.8.3"
 rustls = "0.20.4"
 serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -33,6 +33,7 @@ icecap-qemu = []
 linux = [
   "data-encoding",
   "io-utils/linux",
+  "nix",
   "policy-utils/std",
   "tempfile",
   "veracruz-utils/linux",

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -2987,6 +2987,7 @@ dependencies = [
  "policy-utils",
  "postcard",
  "psa-attestation",
+ "rand",
  "rustls",
  "serde",
  "serde_json",

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -2987,6 +2987,7 @@ dependencies = [
  "policy-utils",
  "postcard",
  "psa-attestation",
+ "rand",
  "rustls",
  "serde",
  "serde_json",

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -2987,6 +2987,7 @@ dependencies = [
  "policy-utils",
  "postcard",
  "psa-attestation",
+ "rand",
  "rustls",
  "serde",
  "serde_json",


### PR DESCRIPTION
* Pick port number at random.
* Ignore SIGCHLD to avoid zombies.
* Kill runtime manager if there is an error.