### PR TITLE
Restore RNG workaround for Nitro and add security disclaimer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,9 @@ To jump straight into the codebase, please read the growing number of guides we 
 - [BUILD_INSTRUCTIONS.markdown](BUILD_INSTRUCTIONS.markdown) - Set up a build environment for Veracruz
 - [CLI_QUICKSTART.markdown](CLI_QUICKSTART.markdown) - Quickly run Veracruz with a prepared demo program
 
+## Security disclaimer
+As of September 27th, 2022, due to an [entropy bug presumably affecting AWS Nitro enclaves](https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap/issues/15), our Nitro backend relies on a temporary workaround for RNG. More specifically, Mbed TLS' RNG has been changed to return an array of all zeroes. This is a temporary workaround that will be removed when the root cause is fixed by AWS.
+
 ## News
 
 - **May 2022**: we have released Veracruz 22.05 (see the `veracruz-2205` Git tag).  See `documents/release-notes/VERACRUZ-2205.markdown` for notable changes in this release.

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -12,7 +12,8 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
   "platform-services/nitro",
   "policy-utils/std",
   "wasmtime",

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.3.0"
 [features]
 icecap = []
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
 ]
 std = [
   "hex/std",

--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["rlib"]
 icecap = []
 linux = []
 nitro = [
-  "mbedtls-sys-auto/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls-sys-auto/fake_random",
 ]
 
 [dependencies]

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -10,7 +10,8 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
   "policy-utils/std",
 ]
 std = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,7 +27,8 @@ linux = [
   "veracruz-utils/linux",
 ]
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
   "policy-utils/std",
   "proxy-attestation-server/nitro",
   "veracruz-server/nitro",

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -17,7 +17,8 @@ cli = ["structopt", "env_logger", "tokio/rt", "tokio/macros"]
 icecap = []
 linux = []
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
 ]
 
 [dependencies]

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -16,7 +16,8 @@ linux = [
   "serde_json/std",
 ]
 nitro = [
-  "mbedtls/monitor_getrandom",
+# FIXME: fake_random is not secure!
+  "mbedtls/fake_random",
   "platform-services/nitro",
   "serde/derive",
   "serde_json/std",


### PR DESCRIPTION
Workaround for https://github.com/veracruz-project/veracruz/issues/507

* Remove `monitor_getrandom` feature as we now know the bug will haunt us
* Restore RNG workaround for Nitro (all-zeros array)
* Add security disclaimer