### PR TITLE
Rework error handling in both veracruz and proxy servers, transport protocol, and session manager. 

### DIFF
--- a/policy-utils/src/parsers.rs
+++ b/policy-utils/src/parsers.rs
@@ -15,7 +15,6 @@
 
 #[cfg(feature = "std")]
 use super::{CANONICAL_STDERR_FILE_PATH, CANONICAL_STDIN_FILE_PATH, CANONICAL_STDOUT_FILE_PATH};
-use anyhow::Result;
 #[cfg(feature = "std")]
 use std::{borrow::Cow, ffi, path};
 

--- a/proxy-attestation-server/Cargo.toml
+++ b/proxy-attestation-server/Cargo.toml
@@ -35,6 +35,7 @@ nitro = [
 ]
 
 [dependencies]
+anyhow = "1"
 actix-http = "3"
 actix-rt = "2"
 actix-web = "4"

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -32,8 +32,9 @@ lazy_static! {
 
 /// Reads a PEM certificate from `pem_cert_path`, converts it to DER format,
 /// and stores it in CA_CERT_DER for use by the service
-pub fn load_ca_certificate<P: AsRef<path::Path>>(pem_cert_path: P) -> Result<(), ProxyAttestationServerError>
-{
+pub fn load_ca_certificate<P: AsRef<path::Path>>(
+    pem_cert_path: P,
+) -> Result<(), ProxyAttestationServerError> {
     let mut f = std::fs::File::open(pem_cert_path).map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer)?;

--- a/proxy-attestation-server/src/attestation.rs
+++ b/proxy-attestation-server/src/attestation.rs
@@ -32,9 +32,7 @@ lazy_static! {
 
 /// Reads a PEM certificate from `pem_cert_path`, converts it to DER format,
 /// and stores it in CA_CERT_DER for use by the service
-pub fn load_ca_certificate<P>(pem_cert_path: P) -> Result<(), ProxyAttestationServerError>
-where
-    P: AsRef<path::Path>,
+pub fn load_ca_certificate<P: AsRef<path::Path>>(pem_cert_path: P) -> Result<(), ProxyAttestationServerError>
 {
     let mut f = std::fs::File::open(pem_cert_path).map_err(ProxyAttestationServerError::IOError)?;
     let mut buffer: Vec<u8> = Vec::new();

--- a/proxy-attestation-server/src/attestation/nitro.rs
+++ b/proxy-attestation-server/src/attestation/nitro.rs
@@ -124,20 +124,18 @@ pub fn attestation_token(body_string: String) -> ProxyAttestationServerResponder
     let (att_doc_data, device_id) =
         transport_protocol::parse_nitro_attestation_doc(parsed.get_nitro_attestation_doc());
 
-    let attestation_document =
-        AttestationDocument::authenticate(&att_doc_data, &AWS_NITRO_ROOT_CERTIFICATE).map_err(
-            |err| {
-                println!(
+    let attestation_document = AttestationDocument::authenticate(
+        &att_doc_data,
+        &AWS_NITRO_ROOT_CERTIFICATE,
+    )
+    .map_err(|err| {
+        println!(
             "proxy-attestation-server::nitro::attestation_token authenticate_token failed:{:?}",
             err
         );
-                let _ignore = std::io::stdout().flush();
-                ProxyAttestationServerError::CborError(format!(
-                    "parse_nitro_token failed to parse token data:{:?}",
-                    err
-                ))
-            },
-        )?;
+        let _ignore = std::io::stdout().flush();
+        anyhow::anyhow!(err)
+    })?;
 
     let attestation_context = {
         let mut ac_hash = ATTESTATION_CONTEXT.lock()

--- a/proxy-attestation-server/src/error.rs
+++ b/proxy-attestation-server/src/error.rs
@@ -86,11 +86,19 @@ pub enum ProxyAttestationServerError {
     IOError(#[error(source)] std::io::Error),
     #[error(display = "ProxyAttestationServer: BadState error")]
     BadStateError,
+    #[error(display = "ProxyAttestationServer: Anyhow error {:?}", _0)]
+    Anyhow(anyhow::Error),
 }
 
 impl<T> From<std::sync::PoisonError<T>> for ProxyAttestationServerError {
     fn from(error: std::sync::PoisonError<T>) -> Self {
         ProxyAttestationServerError::LockError(format!("{:?}", error))
+    }
+}
+
+impl From<anyhow::Error> for ProxyAttestationServerError {
+    fn from(error: anyhow::Error) -> Self {
+        ProxyAttestationServerError::Anyhow(error)
     }
 }
 

--- a/proxy-attestation-server/src/error.rs
+++ b/proxy-attestation-server/src/error.rs
@@ -16,16 +16,8 @@ pub type ProxyAttestationServerResponder = Result<String, ProxyAttestationServer
 
 #[derive(Debug, Error)]
 pub enum ProxyAttestationServerError {
-    #[error(display = "ProxyAttestationServer: HexError: {:?}.", _0)]
-    HexError(#[error(source)] hex::FromHexError),
     #[error(display = "ProxyAttestationServer: Base64Error: {:?}.", _0)]
     Base64Error(#[error(source)] base64::DecodeError),
-    #[error(display = "ProxyAttestationServer: TransportProtocolError: {:?}.", _0)]
-    TransportProtocolError(#[error(source)] transport_protocol::TransportProtocolError),
-    #[error(display = "ProxyAttestationServer: Utf8Error: {:?}.", _0)]
-    Utf8Error(#[error(source)] std::str::Utf8Error),
-    #[error(display = "ProxyAttestationServer: SerdeJsonError: {:?}.", _0)]
-    SerdeJsonError(#[error(source)] serde_json::Error),
     #[error(
         display = "ProxyAttestationServer: OpenSSLError (an error stack): {:#?}.",
         _0
@@ -64,8 +56,6 @@ pub enum ProxyAttestationServerError {
         _0
     )]
     MissingFieldError(&'static str),
-    #[error(display = "ProxyAttestationServer: Failed to verify {}.", _0)]
-    FailedToVerifyError(&'static str),
     #[error(display = "ProxyAttestationServer: Unknown attestation protocol.")]
     UnknownAttestationTokenError,
     #[error(
@@ -76,10 +66,6 @@ pub enum ProxyAttestationServerError {
     UnsupportedRequestError,
     #[error(display = "ProxyAttestationServer: Direct message {}.", _0)]
     DirectMessageError(String, StatusCode),
-    #[error(display = "ProxyAttestationServer: cbor error {}.", _0)]
-    CborError(String),
-    #[error(display = "ProxyAttestationServer: Mutex error {}.", _0)]
-    MutexError(String),
     #[error(display = "ProxyAttestationServer: CSR Verify failed")]
     CsrVerifyError,
     #[error(display = "ProxyAttestationServer: IOError {}.", _0)]

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -156,10 +156,6 @@ fn parse_incoming_buffer(
                 _otherwise => Err(e),
             }
         },
-        //match e {
-            //TransportProtocolError::PartialBuffer(_) => Ok(None),
-            //e2 => Err(anyhow!(e2)),
-        //},
     }
 }
 

--- a/runtime-manager/src/managers/execution_engine_manager.rs
+++ b/runtime-manager/src/managers/execution_engine_manager.rs
@@ -150,10 +150,16 @@ fn parse_incoming_buffer(
 ) -> Result<Option<transport_protocol::RuntimeManagerRequest>> {
     match transport_protocol::parse_runtime_manager_request(Some(tls_session_id), &input) {
         Ok(v) => Ok(Some(v)),
-        Err(e) => match e {
-            TransportProtocolError::PartialBuffer(_) => Ok(None),
-            e2 => Err(anyhow!(e2)),
+        Err(e) => {
+            match e.downcast_ref::<TransportProtocolError>() {
+                Some(TransportProtocolError::PartialBuffer(_)) => Ok(None),
+                _otherwise => Err(e),
+            }
         },
+        //match e {
+            //TransportProtocolError::PartialBuffer(_) => Ok(None),
+            //e2 => Err(anyhow!(e2)),
+        //},
     }
 }
 

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -17,6 +17,7 @@ std = [
 ]
 
 [dependencies]
+anyhow = "1"
 err-derive = "0.2"
 mbedtls = { path = "../third-party/rust-mbedtls/mbedtls" }
 platform-services = { path = "../platform-services" }

--- a/session-manager/Xargo.toml
+++ b/session-manager/Xargo.toml
@@ -1,9 +1,0 @@
-
-[patch.crates-io]
-compiler_builtins = { git = "https://github.com/veracruz-project/compiler-builtins.git", branch = "veracruz" }
-libc = { git = "https://github.com/veracruz-project/libc.git", branch = "veracruz" }
-rustc-std-workspace-alloc = { git = "https://github.com/veracruz-project/rust.git", branch = "veracruz" }
-rustc-std-workspace-core = { git = "https://github.com/veracruz-project/rust.git", branch = "veracruz" }
-[dependencies.std]
-branch = "veracruz"
-git = "https://github.com/veracruz-project/rust.git"

--- a/session-manager/src/error.rs
+++ b/session-manager/src/error.rs
@@ -15,46 +15,17 @@ use err_derive::Error;
 
 /// The various different error modes associated with the session manager
 /// module.
-///
-/// NOTE: `protobuf` does not implement `Clone`, so deriving `Clone` for this
-/// type is impossible.
 #[derive(Debug, Error)]
 pub enum SessionManagerError {
-    /// A generic, unspecified TLS error occurred.
-    #[error(display = "Session manager: an unspecified or unknown TLS error occurred.")]
-    TLSUnspecifiedError,
     /// An invalid, or unknown, ciphersuite was requested.
     #[error(
         display = "Session manager: an invalid cyphersuite was requested in the TLS handshake: {:?}.",
         _0
     )]
     TLSInvalidCiphersuiteError(std::string::String),
-    /// An IO error occurred, with an accompanying error code.
-    #[error(display = "Session manager: an IO error occurred: {:?}.", _0)]
-    IOError(#[error(source)] std::io::Error),
-    /// A generic error occurred in the MbedTLS library.
-    #[error(
-        display = "Session manager: an unspecified error occurred in the MbedTLS library: {:?}.",
-        _0
-    )]
-    MbedtlsUnspecifiedError(#[error(source)] mbedtls::Error),
     /// The runtime failed to obtain the peer certificates from the TLS session.
     #[error(display = "Session manager: failed to retrieve peer certificates.")]
     PeerCertificateError,
-    /// The length of a variable (e.g. the number of expected peer certificates)
-    /// did not match expectations.
-    #[error(
-        display = "Session manager: invalid length of variable `{}`, expected {}",
-        _0,
-        _1
-    )]
-    InvalidLengthError(&'static str, usize),
-    /// A principal has not been assigned any roles in the Veracruz computation.
-    #[error(
-        display = "Session manager: principal {} has not been assigned any role in the computation.",
-        _0
-    )]
-    EmptyRoleError(u64),
     /// A cryptographic certificate was missing.
     #[error(display = "Session manager: no certificate was found.")]
     NoCertificateError,
@@ -62,6 +33,6 @@ pub enum SessionManagerError {
     #[error(display = "Session manager: invalid state")]
     InvalidStateError,
     /// Failed to obtain lock (internal error).
-    #[error(display = "Session manager: lock failed")]
-    LockError,
+    #[error(display = "Session manager: shared buffer lock failed")]
+    SharedBufferLock,
 }

--- a/session-manager/src/session.rs
+++ b/session-manager/src/session.rs
@@ -12,8 +12,8 @@
 //! information on licensing and copyright.
 
 use crate::error::SessionManagerError;
-use mbedtls::alloc::List;
-use mbedtls::x509::Certificate;
+use anyhow::{anyhow, Result};
+use mbedtls::{alloc::List, x509::Certificate};
 use policy_utils::principal::Identity;
 
 use std::{
@@ -107,10 +107,7 @@ impl Write for InsecureConnection {
 impl Session {
     /// Creates a new session from a server configuration and a list of
     /// principals.
-    pub fn new(
-        config: mbedtls::ssl::Config,
-        principals: &Vec<Principal>,
-    ) -> Result<Self, SessionManagerError> {
+    pub fn new(config: Config, principals: &Vec<Principal>) -> Result<Self> {
         let tls_context = mbedtls::ssl::Context::new(Arc::new(config));
         let shared_buffers = Arc::new(Mutex::new(Buffers {
             read_buffer: vec![],
@@ -126,10 +123,10 @@ impl Session {
     }
 
     /// Writes the contents of `input` over the session's TLS server session.
-    pub fn send_tls_data(&mut self, input: &mut Vec<u8>) -> Result<(), SessionManagerError> {
+    pub fn send_tls_data(&mut self, input: &mut Vec<u8>) -> Result<()> {
         self.shared_buffers
             .lock()
-            .map_err(|_| SessionManagerError::LockError)?
+            .map_err(|_| SessionManagerError::SharedBufferLock)?
             .read_buffer
             .append(input);
         Ok(())
@@ -137,7 +134,7 @@ impl Session {
 
     /// Writes the entirety of the `input` buffer over the TLS connection.
     #[inline]
-    pub fn write_plaintext_data(&mut self, input: &[u8]) -> Result<(), SessionManagerError> {
+    pub fn write_plaintext_data(&mut self, input: &[u8]) -> Result<()> {
         self.tls_context.write_all(&input)?;
         Ok(())
     }
@@ -146,18 +143,18 @@ impl Session {
     /// session has no data to read, returns `Ok(None)`.  If data is available
     /// for reading, returns `Ok(Some(buffer))` for some byte buffer, `buffer`.
     /// If reading fails, then an error is returned.
-    pub fn read_tls_data(&mut self) -> Result<Option<Vec<u8>>, SessionManagerError> {
+    pub fn read_tls_data(&mut self) -> Result<Option<Vec<u8>>> {
         let mut shared_buffers = self
             .shared_buffers
             .lock()
-            .map_err(|_| SessionManagerError::LockError)?;
+            .map_err(|_| SessionManagerError::SharedBufferLock)?;
         Ok(shared_buffers.write_buffer.take())
     }
 
     /// Reads data via the established TLS session, returning the unique client
     /// ID and the set of roles associated with the principal that sent the
     /// data.
-    pub fn read_plaintext_data(&mut self) -> Result<Option<(u32, Vec<u8>)>, SessionManagerError> {
+    pub fn read_plaintext_data(&mut self) -> Result<Option<(u32, Vec<u8>)>> {
         let mut received_buffer = vec![];
         self.established()?;
         let t = self.tls_context.read_to_end(&mut received_buffer);
@@ -171,10 +168,10 @@ impl Session {
             let peer_certs = self.tls_context.peer_cert()?;
             if peer_certs.iter().count() == 1 {
                 let peer_cert = peer_certs
-                    .ok_or(SessionManagerError::PeerCertificateError)?
+                    .ok_or(anyhow!(SessionManagerError::PeerCertificateError))?
                     .iter()
                     .nth(0)
-                    .ok_or(SessionManagerError::PeerCertificateError)?
+                    .ok_or(anyhow!(SessionManagerError::PeerCertificateError))?
                     .as_der();
 
                 for principal in self.principals.iter() {
@@ -196,17 +193,17 @@ impl Session {
 
     /// Returns `true` iff the session's TLS server session has data to be read.
     #[inline]
-    pub fn read_tls_needed(&self) -> Result<bool, SessionManagerError> {
+    pub fn read_tls_needed(&self) -> Result<bool> {
         let r = Ok(self
             .shared_buffers
             .lock()
-            .map_err(|_| SessionManagerError::LockError)?
+            .map_err(|_| SessionManagerError::SharedBufferLock)?
             .write_buffer
             .is_some());
         r
     }
 
-    fn established(&mut self) -> Result<(), SessionManagerError> {
+    fn established(&mut self) -> Result<()> {
         if !self.established {
             let conn = InsecureConnection {
                 shared_buffers: Arc::clone(&self.shared_buffers),

--- a/session-manager/src/session.rs
+++ b/session-manager/src/session.rs
@@ -13,9 +13,8 @@
 
 use crate::error::SessionManagerError;
 use anyhow::{anyhow, Result};
-use mbedtls::{alloc::List, x509::Certificate};
+use mbedtls::{alloc::List, x509::Certificate, ssl::Config};
 use policy_utils::principal::Identity;
-
 use std::{
     io::{Read, Write},
     sync::{Arc, Mutex},

--- a/tests/tests/server_test.rs
+++ b/tests/tests/server_test.rs
@@ -40,13 +40,13 @@ use std::{
     vec::Vec,
 };
 use transport_protocol;
-use veracruz_server::veracruz_server::*;
+use veracruz_server::common::*;
 #[cfg(feature = "icecap")]
-use veracruz_server::VeracruzServerIceCap as VeracruzServerEnclave;
+use veracruz_server::icecap::VeracruzServerIceCap as VeracruzServerEnclave;
 #[cfg(feature = "linux")]
-use veracruz_server::VeracruzServerLinux as VeracruzServerEnclave;
+use veracruz_server::linux::veracruz_server_linux::VeracruzServerLinux as VeracruzServerEnclave;
 #[cfg(feature = "nitro")]
-use veracruz_server::VeracruzServerNitro as VeracruzServerEnclave;
+use veracruz_server::nitro::veracruz_server_nitro::VeracruzServerNitro as VeracruzServerEnclave;
 use veracruz_utils::VERACRUZ_RUNTIME_HASH_EXTENSION_ID;
 
 // Policy files

--- a/transport-protocol/Cargo.toml
+++ b/transport-protocol/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.3.0"
 icecap = []
 
 [dependencies]
+anyhow = "1"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 protobuf = "=2.8.1"

--- a/transport-protocol/src/custom.rs
+++ b/transport-protocol/src/custom.rs
@@ -9,11 +9,12 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+use anyhow::{anyhow, Result};
 use crate::transport_protocol;
 use err_derive::Error;
 use lazy_static::lazy_static;
 use protobuf::{error::ProtobufError, Message, ProtobufEnum};
-use std::{collections::HashMap, result::Result, string::ToString, sync::Mutex, vec::Vec};
+use std::{collections::HashMap, string::ToString, sync::Mutex, vec::Vec};
 
 pub const LENGTH_PREFIX_SIZE: usize = 8;
 
@@ -53,7 +54,7 @@ pub enum TransportProtocolError {
     )]
     MutexError(u32),
 }
-pub type TransportProtocolResult = Result<std::vec::Vec<u8>, TransportProtocolError>;
+pub type TransportProtocolResult = Result<std::vec::Vec<u8>>;
 
 /// Strip the length prefix from the input buffer.
 /// Return the length and the stripped buffer.
@@ -61,9 +62,9 @@ pub type TransportProtocolResult = Result<std::vec::Vec<u8>, TransportProtocolEr
 fn get_length_prefix(
     session_id: u32,
     buffer: &[u8],
-) -> Result<(u64, &[u8]), TransportProtocolError> {
+) -> Result<(u64, &[u8])> {
     if buffer.len() < LENGTH_PREFIX_SIZE {
-        return Err(TransportProtocolError::MissingLengthPrefix(session_id));
+        return Err(anyhow!(TransportProtocolError::MissingLengthPrefix(session_id)));
     }
 
     let mut length_bytes: [u8; LENGTH_PREFIX_SIZE] = [0; LENGTH_PREFIX_SIZE];
@@ -112,7 +113,7 @@ fn handle_protocol_buffer(session_id: Option<u32>, mut input: &[u8]) -> Transpor
 
     let (expected_length, incoming_buffer) = match incoming_buffer_hash.get_mut(&session_id) {
         Some(v) => v,
-        None => return Err(TransportProtocolError::BufferNotFound(session_id)),
+        None => return Err(anyhow!(TransportProtocolError::BufferNotFound(session_id))),
     };
 
     // Append chunk to incoming buffer
@@ -128,7 +129,7 @@ fn handle_protocol_buffer(session_id: Option<u32>, mut input: &[u8]) -> Transpor
     // might be the case or if it is hopeless and we could just error out.
 
     if incoming_buffer.len() < *expected_length as usize {
-        Err(TransportProtocolError::PartialBuffer(session_id))
+        Err(anyhow!(TransportProtocolError::PartialBuffer(session_id)))
     } else {
         let incoming_buffer = incoming_buffer.to_vec();
         incoming_buffer_hash.remove(&session_id);
@@ -140,7 +141,7 @@ fn handle_protocol_buffer(session_id: Option<u32>, mut input: &[u8]) -> Transpor
 pub fn parse_runtime_manager_request(
     session_id: Option<u32>,
     buffer: &[u8],
-) -> Result<transport_protocol::RuntimeManagerRequest, TransportProtocolError> {
+) -> Result<transport_protocol::RuntimeManagerRequest> {
     let full_unprefixed_buffer = handle_protocol_buffer(session_id, buffer)?;
     Ok(protobuf::parse_from_bytes::<
         transport_protocol::RuntimeManagerRequest,
@@ -151,7 +152,7 @@ pub fn parse_runtime_manager_request(
 pub fn parse_runtime_manager_response(
     session_id: Option<u32>,
     buffer: &[u8],
-) -> Result<transport_protocol::RuntimeManagerResponse, TransportProtocolError> {
+) -> Result<transport_protocol::RuntimeManagerResponse> {
     let full_unprefixed_buffer = handle_protocol_buffer(session_id, buffer)?;
     Ok(protobuf::parse_from_bytes::<
         transport_protocol::RuntimeManagerResponse,
@@ -161,7 +162,7 @@ pub fn parse_runtime_manager_response(
 pub fn parse_proxy_attestation_server_request(
     session_id: Option<u32>,
     buffer: &[u8],
-) -> Result<transport_protocol::ProxyAttestationServerRequest, TransportProtocolError> {
+) -> Result<transport_protocol::ProxyAttestationServerRequest> {
     let full_unprefixed_buffer = handle_protocol_buffer(session_id, buffer)?;
     Ok(protobuf::parse_from_bytes::<
         transport_protocol::ProxyAttestationServerRequest,
@@ -171,7 +172,7 @@ pub fn parse_proxy_attestation_server_request(
 pub fn parse_proxy_attestation_server_response(
     session_id: Option<u32>,
     buffer: &[u8],
-) -> Result<transport_protocol::ProxyAttestationServerResponse, TransportProtocolError> {
+) -> Result<transport_protocol::ProxyAttestationServerResponse> {
     let full_unprefixed_buffer = handle_protocol_buffer(session_id, buffer)?;
     Ok(protobuf::parse_from_bytes::<
         transport_protocol::ProxyAttestationServerResponse,
@@ -376,7 +377,7 @@ pub fn serialize_psa_attestation_init(challenge: &[u8], device_id: i32) -> Trans
 
 pub fn parse_psa_attestation_init(
     pai: &transport_protocol::PsaAttestationInit,
-) -> Result<(std::vec::Vec<u8>, i32), TransportProtocolError> {
+) -> Result<(std::vec::Vec<u8>, i32)> {
     Ok((pai.get_challenge().to_vec(), pai.get_device_id()))
 }
 
@@ -472,7 +473,7 @@ pub fn serialize_result(
 
 pub fn parse_result(
     response: &transport_protocol::RuntimeManagerResponse,
-) -> Result<Option<std::vec::Vec<u8>>, TransportProtocolError> {
+) -> Result<Option<std::vec::Vec<u8>>> {
     let status = response.get_status();
     let decoded_status = match status {
         transport_protocol::ResponseStatus::UNSET => -1,
@@ -485,7 +486,7 @@ pub fn parse_result(
         transport_protocol::ResponseStatus::FAILED_INVALID_REQUEST => 6,
     };
     if status != transport_protocol::ResponseStatus::SUCCESS {
-        return Err(TransportProtocolError::ResponseStatusError(decoded_status));
+        return Err(anyhow!(TransportProtocolError::ResponseStatusError(decoded_status)));
     }
 
     let data_opt = {

--- a/veracruz-server/src/cli.rs
+++ b/veracruz-server/src/cli.rs
@@ -9,8 +9,8 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use anyhow::anyhow;
 use actix_rt;
+use anyhow::anyhow;
 use log::info;
 use policy_utils::policy::Policy;
 use std::{fs, path, process};

--- a/veracruz-server/src/common.rs
+++ b/veracruz-server/src/common.rs
@@ -10,7 +10,7 @@
 //! information on licensing and copyright.
 
 #[cfg(feature = "icecap")]
-use crate::veracruz_server_icecap::IceCapError;
+use crate::platforms::icecap::IceCapError;
 use actix_web::{error, http::StatusCode, HttpResponse, HttpResponseBuilder};
 use err_derive::Error;
 #[cfg(feature = "nitro")]

--- a/veracruz-server/src/platforms/icecap.rs
+++ b/veracruz-server/src/platforms/icecap.rs
@@ -9,7 +9,7 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use crate::veracruz_server::{VeracruzServer, VeracruzServerError};
+use crate::common::{VeracruzServer, VeracruzServerError};
 use err_derive::Error;
 use io_utils::http::{post_buffer, send_proxy_attestation_server_start};
 use policy_utils::policy::Policy;
@@ -264,7 +264,11 @@ impl IceCapRealm {
     fn shutdown(self) -> Result<(), IceCapError> {
         println!("vc-server: shutting down");
         self.signal_handle.close();
-        self.child.lock().unwrap().kill().map_err(|e| IceCapError::ChannelError(e))?;
+        self.child
+            .lock()
+            .unwrap()
+            .kill()
+            .map_err(|e| IceCapError::ChannelError(e))?;
         Ok(())
     }
 }
@@ -276,7 +280,11 @@ impl VeracruzServerIceCap {
         &mut self,
         request: &RuntimeManagerRequest,
     ) -> Result<RuntimeManagerResponse, VeracruzServerError> {
-        let response = self.0.as_mut().ok_or(VeracruzServerError::UninitializedEnclaveError)?.communicate(request)?;
+        let response = self
+            .0
+            .as_mut()
+            .ok_or(VeracruzServerError::UninitializedEnclaveError)?
+            .communicate(request)?;
         Ok(response)
     }
 
@@ -312,8 +320,9 @@ impl VeracruzServer for VeracruzServerIceCap {
             };
 
         let (root_cert, compute_cert) = {
-            let req =
-                transport_protocol::serialize_native_psa_attestation_token(&token, &csr, device_id)?;
+            let req = transport_protocol::serialize_native_psa_attestation_token(
+                &token, &csr, device_id,
+            )?;
             let req = base64::encode(&req);
             let url = format!(
                 "{:}/PSA/AttestationToken",

--- a/veracruz-server/src/platforms/linux.rs
+++ b/veracruz-server/src/platforms/linux.rs
@@ -404,7 +404,7 @@ pub mod veracruz_server_linux {
                 let req = serialize_native_psa_attestation_token(&token, &csr, challenge_id).map_err(|e| {
                     error!("Failed to serialize native PSA attestation token request.  Error received: {:?}.", e);
 
-                    VeracruzServerError::TransportProtocolError(e)
+                    e
                 })?;
                 let req = base64::encode(&req);
                 let url = format!("{}/PSA/AttestationToken", proxy_attestation_server_url);
@@ -421,7 +421,7 @@ pub mod veracruz_server_linux {
                 let pasr = parse_proxy_attestation_server_response(None, &resp).map_err(|e| {
                     error!("Failed to parse reponse from proxy attestation server.  Error received: {:?}.", e);
 
-                    VeracruzServerError::TransportProtocolError(e)
+                    e
                 })?;
                 let cert_chain = pasr.get_cert_chain();
                 let root_cert = cert_chain.get_root_cert();

--- a/veracruz-server/src/platforms/linux.rs
+++ b/veracruz-server/src/platforms/linux.rs
@@ -12,7 +12,7 @@
 #[cfg(feature = "linux")]
 pub mod veracruz_server_linux {
 
-    use crate::{veracruz_server::VeracruzServer, VeracruzServerError, VeracruzServerResult};
+    use crate::common::{VeracruzServer, VeracruzServerError, VeracruzServerResult};
     use data_encoding::HEXLOWER;
     use io_utils::{
         http::{post_buffer, send_proxy_attestation_server_start},
@@ -141,10 +141,7 @@ pub mod veracruz_server_linux {
         ///    deserialized.
         /// 3. The Runtime Manager enclave sends back a message indicating that
         ///    it was not expecting further TLS data to be requested.
-        pub fn read_tls_data(
-            &mut self,
-            session_id: u32,
-        ) ->VeracruzServerResult<(bool, Vec<u8>)> {
+        pub fn read_tls_data(&mut self, session_id: u32) -> VeracruzServerResult<(bool, Vec<u8>)> {
             info!(
                 "Reading TLS data from Runtime Manager enclave (with session: {}).",
                 session_id
@@ -490,10 +487,7 @@ pub mod veracruz_server_linux {
         }
 
         #[inline]
-        fn plaintext_data(
-            &mut self,
-            _data: Vec<u8>,
-        ) -> VeracruzServerResult<Option<Vec<u8>>> {
+        fn plaintext_data(&mut self, _data: Vec<u8>) -> VeracruzServerResult<Option<Vec<u8>>> {
             Err(VeracruzServerError::UnimplementedError)
         }
 
@@ -509,7 +503,8 @@ pub mod veracruz_server_linux {
 
             info!("Awaiting response...");
 
-            let message: RuntimeManagerResponse = receive_message(&mut self.runtime_manager_socket)?;
+            let message: RuntimeManagerResponse =
+                receive_message(&mut self.runtime_manager_socket)?;
 
             match message {
                 RuntimeManagerResponse::TlsSession(session_id) => {
@@ -540,7 +535,8 @@ pub mod veracruz_server_linux {
 
             info!("Awaiting response...");
 
-            let message: RuntimeManagerResponse = receive_message(&mut self.runtime_manager_socket)?;
+            let message: RuntimeManagerResponse =
+                receive_message(&mut self.runtime_manager_socket)?;
 
             info!("Response received.");
 
@@ -584,7 +580,8 @@ pub mod veracruz_server_linux {
 
             info!("Awaiting response...");
 
-            let message: RuntimeManagerResponse = receive_message(&mut self.runtime_manager_socket)?;
+            let message: RuntimeManagerResponse =
+                receive_message(&mut self.runtime_manager_socket)?;
 
             info!("Response received.");
 

--- a/veracruz-server/src/platforms/mod.rs
+++ b/veracruz-server/src/platforms/mod.rs
@@ -1,6 +1,6 @@
-//! Veracruz server
+//! Veracruz Server on Specific Platforms.
 //!
-//! ## Authors
+//! ## Authors
 //!
 //! The Veracruz Development Team.
 //!
@@ -9,11 +9,9 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-pub mod common;
-pub use self::common::*;
-
-pub mod server;
-pub use self::server::*;
-
-pub mod platforms;
-pub use self::platforms::*;
+#[cfg(feature = "icecap")]
+pub mod icecap;
+#[cfg(feature = "linux")]
+pub mod linux;
+#[cfg(feature = "nitro")]
+pub mod nitro;

--- a/veracruz-server/src/platforms/nitro.rs
+++ b/veracruz-server/src/platforms/nitro.rs
@@ -11,7 +11,7 @@
 
 #[cfg(feature = "nitro")]
 pub mod veracruz_server_nitro {
-    use crate::veracruz_server::{VeracruzServer, VeracruzServerError, VeracruzServerResult};
+    use crate::common::{VeracruzServer, VeracruzServerError, VeracruzServerResult};
     use io_utils::{
         http::{post_buffer, send_proxy_attestation_server_start},
         nitro::NitroEnclave,
@@ -125,10 +125,7 @@ pub mod veracruz_server_nitro {
             Ok(meta)
         }
 
-        fn plaintext_data(
-            &mut self,
-            _data: Vec<u8>,
-        ) -> VeracruzServerResult<Option<Vec<u8>>> {
+        fn plaintext_data(&mut self, _data: Vec<u8>) -> VeracruzServerResult<Option<Vec<u8>>> {
             Err(VeracruzServerError::UnimplementedError)
         }
 
@@ -289,7 +286,8 @@ pub mod veracruz_server_nitro {
         );
 
         let body_vec = base64::decode(&received_body)?;
-        let response = transport_protocol::parse_proxy_attestation_server_response(None, &body_vec)?;
+        let response =
+            transport_protocol::parse_proxy_attestation_server_response(None, &body_vec)?;
 
         let (re_cert, ca_cert) = if response.has_cert_chain() {
             let cert_chain = response.get_cert_chain();

--- a/veracruz-server/src/server.rs
+++ b/veracruz-server/src/server.rs
@@ -9,14 +9,13 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use crate::veracruz_server::*;
+use crate::common::*;
 #[cfg(feature = "icecap")]
-use crate::veracruz_server_icecap::VeracruzServerIceCap as VeracruzServerEnclave;
+use crate::platforms::icecap::VeracruzServerIceCap as VeracruzServerEnclave;
 #[cfg(feature = "linux")]
-use crate::veracruz_server_linux::veracruz_server_linux::VeracruzServerLinux as VeracruzServerEnclave;
+use crate::platforms::linux::veracruz_server_linux::VeracruzServerLinux as VeracruzServerEnclave;
 #[cfg(feature = "nitro")]
-use crate::veracruz_server_nitro::veracruz_server_nitro::VeracruzServerNitro as VeracruzServerEnclave;
-
+use crate::platforms::nitro::veracruz_server_nitro::VeracruzServerNitro as VeracruzServerEnclave;
 use actix_web::{dev::Server, middleware, post, web, App, HttpRequest, HttpServer};
 use base64;
 use futures::executor;
@@ -27,7 +26,7 @@ use std::{
     thread,
 };
 
-type EnclaveHandlerServer = Box<dyn crate::veracruz_server::VeracruzServer + Sync + Send>;
+type EnclaveHandlerServer = Box<dyn crate::common::VeracruzServer + Sync + Send>;
 type EnclaveHandler = Arc<Mutex<Option<EnclaveHandlerServer>>>;
 
 #[post("/veracruz_server")]

--- a/veracruz-server/src/veracruz_server.rs
+++ b/veracruz-server/src/veracruz_server.rs
@@ -12,63 +12,27 @@
 #[cfg(feature = "icecap")]
 use crate::veracruz_server_icecap::IceCapError;
 use actix_web::{error, http::StatusCode, HttpResponse, HttpResponseBuilder};
-#[cfg(feature = "nitro")]
-use base64;
 use err_derive::Error;
 #[cfg(feature = "nitro")]
 use io_utils::nitro::NitroError;
-use io_utils::{error::SocketError, http::HttpError};
 use std::error::Error;
 
 pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 
 #[derive(Debug, Error)]
 pub enum VeracruzServerError {
-    #[error(display = "VeracruzServer: HexError: {:?}.", _0)]
-    HexError(#[error(source)] hex::FromHexError),
-    #[error(display = "VeracruzServer: Utf8Error: {:?}.", _0)]
-    Utf8Error(#[error(source)] std::str::Utf8Error),
-    #[error(display = "VeracruzServer: FromUtf8Error: {:?}.", _0)]
-    FromUtf8Error(#[error(source)] std::string::FromUtf8Error),
     #[error(display = "VeracruzServer: SerdeJsonError: {:?}.", _0)]
     SerdeJsonError(#[error(source)] serde_json::Error),
-    #[error(
-        display = "VeracruzServer: Function {} received non-success status: {:?}",
-        _0,
-        _1
-    )]
-    ResponseError(&'static str, transport_protocol::ResponseStatus),
     #[error(display = "VeracruzServer: IOError: {:?}.", _0)]
     IOError(#[error(source)] std::io::Error),
     #[error(display = "VeracruzServer: Base64Error: {:?}.", _0)]
     Base64Error(#[error(source)] base64::DecodeError),
-    #[error(display = "VeracruzServer: TLSError: unspecified.")]
-    TLSUnspecifiedError,
-    #[error(display = "VeracruzServer: Invalid cipher suite: {:?}", _0)]
-    InvalidCiphersuiteError(String),
     #[error(display = "VeracruzServer: Failed to obtain lock {:?}.", _0)]
     LockError(String),
-    #[error(display = "VeracruzServer: TryIntoError: {}.", _0)]
-    TryIntoError(#[error(source)] std::num::TryFromIntError),
     #[error(display = "VeracruzServer: ParseIntError: {}.", _0)]
     ParseIntError(#[error(source)] std::num::ParseIntError),
     #[error(display = "VeracruzServer: MpscSendError (of type ()) Error: {}.", _0)]
     MpscSendEmptyError(#[error(source)] std::sync::mpsc::SendError<()>),
-    #[error(
-        display = "VeracruzServer: MpscSendError (of type std::sync::mpsc::SendError<(u32, std::vec::Vec<u8>)>) Error: {}.",
-        _0
-    )]
-    MpscSendU32VecU8Error(#[error(source)] std::sync::mpsc::SendError<(u32, std::vec::Vec<u8>)>),
-    #[error(
-        display = "VeracruzServer: MpscSendError (of type std::vec::Vec<u8>) Error: {}.",
-        _0
-    )]
-    MpscSendVecU8Error(#[error(source)] std::sync::mpsc::SendError<std::vec::Vec<u8>>),
-    #[error(display = "VeracruzServer: Mpsc TryRecvError: {}.", _0)]
-    MpscTryRecvError(#[error(source)] std::sync::mpsc::TryRecvError),
-    /// A HTTP error was produced.
-    #[error(display = "Http error: {}.", _0)]
-    HttpError(HttpError),
     #[cfg(any(feature = "linux", feature = "nitro"))]
     #[error(display = "VeracruzServer: BincodeError: {:?}", _0)]
     BincodeError(bincode::ErrorKind),
@@ -82,15 +46,11 @@ pub enum VeracruzServerError {
     )]
     InvalidRuntimeManagerResponse(veracruz_utils::runtime_manager_message::RuntimeManagerResponse),
     #[cfg(feature = "nitro")]
-    #[cfg(any(feature = "linux", feature = "nitro"))]
     #[error(display = "VeracruzServer: Received Invalid Protocol Buffer Message")]
     InvalidProtoBufMessage,
     #[cfg(feature = "nitro")]
     #[error(display = "VeracruzServer: Nix Error: {:?}", _0)]
     NixError(#[error(source)] nix::Error),
-    #[cfg(feature = "nitro")]
-    #[error(display = "VeracruzServer: Serde Error")]
-    SerdeError,
     #[cfg(feature = "nitro")]
     #[error(display = "VeracruzServer: Veracruz Socket Error:{:?}", _0)]
     VeracruzSocketError(#[error(source)] io_utils::error::SocketError),
@@ -99,74 +59,17 @@ pub enum VeracruzServerError {
     NitroError(#[error(source)] NitroError),
     #[cfg(feature = "icecap")]
     #[error(display = "VeracruzServer: IceCap error: {:?}", _0)]
-    IceCapError(IceCapError),
-    #[error(display = "VeracruzServer: Enclave function {} failed.", _0)]
-    EnclaveCallError(&'static str),
-    #[error(
-        display = "VeracruzServer: Missing {}, which is caused by non-existence, empty field, null, zero, etc.",
-        _0
-    )]
-    MissingFieldError(&'static str),
-    #[error(
-        display = "VeracruzServer: MismatchError: variable `{}` mismatch, expected {:?} but received {:?}.",
-        variable,
-        expected,
-        received
-    )]
-    MismatchError {
-        variable: &'static str,
-        expected: std::vec::Vec<u8>,
-        received: std::vec::Vec<u8>,
-    },
+    IceCapError(#[error(source)] IceCapError),
     #[error(display = "VeracruzServer: TransportProtocolError: {:?}.", _0)]
     TransportProtocolError(#[error(source)] transport_protocol::TransportProtocolError),
-    #[error(display = "VeracruzServer: Postcard Error: {:?}.", _0)]
-    PostcardError(#[error(source)] postcard::Error),
     #[error(display = "VeracruzServer: Join Error: {:?}.", _0)]
     JoinError(std::boxed::Box<dyn std::any::Any + Send + 'static>),
-    #[error(
-        display = "VeracruzServer: Invalid length of variable `{}`, expected {}",
-        _0,
-        _1
-    )]
-    InvalidLengthError(&'static str, usize),
     #[error(display = "VeracruzServer: Uninitialized enclave.")]
     UninitializedEnclaveError,
-    #[error(display = "VeracruzServer: Unknown attestation protocol.")]
-    UnknownAttestationTokenError,
-    #[error(display = "VeracruzServer: Unsupported request (not implemented in this platform).")]
-    UnimplementedRequestError,
-    #[error(display = "VeracruzServer: Unsupported request (not found).")]
-    UnsupportedRequestError,
     #[error(display = "VeracruzServer: Invalid request format")]
     InvalidRequestFormatError,
-    #[error(display = "VeracruzServer: Received non-success post status.")]
-    ReceivedNonSuccessPostStatusError,
-    #[error(display = "VeracruzServer: Debug is disable.")]
-    DebugIsDisableError,
-    #[error(display = "VeracruzServer: Direct response message {}.", _0)]
-    DirectMessageError(String, StatusCode),
-    #[error(display = "VeracruzServer: Error message {}.", _0)]
-    DirectStrError(&'static str),
     #[error(display = "VeracruzServer: Unimplemented")]
     UnimplementedError,
-    #[error(display = "VeracruzServer: Invalid runtime manager hash")]
-    InvalidRuntimeManagerHash,
-    /// Transport protocol buffer handling returned an error
-    #[cfg(feature = "nitro")]
-    #[error(display = "VeracruzServer: TransportProtocol error:{}", _0)]
-    TransportProtocol(transport_protocol::custom::TransportProtocolError),
-    /// A base64 decode error occurred
-    // #[cfg(feature = "nitro")]
-    #[error(display = "VeracruzServer: Base64 Decode error:{:?}", _0)]
-    Base64Decode(base64::DecodeError),
-    /// Some socket-related functionality failed.
-    #[error(display = "VeracruzServer: socket error:{:?}", _0)]
-    SocketError(SocketError),
-    /// A remote http server returned a non-success (200) status
-    #[cfg(feature = "nitro")]
-    #[error(display = "NitroServer: Non-Success HTTP Response received")]
-    NonSuccessHttp,
     /// Runtime manager did not start up correctly.
     #[error(display = "Runtime manager did not start up correctly")]
     RuntimeManagerFailed,
@@ -192,13 +95,7 @@ impl error::ResponseError for VeracruzServerError {
         HttpResponseBuilder::new(self.status_code()).body(format!("{:?}", self))
     }
     fn status_code(&self) -> StatusCode {
-        match self {
-            VeracruzServerError::DirectMessageError(_, e) => *e,
-            VeracruzServerError::UnimplementedRequestError
-            | VeracruzServerError::UnknownAttestationTokenError => StatusCode::NOT_IMPLEMENTED,
-            VeracruzServerError::UnsupportedRequestError => StatusCode::NOT_FOUND,
-            _otherwise => StatusCode::INTERNAL_SERVER_ERROR,
-        }
+        StatusCode::INTERNAL_SERVER_ERROR
     }
 }
 
@@ -209,26 +106,28 @@ impl From<std::boxed::Box<bincode::ErrorKind>> for VeracruzServerError {
     }
 }
 
+pub type VeracruzServerResult<T> = Result<T, VeracruzServerError>;
+
 pub trait VeracruzServer {
-    fn new(policy: &str) -> Result<Self, VeracruzServerError>
+    fn new(policy: &str) -> VeracruzServerResult<Self>
     where
         Self: Sized;
 
-    fn plaintext_data(&mut self, _data: Vec<u8>) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+    fn plaintext_data(&mut self, _data: Vec<u8>) -> VeracruzServerResult<Option<Vec<u8>>> {
         // this function is not strictly needed, should we remove at some point?
         unimplemented!();
     }
 
-    fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError>;
+    fn new_tls_session(&mut self) -> VeracruzServerResult<u32>;
 
-    fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError>;
+    fn close_tls_session(&mut self, session_id: u32) -> VeracruzServerResult<()>;
 
     // The first bool indicates if the enclave is active, and the second vec contains the response
     fn tls_data(
         &mut self,
         session_id: u32,
         input: Vec<u8>,
-    ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError>;
+    ) -> VeracruzServerResult<(bool, Option<Vec<Vec<u8>>>)>;
 
     fn shutdown_isolate(&mut self) -> Result<(), Box<dyn Error>>;
 }

--- a/veracruz-server/src/veracruz_server_linux.rs
+++ b/veracruz-server/src/veracruz_server_linux.rs
@@ -12,7 +12,7 @@
 #[cfg(feature = "linux")]
 pub mod veracruz_server_linux {
 
-    use crate::{veracruz_server::VeracruzServer, VeracruzServerError};
+    use crate::{veracruz_server::VeracruzServer, VeracruzServerError, VeracruzServerResult};
     use data_encoding::HEXLOWER;
     use io_utils::{
         http::{post_buffer, send_proxy_attestation_server_start},
@@ -85,7 +85,7 @@ pub mod veracruz_server_linux {
         /// 2. The response could be not be received, or deserialized.
         /// 3. The response was received and deserialized correctly, but was of
         ///    an unexpected form.
-        pub fn tls_data_needed(&mut self, session_id: u32) -> Result<bool, VeracruzServerError> {
+        pub fn tls_data_needed(&mut self, session_id: u32) -> VeracruzServerResult<bool> {
             info!("Checking whether TLS data can be read from Runtime Manager enclave (with session: {}).", session_id);
 
             info!("Sending TLS data check message.");
@@ -144,7 +144,7 @@ pub mod veracruz_server_linux {
         pub fn read_tls_data(
             &mut self,
             session_id: u32,
-        ) -> Result<(bool, Vec<u8>), VeracruzServerError> {
+        ) ->VeracruzServerResult<(bool, Vec<u8>)> {
             info!(
                 "Reading TLS data from Runtime Manager enclave (with session: {}).",
                 session_id
@@ -205,7 +205,7 @@ pub mod veracruz_server_linux {
 
     impl VeracruzServer for VeracruzServerLinux {
         /// Creates a new instance of the `VeracruzServerLinux` type.
-        fn new(policy: &str) -> Result<Self, VeracruzServerError>
+        fn new(policy: &str) -> VeracruzServerResult<Self>
         where
             Self: Sized,
         {
@@ -493,11 +493,11 @@ pub mod veracruz_server_linux {
         fn plaintext_data(
             &mut self,
             _data: Vec<u8>,
-        ) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+        ) -> VeracruzServerResult<Option<Vec<u8>>> {
             Err(VeracruzServerError::UnimplementedError)
         }
 
-        fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
+        fn new_tls_session(&mut self) -> VeracruzServerResult<u32> {
             info!("Requesting new TLS session.");
 
             send_message(
@@ -528,7 +528,7 @@ pub mod veracruz_server_linux {
             }
         }
 
-        fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
+        fn close_tls_session(&mut self, session_id: u32) -> VeracruzServerResult<()> {
             info!("Requesting close of TLS session with ID: {}.", session_id);
 
             send_message(
@@ -569,7 +569,7 @@ pub mod veracruz_server_linux {
             &mut self,
             session_id: u32,
             input: Vec<u8>,
-        ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError> {
+        ) -> VeracruzServerResult<(bool, Option<Vec<Vec<u8>>>)> {
             info!(
                 "Sending TLS data to runtime manager enclave (with session {}).",
                 session_id

--- a/veracruz-server/src/veracruz_server_nitro.rs
+++ b/veracruz-server/src/veracruz_server_nitro.rs
@@ -11,7 +11,7 @@
 
 #[cfg(feature = "nitro")]
 pub mod veracruz_server_nitro {
-    use crate::veracruz_server::{VeracruzServer, VeracruzServerError};
+    use crate::veracruz_server::{VeracruzServer, VeracruzServerError, VeracruzServerResult};
     use io_utils::{
         http::{post_buffer, send_proxy_attestation_server_start},
         nitro::NitroEnclave,
@@ -34,7 +34,7 @@ pub mod veracruz_server_nitro {
     }
 
     impl VeracruzServer for VeracruzServerNitro {
-        fn new(policy_json: &str) -> Result<Self, VeracruzServerError> {
+        fn new(policy_json: &str) -> VeracruzServerResult<Self> {
             // Set up, initialize Nitro Root Enclave
             let policy: Policy = Policy::from_json(policy_json)?;
 
@@ -128,11 +128,11 @@ pub mod veracruz_server_nitro {
         fn plaintext_data(
             &mut self,
             _data: Vec<u8>,
-        ) -> Result<Option<Vec<u8>>, VeracruzServerError> {
+        ) -> VeracruzServerResult<Option<Vec<u8>>> {
             Err(VeracruzServerError::UnimplementedError)
         }
 
-        fn new_tls_session(&mut self) -> Result<u32, VeracruzServerError> {
+        fn new_tls_session(&mut self) -> VeracruzServerResult<u32> {
             let nls_message = RuntimeManagerRequest::NewTlsSession;
             let nls_buffer = bincode::serialize(&nls_message)?;
             self.enclave.send_buffer(&nls_buffer)?;
@@ -151,7 +151,7 @@ pub mod veracruz_server_nitro {
             Ok(session_id)
         }
 
-        fn close_tls_session(&mut self, session_id: u32) -> Result<(), VeracruzServerError> {
+        fn close_tls_session(&mut self, session_id: u32) -> VeracruzServerResult<()> {
             let cts_message = RuntimeManagerRequest::CloseTlsSession(session_id);
             let cts_buffer = bincode::serialize(&cts_message)?;
 
@@ -171,7 +171,7 @@ pub mod veracruz_server_nitro {
             &mut self,
             session_id: u32,
             input: Vec<u8>,
-        ) -> Result<(bool, Option<Vec<Vec<u8>>>), VeracruzServerError> {
+        ) -> VeracruzServerResult<(bool, Option<Vec<Vec<u8>>>)> {
             let std_message: RuntimeManagerRequest =
                 RuntimeManagerRequest::SendTlsData(session_id, input);
             let std_buffer: Vec<u8> = bincode::serialize(&std_message)?;
@@ -243,7 +243,7 @@ pub mod veracruz_server_nitro {
     }
 
     impl VeracruzServerNitro {
-        fn tls_data_needed(&self, session_id: u32) -> Result<bool, VeracruzServerError> {
+        fn tls_data_needed(&self, session_id: u32) -> VeracruzServerResult<bool> {
             let gtdn_message = RuntimeManagerRequest::GetTlsDataNeeded(session_id);
             let gtdn_buffer: Vec<u8> = bincode::serialize(&gtdn_message)?;
 
@@ -265,7 +265,7 @@ pub mod veracruz_server_nitro {
         proxy_attestation_server_url: &str,
         att_doc: &[u8],
         challenge_id: i32,
-    ) -> Result<Vec<Vec<u8>>, VeracruzServerError> {
+    ) -> VeracruzServerResult<Vec<Vec<u8>>> {
         let serialized_nitro_attestation_doc_request =
             transport_protocol::serialize_nitro_attestation_doc(att_doc, challenge_id)?;
         let encoded_str = base64::encode(&serialized_nitro_attestation_doc_request);


### PR DESCRIPTION
Rework the error handling and codebase.
- Use `anyhow` for handling errors in `session` and `transport-protocol`.
- Remove the unused error cases in `veracruz-server` and `proxy-server`. Note that these two crates still use customed Error types as they implement `actix` error message.
- Change the code structure of `veracruz-server`.