### PR TITLE
Replace RUNTIME_ENCLAVE_SPAWN_DELAY with "--write-nl".

### DIFF
--- a/runtime-manager/src/runtime_manager_linux.rs
+++ b/runtime-manager/src/runtime_manager_linux.rs
@@ -173,6 +173,11 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
                 .help("SHA256 measurement of the Runtime Manager enclave binary.")
                 .value_name("MEASUREMENT"),
         )
+        .arg(
+            Arg::with_name("write_nl_when_ready")
+                .long("write-nl")
+                .help("Write a newline character when server is ready."),
+        )
         .get_matches();
 
     let port = if let Some(port) = matches.value_of("port") {
@@ -216,6 +221,10 @@ pub fn linux_main() -> Result<(), RuntimeManagerError> {
     })?;
 
     info!("TCP listener created on {}.", address);
+
+    if matches.is_present("write_nl_when_ready") {
+        println!("");
+    }
 
     let (mut fd, client_addr) = listener.accept().map_err(|ioerr| {
         error!(

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -182,6 +182,9 @@ pub enum VeracruzServerError {
     #[cfg(feature = "nitro")]
     #[error(display = "NitroServer: Non-Success HTTP Response received")]
     NonSuccessHttp,
+    /// Runtime manager did not start up correctly.
+    #[error(display = "Runtime manager did not start up correctly")]
+    RuntimeManagerFailed,
 }
 
 impl<T> From<std::sync::PoisonError<T>> for VeracruzServerError {


### PR DESCRIPTION
In `runtime_manager_linux.rs`, if `--write-nl` was specified, write a newline when the server is ready.

In `veracruz_server_linux.rs`, remove `RUNTIME_ENCLAVE_SPAWN_DELAY`, specify `--write-nl`, and expect to read a newline from the runtime managers's `stdout`.

There is a call to `nix::unistd::alarm::set` to generate `SIGALRM` in 30 seconds in case the runtime manager never starts up.
