### PR TITLE
Plumb Mbed TLS' RNG into Veracruz's platform services

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -12,8 +12,6 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
   "platform-services/nitro",
   "policy-utils/std",
   "wasmtime",

--- a/platform-services/src/lib.rs
+++ b/platform-services/src/lib.rs
@@ -19,8 +19,6 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-#![no_std]
-
 use crate::result::Result;
 use cfg_if::cfg_if;
 
@@ -41,6 +39,9 @@ cfg_if! {
             "Unrecognised feature: platforms supported are Icecap, Nitro and std.");
     }
 }
+
+// Shim layer
+pub mod shim;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Platform services

--- a/platform-services/src/shim.rs
+++ b/platform-services/src/shim.rs
@@ -1,0 +1,26 @@
+//! Shim layer
+//!
+//! A layer exposing platform services to external Rust dependencies and
+//! handling FFI between Rust and C
+//!
+//! Services exposed:
+//! - getrandom()
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Licensing and copyright notice
+//!
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
+//! information on licensing and copyright.
+
+use crate::{getrandom, result::Result};
+
+pub extern "C" fn veracruz_getrandom(buf: *mut u8, buflen: usize, _flags: usize) -> isize {
+	let slice: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(buf, buflen) };
+	match getrandom(slice) {
+		Result::Success(_) => slice.len() as isize,
+		_otherwise => -1
+	}
+}

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -7,10 +7,6 @@ version = "0.3.0"
 
 [features]
 icecap = []
-nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls/fake_random",
-]
 std = [
   "hex/std",
   "serde/std",

--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -14,10 +14,7 @@ crate-type = ["rlib"]
 # build.rs depends on features
 icecap = []
 linux = []
-nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls-sys-auto/fake_random",
-]
+nitro = []
 
 [dependencies]
 libc = "0.2.124"

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -10,8 +10,6 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls/fake_random",
   "policy-utils/std",
 ]
 std = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,8 +27,6 @@ linux = [
   "veracruz-utils/linux",
 ]
 nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls/fake_random",
   "policy-utils/std",
   "proxy-attestation-server/nitro",
   "veracruz-server/nitro",

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -16,10 +16,7 @@ required-features = ["cli"]
 cli = ["structopt", "env_logger", "tokio/rt", "tokio/macros"]
 icecap = []
 linux = []
-nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls/fake_random",
-]
+nitro = []
 
 [dependencies]
 anyhow = "1"

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -16,8 +16,6 @@ linux = [
   "serde_json/std",
 ]
 nitro = [
-# FIXME: fake_random is not secure! (Also, does this run in the enclave?)
-  "mbedtls/fake_random",
   "platform-services/nitro",
   "serde/derive",
   "serde_json/std",


### PR DESCRIPTION
Fix for https://github.com/veracruz-project/veracruz/issues/507
Updates https://github.com/veracruz-project/veracruz/pull/509

This is the longer-term solution for the entropy problem on Nitro.
The C vendor code uses an external `veracruz_getrandom()` instead of the `getrandom()` syscall.
`veracruz_getrandom()` is defined in the Rust wrapper code and calls the associated `veracruz_getrandom()`, defined in `platform-services` and in charge of getting the random bytes in the most suitable way depending on the underlying platform.
The plumbing is done at the Cargo layer to avoid having to rely on hacks like passing flags to the linker, which has empirically been found tricky to get right (link order issues).