### PR TITLE
Replace RNG workaround with monitoring mechanism and remove security disclaimer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,9 +27,6 @@ To jump straight into the codebase, please read the growing number of guides we 
 - [BUILD_INSTRUCTIONS.markdown](BUILD_INSTRUCTIONS.markdown) - Set up a build environment for Veracruz
 - [CLI_QUICKSTART.markdown](CLI_QUICKSTART.markdown) - Quickly run Veracruz with a prepared demo program
 
-## Security disclaimer
-As of September 27th, 2022, due to an [entropy bug presumably affecting AWS Nitro enclaves](https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap/issues/15), our Nitro backend relies on a temporary workaround for RNG. More specifically, Mbed TLS' RNG has been changed to return an array of all zeroes. This is a temporary workaround that will be removed when the root cause is fixed by AWS.
-
 ## News
 
 - **May 2022**: we have released Veracruz 22.05 (see the `veracruz-2205` Git tag).  See `documents/release-notes/VERACRUZ-2205.markdown` for notable changes in this release.

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -12,8 +12,7 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
   "platform-services/nitro",
   "policy-utils/std",
   "wasmtime",

--- a/policy-utils/Cargo.toml
+++ b/policy-utils/Cargo.toml
@@ -8,8 +8,7 @@ version = "0.3.0"
 [features]
 icecap = []
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
 ]
 std = [
   "hex/std",

--- a/psa-attestation/Cargo.toml
+++ b/psa-attestation/Cargo.toml
@@ -15,8 +15,7 @@ crate-type = ["rlib"]
 icecap = []
 linux = []
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls-sys-auto/fake_random",
+  "mbedtls-sys-auto/monitor_getrandom",
 ]
 
 [dependencies]

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -10,8 +10,7 @@ icecap = [
   "policy-utils/icecap",
 ]
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
   "policy-utils/std",
 ]
 std = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,8 +27,7 @@ linux = [
   "veracruz-utils/linux",
 ]
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
   "policy-utils/std",
   "proxy-attestation-server/nitro",
   "veracruz-server/nitro",

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -17,8 +17,7 @@ cli = ["structopt", "env_logger", "tokio/rt", "tokio/macros"]
 icecap = []
 linux = []
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
 ]
 
 [dependencies]

--- a/veracruz-utils/Cargo.toml
+++ b/veracruz-utils/Cargo.toml
@@ -16,8 +16,7 @@ linux = [
   "serde_json/std",
 ]
 nitro = [
-# FIXME: fake_random is not secure!
-  "mbedtls/fake_random",
+  "mbedtls/monitor_getrandom",
   "platform-services/nitro",
   "serde/derive",
   "serde_json/std",


### PR DESCRIPTION
We can remove the RNG workaround and the security disclaimer now that the bug is gone.
Let's keep the monitoring mechanism (timeout) just in case