### PR TITLE
Remove rust-psa-crypto; use rust-mbedtls instead.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,9 +27,6 @@
 	path = third-party/wasmi
 	url = https://github.com/veracruz-project/wasmi.git
 	branch = veracruz
-[submodule "third-party/rust-psa-crypto"]
-	path = third-party/rust-psa-crypto
-	url = https://github.com/veracruz-project/rust-psa-crypto.git
 [submodule "workspaces/icecap-runtime/deps/seL4"]
 	path = workspaces/icecap-runtime/deps/seL4
 	url = https://gitlab.com/arm-research/security/icecap/seL4.git

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -32,13 +32,13 @@ cfg-if = "1"
 ctor = "=0.1.16"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+mbedtls = { path = "../third-party/rust-mbedtls/mbedtls" }
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 postcard = { version = "0.7.2", features = [ "alloc", "use-std" ] }
 platform-services = { path = "../platform-services" }
 policy-utils = { path = "../policy-utils" }
-psa-crypto = { path = "../third-party/rust-psa-crypto/psa-crypto" }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.24"

--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -18,9 +18,9 @@ nitro = []
 
 [dependencies]
 libc = "0.2.124"
-# We are not really using psa-crypto-sys but we are using the C
-# libraries libmbedcrypto.a and libshim.a that psa-crypto-sys uses.
-psa-crypto-sys = { path = "../third-party/rust-psa-crypto/psa-crypto-sys" }
+# We are not really using mbedtls-sys-auto but we are using the C
+# libraries libmbedcrypto.a and libshim.a that mbedtls-sys-auto builds.
+mbedtls-sys-auto = { path = "../third-party/rust-mbedtls/mbedtls-sys" }
 
 [build-dependencies]
 bindgen = "0.59.2"

--- a/psa-attestation/build.rs
+++ b/psa-attestation/build.rs
@@ -47,7 +47,7 @@ fn main() {
 
     println!("cargo:rustc-link-lib=static=psa_attestation");
     println!("cargo:rustc-link-search={:}", target_dir);
-    // These two C libraries come from psa-crypto / psa-crypto-sys:
+    // These two C libraries come from mbedtls-sys-auto:
     println!("cargo:rustc-link-lib=static=mbedcrypto");
     println!("cargo:rustc-link-lib=static=shim");
 

--- a/psa-attestation/c_src/Makefile
+++ b/psa-attestation/c_src/Makefile
@@ -11,7 +11,7 @@
 
 OUT_DIR?=.
 CFLAGS=-g -fPIC
-INCLUDE_PATHS=-I ../include/ -I ../include/internal/ -I ../../third-party/rust-psa-crypto/psa-crypto-sys/vendor/include -I ../lib/QCBOR/inc -I ../lib/t_cose/inc -I ../lib/t_cose/inc/t_cose -I ../lib/psa_crypto/include/
+INCLUDE_PATHS=-I ../include/ -I ../include/internal/ -I ../../third-party/rust-mbedtls/mbedtls-sys/vendor/include -I ../lib/QCBOR/inc -I ../lib/t_cose/inc -I ../lib/t_cose/inc/t_cose -I ../lib/psa_crypto/include/
 
 .PHONY: clean all
 
@@ -57,7 +57,7 @@ $(OUT_DIR)/qcbor_err_to_str.o: $(QCBOR_SRC_DIR)/qcbor_err_to_str.c
 
 T_COSE_OBJ=$(OUT_DIR)/t_cose_sign1_verify.o $(OUT_DIR)/t_cose_sign1_sign.o $(OUT_DIR)/t_cose_util.o $(OUT_DIR)/t_cose_parameters.o $(OUT_DIR)/t_cose_psa_crypto.o
 T_COSE_SRC_DIR=../lib/t_cose
-T_COSE_INCLUDE_PATHS=-I../lib/QCBOR/inc -I../lib/t_cose/inc -I../lib/t_cose/src -I../../third-party/rust-psa-crypto/psa-crypto-sys/vendor/include -DT_COSE_USE_PSA_CRYPTO
+T_COSE_INCLUDE_PATHS=-I../lib/QCBOR/inc -I../lib/t_cose/inc -I../lib/t_cose/src -I../../third-party/rust-mbedtls/mbedtls-sys/vendor/include -DT_COSE_USE_PSA_CRYPTO
 
 $(OUT_DIR)/t_cose_sign1_verify.o: $(T_COSE_SRC_DIR)/src/t_cose_sign1_verify.c
 	$(CC) -c $(CFLAGS) -o $@ $< $(T_COSE_INCLUDE_PATHS)

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4.19", optional = true }
 err-derive = "0.2"
 mbedtls = { path = "../third-party/rust-mbedtls/mbedtls" }
 platform-services = { path = "../platform-services" }
-psa-crypto = { path = "../third-party/rust-psa-crypto/psa-crypto" }
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 serde = { version = "1.0.115", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false }

--- a/veracruz-utils/src/sha256.rs
+++ b/veracruz-utils/src/sha256.rs
@@ -9,14 +9,15 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory
 //! for information on licensing and copyright.
 
-use psa_crypto;
-use psa_crypto::operations::hash;
-use psa_crypto::types::algorithm::Hash;
+use mbedtls::hash::{Md, Type};
 
 /// Compute SHA-256 hash/digest.
 pub fn sha256(x: &[u8]) -> Vec<u8> {
-    psa_crypto::init().unwrap();
-    let mut hash = vec![0; Hash::Sha256.hash_length()];
-    hash::hash_compute(Hash::Sha256, x, &mut hash).unwrap();
-    hash
+    const HASH_SIZE: usize = 32;
+    let mut out: [u8; HASH_SIZE] = [0; HASH_SIZE];
+    let n = Md::hash(Type::Sha256, x, &mut out);
+    if n.is_err() || n.unwrap() != HASH_SIZE {
+        panic!("bad sha256")
+    }
+    out.to_vec()
 }

--- a/workspaces/host/Cargo.lock
+++ b/workspaces/host/Cargo.lock
@@ -609,13 +609,13 @@ dependencies = [
  "err-derive",
  "lazy_static",
  "log",
+ "mbedtls",
  "num",
  "num-derive",
  "num-traits",
  "platform-services",
  "policy-utils",
  "postcard",
- "psa-crypto",
  "serde",
  "serde_json",
  "strum",
@@ -1001,7 +1001,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1339,26 +1338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
-]
-
-[[package]]
 name = "psm"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,15 +1554,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1904,7 +1874,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -1928,17 +1897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -2241,27 +2199,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/host/Cargo.toml
+++ b/workspaces/host/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/third-party/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1943,27 +1942,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -2138,15 +2117,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2816,7 +2786,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2840,17 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -3022,27 +2980,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/icecap-host/Cargo.toml
+++ b/workspaces/icecap-host/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/third-party/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [

--- a/workspaces/icecap-runtime/Cargo.lock
+++ b/workspaces/icecap-runtime/Cargo.lock
@@ -652,13 +652,13 @@ dependencies = [
  "err-derive",
  "lazy_static",
  "log",
+ "mbedtls",
  "num",
  "num-derive",
  "num-traits",
  "platform-services",
  "policy-utils",
  "postcard",
- "psa-crypto",
  "serde",
  "serde_json",
  "strum",
@@ -1286,7 +1286,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1691,27 +1690,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -1982,15 +1961,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2380,7 +2350,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2433,17 +2402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -2746,27 +2704,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/icecap-runtime/Cargo.toml
+++ b/workspaces/icecap-runtime/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/icecap/sysroot/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1943,27 +1942,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -2138,15 +2117,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2816,7 +2786,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2840,17 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -3022,27 +2980,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/linux-host/Cargo.toml
+++ b/workspaces/linux-host/Cargo.toml
@@ -15,7 +15,6 @@ cargo-features = ["resolver"]
 [workspace]
 exclude = [
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
 ]
 members = [
   "crates/proxy-attestation-server",

--- a/workspaces/linux-runtime/Cargo.lock
+++ b/workspaces/linux-runtime/Cargo.lock
@@ -653,13 +653,13 @@ dependencies = [
  "err-derive",
  "lazy_static",
  "log",
+ "mbedtls",
  "num",
  "num-derive",
  "num-traits",
  "platform-services",
  "policy-utils",
  "postcard",
- "psa-crypto",
  "serde",
  "serde_json",
  "strum",
@@ -1272,7 +1272,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1677,27 +1676,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -1968,15 +1947,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2366,7 +2336,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2390,17 +2359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -2703,27 +2661,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/linux-runtime/Cargo.toml
+++ b/workspaces/linux-runtime/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/icecap/sysroot/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1943,27 +1942,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -2138,15 +2117,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2816,7 +2786,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2840,17 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -3022,27 +2980,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/nitro-host/Cargo.toml
+++ b/workspaces/nitro-host/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/third-party/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [

--- a/workspaces/nitro-runtime/Cargo.lock
+++ b/workspaces/nitro-runtime/Cargo.lock
@@ -652,13 +652,13 @@ dependencies = [
  "err-derive",
  "lazy_static",
  "log",
+ "mbedtls",
  "num",
  "num-derive",
  "num-traits",
  "platform-services",
  "policy-utils",
  "postcard",
- "psa-crypto",
  "serde",
  "serde_json",
  "strum",
@@ -1272,7 +1272,6 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "psa-crypto-sys",
  "quote",
  "syn",
 ]
@@ -1677,27 +1676,7 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libc",
- "psa-crypto-sys",
-]
-
-[[package]]
-name = "psa-crypto"
-version = "0.9.1"
-dependencies = [
- "log",
- "psa-crypto-sys",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "psa-crypto-sys"
-version = "0.9.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "walkdir",
+ "mbedtls-sys-auto",
 ]
 
 [[package]]
@@ -1968,15 +1947,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2366,7 +2336,6 @@ dependencies = [
  "err-derive",
  "mbedtls",
  "platform-services",
- "psa-crypto",
  "serde",
  "serde_json",
 ]
@@ -2390,17 +2359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]
@@ -2703,27 +2661,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint 0.2.6",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/workspaces/nitro-runtime/Cargo.toml
+++ b/workspaces/nitro-runtime/Cargo.toml
@@ -16,7 +16,6 @@ cargo-features = ["resolver"]
 exclude = [
   "crates/icecap/sysroot/libc",
   "crates/third-party/rust-mbedtls",
-  "crates/third-party/rust-psa-crypto",
   "crates/third-party/wasmi",
 ]
 members = [


### PR DESCRIPTION
- execution-engine: Use mbedtls::cipher.
- psa-attestation: C code refers to mbedtls-sys instead.
- third-party/rust-mbedtls: Various changes.
- third-party/rust-psa-crypto: Removed.
- veracruz-utils: Use mbedtls::hash.
