### PR TITLE
Strip Nitro binaries before generating the EIF file

### DIFF
--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -42,6 +42,7 @@ build:
 		--features veracruz-client/nitro \
 		--features veracruz-server/nitro \
 		--features cli
+	strip target/$(PROFILE_PATH)/proxy-attestation-server target/$(PROFILE_PATH)/veracruz-client target/$(PROFILE_PATH)/veracruz-server
 
 .PHONY: $(MEASUREMENT_FILE)
 $(MEASUREMENT_FILE):

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -41,6 +41,7 @@ runtime-manager-enclave:
 	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
 	cargo build --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
 		--features nitro -p runtime_manager_enclave
+	strip target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave
 
 doc:
 	cargo doc


### PR DESCRIPTION
This generates much smaller EIF files with no additional compilation cost.
Stripping symbols is not a limitation here, as there is no debugger in Nitro.