### PR TITLE
Nitro: For reproducibility, do not include build-id in binaries.

### DIFF
--- a/workspaces/nitro-host/Makefile
+++ b/workspaces/nitro-host/Makefile
@@ -34,6 +34,7 @@ CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inceptio
 all: build test-collateral
 
 build:
+	RUSTFLAGS="-C link-args=-Wl,--build-id=none" \
 	$(CC) \
 		cargo build $(PROFILE_FLAG) $(V_FLAG) \
 		-p proxy-attestation-server \

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -39,6 +39,7 @@ target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave: runti
 runtime-manager-enclave:
 	rustup target add $(ARCH)-unknown-linux-musl
 	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
+	RUSTFLAGS="-C link-args=-Wl,--build-id=none" \
 	cargo build --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
 		--features nitro -p runtime_manager_enclave
 	strip target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave


### PR DESCRIPTION
Add RUSTFLAGS="-C link-args=-Wl,--build-id=none" to Makefiles.

(It would be interesting to know what change in the input to the linker is causing the build-id to vary.)