### PR TITLE
Rework on the error handler in veracruz-client

### DIFF
--- a/tests/tests/integration_test.rs
+++ b/tests/tests/integration_test.rs
@@ -281,8 +281,7 @@ async fn veracruz_phase4_linear_regression_two_clients_parallel() {
             let program_data = read_local_file(prog_path).unwrap();
             info!("### program provider send binary.");
             client
-                .write_file("/program/linear-regression.wasm", &program_data)
-                .await?;
+                .write_file("/program/linear-regression.wasm", &program_data)?;
             Result::<()>::Ok(())
         };
         let data_provider_handle = async {
@@ -299,15 +298,13 @@ async fn veracruz_phase4_linear_regression_two_clients_parallel() {
             let data = read_local_file(&data_filename).unwrap();
             info!("### data provider send input.");
             client
-                .write_file("/input/linear-regression.dat", &data)
-                .await?;
+                .write_file("/input/linear-regression.dat", &data)?;
             info!("### data provider read result.");
             client
-                .request_compute("/program/linear-regression.wasm")
-                .await?;
-            client.read_file("/output/linear-regression.dat").await?;
+                .request_compute("/program/linear-regression.wasm")?;
+            client.read_file("/output/linear-regression.dat")?;
             info!("### data provider request shutdown.");
-            client.request_shutdown().await?;
+            client.request_shutdown()?;
             Result::<()>::Ok(())
         };
 
@@ -331,8 +328,8 @@ async fn server_tls_loop<P: AsRef<str>>(policy_json: P) -> Result<()> {
 
 /// Test states.
 struct TestExecutor {
-    // The policy for the runtime.
-    policy: Policy,
+    //// The policy for the runtime.
+    //policy: Policy,
     // The json string of the policy
     policy_json: String,
 }
@@ -372,7 +369,7 @@ impl TestExecutor {
         proxy_attestation_setup(policy.proxy_attestation_server_url().clone());
 
         Ok(TestExecutor {
-            policy,
+            //policy,
             policy_json,
         })
     }
@@ -415,7 +412,6 @@ impl TestExecutor {
                 info!("Process client{} event {:?}.", client_index, event);
                 let time_init = Instant::now();
                 Self::process_event(&mut client, &event)
-                    .await
                     .map_err(|e| {
                         error!("Client of index {}: {:?}", client_index, e);
                         e
@@ -454,28 +450,28 @@ impl TestExecutor {
         Ok(())
     }
 
-    async fn process_event(client: &mut VeracruzClient, event: &TestEvent) -> Result<()> {
+    fn process_event(client: &mut VeracruzClient, event: &TestEvent) -> Result<()> {
         match event {
             TestEvent::CheckHash => {
-                client.check_policy_hash().await?;
+                client.check_policy_hash()?;
                 client.check_runtime_hash()?;
             }
             TestEvent::WriteFile(remote_path, local_path) => {
                 let data = read_local_file(local_path)?;
-                client.write_file(remote_path, &data).await?;
+                client.write_file(remote_path, &data)?;
             }
             TestEvent::AppendFile(remote_path, local_path) => {
                 let data = read_local_file(local_path)?;
-                client.append_file(remote_path, &data).await?;
+                client.append_file(remote_path, &data)?;
             }
             TestEvent::Execute(remote_path) => {
-                client.request_compute(remote_path).await?;
+                client.request_compute(remote_path)?;
             }
             TestEvent::ReadFile(remote_path) => {
-                let result = client.read_file(&remote_path).await?;
+                let result = client.read_file(&remote_path)?;
                 info!("receive data of bytes {}", result.len());
             }
-            TestEvent::ShutDown => client.request_shutdown().await?,
+            TestEvent::ShutDown => client.request_shutdown()?,
         };
         Ok(())
     }

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -19,6 +19,7 @@ linux = []
 nitro = []
 
 [dependencies]
+anyhow = "1"
 base64 = "0.13.0"
 curl = "0.4.43"
 env_logger = { version = "0.9.0", optional = true }

--- a/veracruz-client/src/cli.rs
+++ b/veracruz-client/src/cli.rs
@@ -217,10 +217,7 @@ async fn main() {
             }
         };
 
-        match veracruz_client
-            .write_file(&program_name, &program_data)
-            .await
-        {
+        match veracruz_client.write_file(&program_name, &program_data) {
             Ok(()) => {}
             Err(err) => {
                 eprintln!("{}", err);
@@ -261,7 +258,7 @@ async fn main() {
             }
         };
 
-        match veracruz_client.write_file(data_name, &data_data).await {
+        match veracruz_client.write_file(data_name, &data_data) {
             Ok(()) => {}
             Err(err) => {
                 eprintln!("{}", err);
@@ -275,7 +272,7 @@ async fn main() {
         qprintln!(opt, "Requesting compute of <enclave>/{}", compute_name);
         did_something = true;
 
-        match veracruz_client.request_compute(&compute_name).await {
+        match veracruz_client.request_compute(&compute_name) {
             Ok(_) => {}
             Err(err) => {
                 eprintln!("{}", err);
@@ -297,7 +294,7 @@ async fn main() {
         );
         did_something = true;
 
-        let results = match veracruz_client.read_file(output_name).await {
+        let results = match veracruz_client.read_file(output_name) {
             Ok(results) => results,
             Err(err) => {
                 eprintln!("{}", err);
@@ -329,7 +326,7 @@ async fn main() {
         qprintln!(opt, "Shutting down enclave");
         did_something = true;
 
-        match veracruz_client.request_shutdown().await {
+        match veracruz_client.request_shutdown() {
             Ok(()) => {}
             Err(err) => {
                 eprintln!("{}", err);

--- a/veracruz-client/src/error.rs
+++ b/veracruz-client/src/error.rs
@@ -13,92 +13,28 @@ use err_derive::Error;
 
 #[derive(Debug, Error)]
 pub enum VeracruzClientError {
-    // NOTE: Protobuf does not implement clone, hence derive(clone) is impossible.
-    #[error(display = "VeracruzClient: HexError: {:?}.", _0)]
-    HexError(#[error(source)] hex::FromHexError),
-    #[error(display = "VeracruzClient: Base64Error: {:?}.", _0)]
-    Base64Error(#[error(source)] base64::DecodeError),
-    #[error(display = "VeracruzClient: Utf8Error: {:?}.", _0)]
-    Utf8Error(#[error(source)] std::str::Utf8Error),
-    #[error(display = "VeracruzClient: Reqwest: {:?}.", _0)]
-    ReqwestError(#[error(source)] reqwest::Error),
-    #[error(display = "VeracruzClient: Invalid reqwest estatus {:?}.", _0)]
-    InvalidReqwestError(reqwest::StatusCode),
-    #[error(display = "VeracruzClient: IOError: {:?}.", _0)]
-    IOError(#[error(source)] std::io::Error),
-    #[error(display = "VeracruzClient: TLSError: unspecified.")]
-    TLSUnspecifiedError,
-    #[error(display = "VeracruzClient: TLSError: invalid cyphersuite {:?}.", _0)]
-    TLSInvalidCiphersuiteError(std::string::String),
-    #[error(display = "VeracruzClient: MbedTLS: {:?}", _0)]
-    MbedTLSError(#[error(source)] mbedtls::Error),
-    #[error(display = "VeracruzClient: SerdeJsonError: {:?}.", _0)]
-    SerdeJsonError(#[error(source)] serde_json::error::Error),
-    #[error(display = "VeracruzClient: X509Error: {:?}.", _0)]
-    X509ParserPEMError(x509_parser::error::PEMError),
-    #[error(display = "VeracruzClient: X509Error: {:?}.", _0)]
-    X509ParserError(String),
-    #[error(display = "VeracruzClient: TryIntoError: {}.", _0)]
-    TryIntoError(#[error(source)] std::num::TryFromIntError),
-    #[error(display = "VeracruzClient: ParseIntError: {}.", _0)]
-    ParseIntError(#[error(source)] std::num::ParseIntError),
-    #[error(display = "VeracruzClient: TransportProtocolError: {:?}.", _0)]
-    TransportProtocolError(#[error(source)] transport_protocol::TransportProtocolError),
-    #[error(display = "VeracruzClient: PolicyError: {:?}.", _0)]
-    VeracruzUtilError(#[error(source)] policy_utils::error::PolicyError),
-    #[error(display = "VeracruzClient: Certificate expired: {:?}.", _0)]
-    CertificateExpireError(String),
-    #[error(
-        display = "VeracruzClient: MismatchError: variable `{}` mismatch, expected {:?} but received {:?}.",
-        variable,
-        expected,
-        received
-    )]
-    MismatchError {
-        variable: &'static str,
-        expected: std::vec::Vec<u8>,
-        received: std::vec::Vec<u8>,
-    },
-    #[error(
-        display = "VeracruzClient: Invalid length of variable `{}`, expected {}",
-        _0,
-        _1
-    )]
-    InvalidLengthError(&'static str, usize),
-    #[error(
-        display = "VeracruzClient: Function {} received non-success status: {:?}",
-        _0,
-        _1
-    )]
-    ResponseError(&'static str, transport_protocol::ResponseStatus),
+    #[error(display = "VeracruzClient: Received non-success status: {:?}", _0)]
+    ResponseStatus(transport_protocol::ResponseStatus),
     #[error(display = "VeracruzClient: Received no result from the Veracruz server")]
-    VeracruzServerResponseNoResultError,
-    #[error(display = "VeracruzClient: Too many interation: {:?}", _0)]
-    ExcessiveIterationError(&'static str),
-    #[error(display = "VeracruzClient: Unauthorized client certificate: {}.", _0)]
-    InvalidClientCertificateError(String),
+    ResponseNoResult,
     #[error(display = "VeracruzClient: No Peer certificates received")]
-    NoPeerCertificatesError,
-    #[error(display = "VeracruzClient: unexpected certificate error")]
-    UnexpectedCertificateError,
+    NoPeerCertificates,
+    #[error(display = "VeracruzClient: Unexpected certificate error")]
+    UnexpectedCertificate,
+    #[error(display = "VeracruzClient: Unexpected key error")]
+    UnexpectedKey,
+    #[error(display = "VeracruzClient: Unexpected policy error")]
+    UnexpectedPolicy,
+    #[error(display = "VeracruzClient: Unexpected ciphersuite error")]
+    UnexpectedCiphersuite,
     #[error(
         display = "VeracruzClient: Runtime enclave hash extension is not present in the peer certificate"
     )]
-    RuntimeHashExtensionMissingError,
-    #[error(display = "VeracruzClient: Direct message: {}.", _0)]
-    DirectMessage(String),
-    #[error(display = "VeracruzClient: Unable to read")]
-    UnableToReadError,
-    #[error(display = "VeracruzClient: No match found for runtime isolate hash")]
-    NoMatchingRuntimeIsolateHash,
-    #[error(display = "VeracruzClient: Invalid Path")]
+    RuntimeHashExtensionMissing,
+    #[error(display = "VeracruzClient: Unexpected runtime hash")]
+    UnexpectedRuntimeHash,
+    #[error(display = "VeracruzClient: Unvalid path")]
     InvalidPath,
-    #[error(display = "VeracruzClient: Lock failed")]
-    LockFailed,
-}
-
-impl From<x509_parser::error::PEMError> for VeracruzClientError {
-    fn from(error: x509_parser::error::PEMError) -> Self {
-        VeracruzClientError::X509ParserPEMError(error)
-    }
+    #[error(display = "VeracruzClient: Lock session failed")]
+    LockSessionFailed,
 }

--- a/veracruz-client/src/tests.rs
+++ b/veracruz-client/src/tests.rs
@@ -45,7 +45,7 @@ fn test_internal_read_all_bytes_in_file_succ() {
     if let Err(_) = File::create(filename).and_then(|mut file| file.write_all(content)) {
         panic!("cannot create test file: {}", filename);
     }
-    let rst = VeracruzClient::pub_read_all_bytes_in_file(filename);
+    let rst = VeracruzClient::read_all_bytes_in_file(filename);
     assert!(rst.is_ok());
     let rst_content = rst.unwrap();
     assert_eq!(rst_content, content);
@@ -53,32 +53,32 @@ fn test_internal_read_all_bytes_in_file_succ() {
 
 #[test]
 fn test_internal_read_all_bytes_in_file_invalid_file() {
-    assert!(VeracruzClient::pub_read_all_bytes_in_file(data_dir("invalid_file")).is_err());
+    assert!(VeracruzClient::read_all_bytes_in_file(data_dir("invalid_file")).is_err());
 }
 
 #[test]
 fn test_internal_read_all_bytes_in_file_invalid_path() {
-    assert!(VeracruzClient::pub_read_all_bytes_in_file("invalid_path").is_err());
+    assert!(VeracruzClient::read_all_bytes_in_file("invalid_path").is_err());
 }
 
 #[test]
 fn test_internal_read_cert_succ() {
-    assert!(VeracruzClient::pub_read_cert(trust_path(CLIENT_CERT_FILENAME)).is_ok());
+    assert!(VeracruzClient::read_cert(trust_path(CLIENT_CERT_FILENAME)).is_ok());
 }
 
 #[test]
 fn test_internal_read_cert_invalid_certificate() {
-    assert!(VeracruzClient::pub_read_cert(trust_path(CLIENT_KEY_FILENAME)).is_err());
+    assert!(VeracruzClient::read_cert(trust_path(CLIENT_KEY_FILENAME)).is_err());
 }
 
 #[test]
 fn test_internal_read_private_key_succ() {
-    assert!(VeracruzClient::pub_read_private_key(trust_path(CLIENT_KEY_FILENAME)).is_ok());
+    assert!(VeracruzClient::read_private_key(trust_path(CLIENT_KEY_FILENAME)).is_ok());
 }
 
 #[test]
 fn test_internal_read_cert_invalid_private_key() {
-    assert!(VeracruzClient::pub_read_private_key(trust_path(CLIENT_CERT_FILENAME)).is_err());
+    assert!(VeracruzClient::read_private_key(trust_path(CLIENT_CERT_FILENAME)).is_err());
 }
 
 #[test]

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -10,12 +10,13 @@
 //! information on licensing and copyright.
 
 use crate::error::VeracruzClientError;
+use anyhow::{anyhow, Result};
 use log::{error, info};
-use mbedtls::alloc::List;
-use mbedtls::x509::Certificate;
+use mbedtls::{alloc::List, pk::Pk, ssl::Context, x509::Certificate};
 use policy_utils::{parsers::enforce_leading_backslash, policy::Policy, Platform};
 use std::{
-    io::{Read, Write},
+    fs::File,
+    io::{BufReader, Read, Write},
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -28,7 +29,7 @@ use veracruz_utils::VERACRUZ_RUNTIME_HASH_EXTENSION_ID;
 /// expect multiple threads to be involved, since the compiler can not
 /// check this, it is safer to use a Mutex.
 pub struct VeracruzClient {
-    tls_context: mbedtls::ssl::Context<InsecureConnection>,
+    tls_context: Context<InsecureConnection>,
     remote_session_id: Arc<Mutex<Option<u32>>>,
     policy: Policy,
     policy_hash: String,
@@ -74,7 +75,7 @@ impl Write for InsecureConnection {
                 .unwrap_or(0),
             string_data
         );
-        let dest_url = format!("http://{:}/runtime_manager", self.veracruz_server_url,);
+        let dest_url = format!("http://{:}/runtime_manager", self.veracruz_server_url);
         // Spawn a separate thread so that we can use reqwest::blocking.
         let body = std::thread::spawn(move || {
             let client_build = reqwest::blocking::ClientBuilder::new()
@@ -122,13 +123,13 @@ impl VeracruzClient {
     /// Read all the bytes in the file.
     /// Return Ok(vec) if succ
     /// Otherwise return Err(msg) with the error message as String
-    fn read_all_bytes_in_file<P: AsRef<Path>>(filename: P) -> Result<Vec<u8>, VeracruzClientError> {
+    pub(crate) fn read_all_bytes_in_file<P: AsRef<Path>>(filename: P) -> Result<Vec<u8>> {
         let mut file = std::fs::File::open(filename)?;
         let mut buffer = std::vec::Vec::new();
         match file.read_to_end(&mut buffer) {
             Ok(_num) => (),
             Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => (),
-            Err(err) => return Err(VeracruzClientError::IOError(err)),
+            Err(err) => return Err(err.into()),
         }
 
         Ok(buffer)
@@ -138,17 +139,14 @@ impl VeracruzClient {
     /// Read the certificate in the file.
     /// Return Ok(vec) if succ
     /// Otherwise return Err(msg) with the error message as String
-    fn read_cert<P: AsRef<Path>>(
-        filename: P,
-    ) -> Result<List<mbedtls::x509::Certificate>, VeracruzClientError> {
+    pub(crate) fn read_cert<P: AsRef<Path>>(filename: P) -> Result<List<Certificate>> {
         let mut buffer = VeracruzClient::read_all_bytes_in_file(filename)?;
         buffer.push(b'\0');
-        let cert_vec = Certificate::from_pem_multiple(&buffer)
-            .map_err(|_| VeracruzClientError::TLSUnspecifiedError)?;
+        let cert_vec = Certificate::from_pem_multiple(&buffer)?;
         if cert_vec.iter().count() == 1 {
             Ok(cert_vec)
         } else {
-            Err(VeracruzClientError::InvalidLengthError("cert_vec", 1))
+            Err(anyhow!(VeracruzClientError::UnexpectedCertificate))
         }
     }
 
@@ -156,13 +154,10 @@ impl VeracruzClient {
     /// Read the private in the file.
     /// Return Ok(vec) if succ
     /// Otherwise return Err(msg) with the error message as String
-    fn read_private_key<P: AsRef<Path>>(
-        filename: P,
-    ) -> Result<mbedtls::pk::Pk, VeracruzClientError> {
+    pub(crate) fn read_private_key<P: AsRef<Path>>(filename: P) -> Result<Pk> {
         let mut buffer = VeracruzClient::read_all_bytes_in_file(filename)?;
         buffer.push(b'\0');
-        let pkey_vec = mbedtls::pk::Pk::from_private_key(&buffer, None)
-            .map_err(|_| VeracruzClientError::TLSUnspecifiedError)?;
+        let pkey_vec = Pk::from_private_key(&buffer, None)?;
         Ok(pkey_vec)
     }
 
@@ -171,30 +166,20 @@ impl VeracruzClient {
     /// check if the certificate is valid in term of time.
     fn check_certificate_validity<P: AsRef<Path>>(
         client_cert_filename: P,
-        public_key: &mut mbedtls::pk::Pk,
-    ) -> Result<(), VeracruzClientError> {
-        let cert_file = std::fs::File::open(&client_cert_filename)?;
-        let parsed_cert = x509_parser::pem::Pem::read(std::io::BufReader::new(cert_file))?;
-        let parsed_cert = parsed_cert
-            .0
-            .parse_x509()
-            .map_err(|e| VeracruzClientError::X509ParserError(e.to_string()))?
-            .tbs_certificate;
+        public_key: &mut Pk,
+    ) -> Result<()> {
+        let cert_file = File::open(&client_cert_filename)?;
+        let parsed_cert = x509_parser::pem::Pem::read(BufReader::new(cert_file))?;
+        let parsed_cert = parsed_cert.0.parse_x509()?.tbs_certificate;
         let cert_public_key_der =
-            mbedtls::pk::Pk::from_public_key(parsed_cert.subject_pki.subject_public_key.data)?
+            Pk::from_public_key(parsed_cert.subject_pki.subject_public_key.data)?
                 .write_public_der_vec()?;
 
         let public_key_der = public_key.write_public_der_vec()?;
         if cert_public_key_der != public_key_der {
-            Err(VeracruzClientError::MismatchError {
-                variable: "public_key",
-                expected: cert_public_key_der,
-                received: public_key_der,
-            })
+            Err(anyhow!(VeracruzClientError::UnexpectedKey))
         } else if parsed_cert.validity.time_to_expiration().is_none() {
-            Err(VeracruzClientError::CertificateExpireError(
-                client_cert_filename.as_ref().to_string_lossy().to_string(),
-            ))
+            Err(anyhow!(VeracruzClientError::UnexpectedCertificate))
         } else {
             Ok(())
         }
@@ -207,11 +192,11 @@ impl VeracruzClient {
         client_cert_filename: P1,
         client_key_filename: P2,
         policy_json: &str,
-    ) -> Result<VeracruzClient, VeracruzClientError> {
+    ) -> Result<VeracruzClient> {
         let policy = Policy::from_json(policy_json)?;
         let policy_hash = policy
             .policy_hash()
-            .expect("policy did not hash json?")
+            .ok_or(anyhow!(VeracruzClientError::UnexpectedPolicy))?
             .to_string();
 
         Self::with_policy_and_hash(
@@ -231,7 +216,7 @@ impl VeracruzClient {
         client_key_filename: P2,
         policy: Policy,
         policy_hash: String,
-    ) -> Result<VeracruzClient, VeracruzClientError> {
+    ) -> Result<VeracruzClient> {
         let client_cert = Self::read_cert(&client_cert_filename)?;
         let mut client_priv_key = Self::read_private_key(&client_key_filename)?;
 
@@ -241,22 +226,16 @@ impl VeracruzClient {
         let proxy_service_cert = {
             let mut certs_pem = policy.proxy_service_cert().clone();
             certs_pem.push('\0');
-            let certs = Certificate::from_pem_multiple(certs_pem.as_bytes()).map_err(|_| {
-                VeracruzClientError::X509ParserError("Certificate::from_pem_multiple".to_string())
-            })?;
+            let certs = Certificate::from_pem_multiple(certs_pem.as_bytes())?;
             certs
         };
-        let mut config = mbedtls::ssl::Config::new(
-            mbedtls::ssl::config::Endpoint::Client,
-            mbedtls::ssl::config::Transport::Stream,
-            mbedtls::ssl::config::Preset::Default,
-        );
-        config.set_min_version(mbedtls::ssl::config::Version::Tls1_2)?;
-        config.set_max_version(mbedtls::ssl::config::Version::Tls1_2)?;
+
+        use mbedtls::ssl::config::{Config, Endpoint, Preset, Transport, Version};
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+        config.set_min_version(Version::Tls1_2)?;
+        config.set_max_version(Version::Tls1_2)?;
         let policy_ciphersuite = veracruz_utils::lookup_ciphersuite(policy.ciphersuite().as_str())
-            .ok_or_else(|| {
-                VeracruzClientError::TLSInvalidCiphersuiteError(policy.ciphersuite().to_string())
-            })?;
+            .ok_or(anyhow!(VeracruzClientError::UnexpectedCiphersuite))?;
         let cipher_suites: Vec<i32> = vec![policy_ciphersuite.into(), 0];
         config.set_ciphersuites(Arc::new(cipher_suites));
         let entropy = Arc::new(mbedtls::rng::OsEntropy::new());
@@ -264,7 +243,7 @@ impl VeracruzClient {
         config.set_rng(rng);
         config.set_ca_list(Arc::new(proxy_service_cert), None);
         config.push_cert(Arc::new(client_cert), Arc::new(client_priv_key))?;
-        let mut ctx = mbedtls::ssl::Context::new(Arc::new(config));
+        let mut ctx = Context::new(Arc::new(config));
         let remote_session_id = Arc::new(Mutex::new(Some(0)));
         let conn = InsecureConnection {
             read_buffer: vec![],
@@ -283,123 +262,95 @@ impl VeracruzClient {
 
     /// A general pattern of the request, which lift the `serialize_functor` to a request to
     /// veracruz and parse the response.
-    pub async fn request_functor<P: AsRef<Path>>(
+    pub fn request_functor<P: AsRef<Path>>(
         &mut self,
         path: P,
         data: &[u8],
         serialize_functor: fn(&[u8], &str) -> transport_protocol::TransportProtocolResult,
-    ) -> Result<transport_protocol::RuntimeManagerResponse, VeracruzClientError> {
+    ) -> Result<transport_protocol::RuntimeManagerResponse> {
         let path = enforce_leading_backslash(
             path.as_ref()
                 .to_str()
                 .ok_or(VeracruzClientError::InvalidPath)?,
         );
         let serialized_data = serialize_functor(data, &path)?;
-        let response = self.send(&serialized_data).await?;
+        let response = self.send(&serialized_data)?;
 
         let parsed_response = transport_protocol::parse_runtime_manager_response(
             *self
                 .remote_session_id
                 .lock()
-                .map_err(|_| VeracruzClientError::LockFailed)?,
+                .map_err(|_| anyhow!(VeracruzClientError::LockSessionFailed))?,
             &response,
         )?;
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => Ok(parsed_response),
-            _ => Err(VeracruzClientError::ResponseError("Response", status)),
+            _ => Err(anyhow!(VeracruzClientError::ResponseStatus(status))),
         }
     }
 
     /// Request to write `data` to the `path` from the beginning.
-    pub async fn write_file<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        data: &[u8],
-    ) -> Result<(), VeracruzClientError> {
-        self.request_functor(path, data, transport_protocol::serialize_write_file)
-            .await?;
+    pub fn write_file<P: AsRef<Path>>(&mut self, path: P, data: &[u8]) -> Result<()> {
+        self.request_functor(path, data, transport_protocol::serialize_write_file)?;
         Ok(())
     }
 
     /// Request to append `data` to the `path`.
-    pub async fn append_file<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        data: &[u8],
-    ) -> Result<(), VeracruzClientError> {
-        self.request_functor(path, data, transport_protocol::serialize_append_file)
-            .await?;
+    pub fn append_file<P: AsRef<Path>>(&mut self, path: P, data: &[u8]) -> Result<()> {
+        self.request_functor(path, data, transport_protocol::serialize_append_file)?;
         Ok(())
     }
 
     /// Check the policy and runtime hashes, and request the veracruz to execute the program at the
     /// remote `path`.
-    pub async fn request_compute<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-    ) -> Result<Vec<u8>, VeracruzClientError> {
-        let parsed_response = self
-            .request_functor(path, &[], |_, path| {
-                transport_protocol::serialize_request_result(path)
-            })
-            .await?;
+    pub fn request_compute<P: AsRef<Path>>(&mut self, path: P) -> Result<Vec<u8>> {
+        let parsed_response = self.request_functor(path, &[], |_, path| {
+            transport_protocol::serialize_request_result(path)
+        })?;
 
         if !parsed_response.has_result() {
-            return Err(VeracruzClientError::VeracruzServerResponseNoResultError);
+            return Err(anyhow!(VeracruzClientError::ResponseNoResult));
         }
         Ok(parsed_response.get_result().data.clone())
     }
 
     /// Check the policy and runtime hashes, and read the result at the remote `path`.
-    pub async fn read_file<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-    ) -> Result<Vec<u8>, VeracruzClientError> {
-        let parsed_response = self
-            .request_functor(path, &[], |_, path| {
-                transport_protocol::serialize_read_file(path)
-            })
-            .await?;
+    pub fn read_file<P: AsRef<Path>>(&mut self, path: P) -> Result<Vec<u8>> {
+        let parsed_response = self.request_functor(path, &[], |_, path| {
+            transport_protocol::serialize_read_file(path)
+        })?;
 
         if !parsed_response.has_result() {
-            return Err(VeracruzClientError::VeracruzServerResponseNoResultError);
+            return Err(anyhow!(VeracruzClientError::ResponseNoResult));
         }
         Ok(parsed_response.get_result().data.clone())
     }
 
     /// Indicate the veracruz to shutdown.
-    pub async fn request_shutdown(&mut self) -> Result<(), VeracruzClientError> {
-        self
-            .request_functor("", &[], |_, _| {
-                transport_protocol::serialize_request_shutdown()
-            })
-            .await?;
+    pub fn request_shutdown(&mut self) -> Result<()> {
+        self.request_functor("", &[], |_, _| {
+            transport_protocol::serialize_request_shutdown()
+        })?;
         Ok(())
     }
 
     /// Request the hash of the remote policy and check if it matches.
-    pub async fn check_policy_hash(&mut self) -> Result<(), VeracruzClientError> {
-        let parsed_response = self
-            .request_functor("", &[], |_, _| {
-                transport_protocol::serialize_request_policy_hash()
-            })
-            .await?;
+    pub fn check_policy_hash(&mut self) -> Result<()> {
+        let parsed_response = self.request_functor("", &[], |_, _| {
+            transport_protocol::serialize_request_policy_hash()
+        })?;
 
         let received_hash = std::str::from_utf8(&parsed_response.get_policy_hash().data)?;
         if self.policy_hash != received_hash {
-            return Err(VeracruzClientError::MismatchError {
-                variable: "check_policy_hash",
-                expected: self.policy_hash.as_bytes().to_vec(),
-                received: received_hash.as_bytes().to_vec(),
-            });
+            Err(anyhow!(VeracruzClientError::UnexpectedPolicy))
         } else {
             Ok(())
         }
     }
 
     /// Check if the hash `received` matches those in the policy.
-    fn compare_runtime_hash(&self, received: &[u8]) -> Result<(), VeracruzClientError> {
+    fn compare_runtime_hash(&self, received: &[u8]) -> Result<()> {
         let platforms = vec![Platform::Linux, Platform::Nitro, Platform::IceCap];
         for platform in platforms {
             let expected = match self.policy.runtime_manager_hash(&platform) {
@@ -412,26 +363,26 @@ impl VeracruzClient {
                 return Ok(());
             }
         }
-        Err(VeracruzClientError::NoMatchingRuntimeIsolateHash)
+        Err(anyhow!(VeracruzClientError::UnexpectedRuntimeHash))
     }
 
     /// Request the hash of the remote veracruz runtime and check if it matches.
-    pub fn check_runtime_hash(&self) -> Result<(), VeracruzClientError> {
+    pub fn check_runtime_hash(&self) -> Result<()> {
         let certs = self.tls_context.peer_cert()?;
         if certs.iter().count() != 1 {
-            return Err(VeracruzClientError::NoPeerCertificatesError);
+            return Err(anyhow!(VeracruzClientError::NoPeerCertificates));
         }
         let cert = certs
-            .ok_or(VeracruzClientError::UnexpectedCertificateError)?
+            .ok_or(anyhow!(VeracruzClientError::UnexpectedCertificate))?
             .iter()
             .nth(0)
-            .ok_or(VeracruzClientError::UnexpectedCertificateError)?;
+            .ok_or(anyhow!(VeracruzClientError::UnexpectedCertificate))?;
         let extensions = cert.extensions()?;
         // check for OUR extension
         match veracruz_utils::find_extension(extensions, &VERACRUZ_RUNTIME_HASH_EXTENSION_ID) {
             None => {
                 error!("Our extension is not present. This should be fatal");
-                Err(VeracruzClientError::RuntimeHashExtensionMissingError)
+                Err(anyhow!(VeracruzClientError::RuntimeHashExtensionMissing))
             }
             Some(data) => {
                 info!("Certificate extension present.");
@@ -451,7 +402,7 @@ impl VeracruzClient {
 
     /// Send the data to the runtime_manager path on the Veracruz server
     /// and return the response.
-    async fn send(&mut self, data: &[u8]) -> Result<Vec<u8>, VeracruzClientError> {
+    pub(crate) fn send(&mut self, data: &[u8]) -> Result<Vec<u8>> {
         self.tls_context.write_all(&data)?;
         let mut response = vec![];
         match self.tls_context.read_to_end(&mut response) {
@@ -459,32 +410,5 @@ impl VeracruzClient {
             x => x?,
         };
         Ok(response)
-    }
-
-    // APIs for testing: expose internal functions
-    #[cfg(test)]
-    pub fn pub_read_all_bytes_in_file<P: AsRef<Path>>(
-        filename: P,
-    ) -> Result<Vec<u8>, VeracruzClientError> {
-        VeracruzClient::read_all_bytes_in_file(filename)
-    }
-
-    #[cfg(test)]
-    pub fn pub_read_cert<P: AsRef<Path>>(
-        filename: P,
-    ) -> Result<List<Certificate>, VeracruzClientError> {
-        VeracruzClient::read_cert(filename)
-    }
-
-    #[cfg(test)]
-    pub fn pub_read_private_key<P: AsRef<Path>>(
-        filename: P,
-    ) -> Result<mbedtls::pk::Pk, VeracruzClientError> {
-        VeracruzClient::read_private_key(filename)
-    }
-
-    #[cfg(test)]
-    pub async fn pub_send(&mut self, data: &Vec<u8>) -> Result<Vec<u8>, VeracruzClientError> {
-        self.send(data).await
     }
 }


### PR DESCRIPTION
Use anyhow as the error handler in `veracruz-client` and remove several async blocks.