### PR TITLE
Improve Mbed TLS debugging

### DIFF
--- a/runtime-manager/Cargo.toml
+++ b/runtime-manager/Cargo.toml
@@ -15,6 +15,9 @@ name = "runtime_manager_enclave"
 path = "src/main.rs"
 
 [features]
+debug = [
+  "session-manager/debug",
+]
 default = []
 icecap = [
   "bincode",

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -6,6 +6,7 @@ name = "session-manager"
 version = "0.3.0"
 
 [features]
+debug = []
 icecap = [
   "policy-utils/icecap",
 ]

--- a/session-manager/src/session_context.rs
+++ b/session-manager/src/session_context.rs
@@ -25,6 +25,8 @@ use mbedtls::{
 };
 use platform_services::getrandom;
 use policy_utils::policy::Policy;
+#[cfg(feature = "debug")]
+use std::borrow::Cow;
 use std::{string::String, sync::Arc, vec::Vec};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -152,6 +154,16 @@ impl SessionContext {
             config::Transport::Stream,
             config::Preset::Default,
         );
+        #[cfg(feature = "debug")]
+        {
+            let dbg_callback =
+                |level: i32, file: Cow<'_, str>, line: i32, message: Cow<'_, str>| {
+                    print!("{} {}:{} {}", level, file, line, message);
+                };
+            config.set_dbg_callback(dbg_callback);
+            // TODO: waiting for https://github.com/veracruz-project/rust-mbedtls/issues/1 to be fixed
+            //unsafe { mbedtls::set_global_debug_threshold(3); }
+        }
         config.set_ciphersuites(Arc::new(self.cipher_suites.clone()));
         let entropy = Arc::new(mbedtls::rng::OsEntropy::new());
         let rng = Arc::new(mbedtls::rng::CtrDrbg::new(entropy, None)?);

--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -15,6 +15,7 @@ use log::{error, info};
 use mbedtls::{alloc::List, pk::Pk, ssl::Context, x509::Certificate};
 use policy_utils::{parsers::enforce_leading_backslash, policy::Policy, Platform};
 use std::{
+    borrow::Cow,
     io::{Read, Write},
     path::Path,
     sync::{
@@ -246,6 +247,12 @@ impl VeracruzClient {
 
         use mbedtls::ssl::config::{Config, Endpoint, Preset, Transport, Version};
         let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+        let dbg_callback = |level: i32, file: Cow<'_, str>, line: i32, message: Cow<'_, str>| {
+            print!("{} {}:{} {}", level, file, line, message);
+        };
+        config.set_dbg_callback(dbg_callback);
+        // TODO: waiting for https://github.com/veracruz-project/rust-mbedtls/issues/1 to be fixed
+        //unsafe { mbedtls::set_global_debug_threshold(3); }
         config.set_min_version(Version::Tls1_3)?;
         config.set_max_version(Version::Tls1_3)?;
         let policy_ciphersuite = veracruz_utils::lookup_ciphersuite(policy.ciphersuite().as_str())


### PR DESCRIPTION
Add a debug feature to dump Mbed TLS debugging information.
Implemented on the client (vc-client) and server (session manager) side.

TODO:
Set log level (waiting for https://github.com/veracruz-project/rust-mbedtls/issues/1 to be fixed)