### PR TITLE
Fix padding in AES-CTR native module

### DIFF
--- a/execution-engine/src/native_modules/aes.rs
+++ b/execution-engine/src/native_modules/aes.rs
@@ -100,8 +100,9 @@ impl AesCounterModeService {
             .map_err(|_| ErrNo::Canceled)?;
 
             let block_size = cypher.block_size();
-            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long
-            let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
+            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long.
+            // Cf. the documentation of `mbedtls_cipher_update()`
+            let padded_size = input.len() + block_size;
             output.resize(padded_size, 0);
 
             cypher
@@ -118,8 +119,9 @@ impl AesCounterModeService {
             .map_err(|_| ErrNo::Canceled)?;
 
             let block_size = cypher.block_size();
-            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long
-            let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
+            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long.
+            // Cf. the documentation of `mbedtls_cipher_update()`
+            let padded_size = input.len() + block_size;
             output.resize(padded_size, 0);
 
             cypher

--- a/execution-engine/src/native_modules/aes.rs
+++ b/execution-engine/src/native_modules/aes.rs
@@ -100,8 +100,7 @@ impl AesCounterModeService {
             .map_err(|_| ErrNo::Canceled)?;
 
             let block_size = cypher.block_size();
-            // For some reason, the length of the output buffer needs to be
-            // a multiple of the block size and at least two blocks:
+            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long
             let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
             output.resize(padded_size, 0);
 
@@ -119,8 +118,7 @@ impl AesCounterModeService {
             .map_err(|_| ErrNo::Canceled)?;
 
             let block_size = cypher.block_size();
-            // For some reason, the length of the output buffer needs to be
-            // a multiple of the block size and at least two blocks:
+            // Mbed TLS requires the output buffer to be at least `ilen + block_size` long
             let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
             output.resize(padded_size, 0);
 

--- a/execution-engine/src/native_modules/aes.rs
+++ b/execution-engine/src/native_modules/aes.rs
@@ -102,10 +102,7 @@ impl AesCounterModeService {
             let block_size = cypher.block_size();
             // For some reason, the length of the output buffer needs to be
             // a multiple of the block size and at least two blocks:
-            let padded_size = std::cmp::max(
-                2 * block_size,
-                (input.len() + block_size - 1) / block_size * block_size,
-            );
+            let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
             output.resize(padded_size, 0);
 
             cypher
@@ -124,10 +121,7 @@ impl AesCounterModeService {
             let block_size = cypher.block_size();
             // For some reason, the length of the output buffer needs to be
             // a multiple of the block size and at least two blocks:
-            let padded_size = std::cmp::max(
-                2 * block_size,
-                (input.len() + block_size - 1) / block_size * block_size,
-            );
+            let padded_size = (input.len() + 2 * block_size - 1) / block_size * block_size;
             output.resize(padded_size, 0);
 
             cypher


### PR DESCRIPTION
AES-CTR expects the output to be at least a full block longer than the input, or else it fails with `CipherFullBlockExpected`.
Completes https://github.com/veracruz-project/veracruz/issues/535

