### PR TITLE
Use mbedtls fake_random feature on Nitro.

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -12,6 +12,8 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
   "platform-services/nitro",
   "policy-utils/std",
   "wasmtime",

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -7,6 +7,10 @@ version = "0.3.0"
 
 [features]
 icecap = []
+nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls/fake_random",
+]
 std = [
   "hex/std",
   "serde/std",

--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -14,7 +14,10 @@ crate-type = ["rlib"]
 # build.rs depends on features
 icecap = []
 linux = []
-nitro = []
+nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls-sys-auto/fake_random",
+]
 
 [dependencies]
 libc = "0.2.124"

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -10,6 +10,8 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls/fake_random",
   "policy-utils/std",
 ]
 std = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,8 @@ linux = [
   "veracruz-utils/linux",
 ]
 nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls/fake_random",
   "policy-utils/std",
   "proxy-attestation-server/nitro",
   "veracruz-server/nitro",

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -16,7 +16,10 @@ required-features = ["cli"]
 cli = ["structopt", "env_logger", "tokio/rt", "tokio/macros"]
 icecap = []
 linux = []
-nitro = []
+nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls/fake_random",
+]
 
 [dependencies]
 anyhow = "1"

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -16,6 +16,8 @@ linux = [
   "serde_json/std",
 ]
 nitro = [
+# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
+  "mbedtls/fake_random",
   "platform-services/nitro",
   "serde/derive",
   "serde_json/std",


### PR DESCRIPTION
I have probably enabled `fake_random` for everything built for Nitro, not just for things that go into the enclave. I am not sure what the best way is to enable it just for the enclave.

Fix for https://github.com/veracruz-project/veracruz/issues/507, following up on https://github.com/veracruz-project/rust-mbedtls/pull/3