### PR TITLE
Remove some async, base64 and sleep.

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -47,7 +47,7 @@ mbedtls = { path = "../third-party/rust-mbedtls/mbedtls" }
 postcard = "0.7.2"
 policy-utils = { path = "../policy-utils", optional = true }
 proxy-attestation-server = { path = "../proxy-attestation-server" }
-tokio = { version = "1.16.1", default-features = false, features = [] }
+tokio = { version = "1.16.1", default-features = false, features = ["macros"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-client = { path = "../veracruz-client" }
 veracruz-server = { path = "../veracruz-server" }

--- a/tests/tests/integration_test.rs
+++ b/tests/tests/integration_test.rs
@@ -66,7 +66,7 @@ use std::{
     path::Path,
     time::Duration,
 };
-use tokio::time::{sleep, Instant};
+use tokio::time::Instant;
 use veracruz_client::{self, VeracruzClient};
 use veracruz_server;
 
@@ -266,8 +266,6 @@ async fn veracruz_phase4_linear_regression_two_clients_parallel() {
         let server_handle = server_tls_loop(policy_json_clone);
 
         let program_provider_handle = async {
-            // Wait for the server
-            sleep(Duration::from_millis(30000)).await;
             info!("### program provider start.");
             let mut client = veracruz_client::VeracruzClient::new(
                 cert_key_dir(PROGRAM_CLIENT_CERT).as_path(),
@@ -282,8 +280,6 @@ async fn veracruz_phase4_linear_regression_two_clients_parallel() {
             Result::<()>::Ok(())
         };
         let data_provider_handle = async {
-            // Wait for the server
-            sleep(Duration::from_millis(30000)).await;
             info!("### data provider start.");
             let mut client = veracruz_client::VeracruzClient::new(
                 cert_key_dir(DATA_CLIENT_CERT).as_path(),
@@ -316,11 +312,7 @@ async fn veracruz_phase4_linear_regression_two_clients_parallel() {
 }
 
 async fn server_tls_loop(policy_json: String) -> Result<()> {
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(veracruz_server::server::server(&policy_json))
-            .unwrap();
-    });
+    veracruz_server::server::server(&policy_json).unwrap();
     Ok(())
 }
 
@@ -383,9 +375,6 @@ impl TestExecutor {
         // create the async block for all clients driven by events.
         // NOTE: this does not run the code but only create a future.
         let clients_handle = async move {
-            // Wait for the server
-            sleep(Duration::from_millis(30000)).await;
-
             info!("Initialise clients.");
             // Initialise all clients
             let mut clients = Vec::new();

--- a/tests/tests/server_test.rs
+++ b/tests/tests/server_test.rs
@@ -956,9 +956,6 @@ fn init_veracruz_server_and_tls_session<T: AsRef<str>>(
     let mut veracruz_server =
         VeracruzServerEnclave::new(policy_json.as_ref()).map_err(|e| anyhow!("{:?}", e))?;
 
-    // wait for the client to start
-    thread::sleep(Duration::from_millis(100));
-
     let session_id = veracruz_server
         .new_tls_session()
         .map_err(|e| anyhow!("{:?}", e))?;

--- a/veracruz-client/Cargo.toml
+++ b/veracruz-client/Cargo.toml
@@ -13,7 +13,7 @@ required-features = ["cli"]
 [features]
 # a feature to enable CLI-only dependencies
 # https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies
-cli = ["structopt", "env_logger", "tokio/rt", "tokio/macros"]
+cli = ["structopt", "env_logger"]
 icecap = []
 linux = []
 nitro = [
@@ -22,7 +22,7 @@ nitro = [
 
 [dependencies]
 anyhow = "1"
-base64 = "0.13.0"
+bincode = { version = "1.2.1", default-features = false }
 env_logger = { version = "0.9.0", optional = true }
 err-derive = "0.2"
 hex = "0.4.2"
@@ -33,6 +33,5 @@ rand = "0.8.3"
 # The cargo patch mechanism does NOT work when we add function into a macro_rules!
 serde_json = "1.0"
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
-tokio = { version = "1.16.1", default-features = false, features = ["io-util", "macros", "net", "rt-multi-thread"] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", features = ["std"] }

--- a/veracruz-client/src/cli.rs
+++ b/veracruz-client/src/cli.rs
@@ -143,8 +143,7 @@ macro_rules! qprintln {
 }
 
 /// Entry point
-#[tokio::main]
-async fn main() {
+fn main() {
     // parse args
     let opt = Opt::from_args();
 

--- a/veracruz-server/Cargo.toml
+++ b/veracruz-server/Cargo.toml
@@ -65,6 +65,5 @@ serde_json = "1.0"
 signal-hook = { version = "0.3.13", optional = true }
 structopt = { version = "0.3", optional = true, features = ["wrap_help"] }
 tempfile = { version = "3.2.0", optional = true }
-tokio = { version = "1.16.1", default-features = false, features = [] }
 transport-protocol = { path = "../transport-protocol" }
 veracruz-utils = { path = "../veracruz-utils", optional = true }

--- a/veracruz-server/src/cli.rs
+++ b/veracruz-server/src/cli.rs
@@ -46,22 +46,15 @@ fn main() {
     };
     info!("Loaded policy {}", policy.policy_hash().unwrap_or("???"));
 
-    // create runtime
-    let rt = tokio::runtime::Runtime::new().unwrap_or_else(|err| {
-        eprintln!("{}", err);
-        process::exit(1);
-    });
-
     // create Veracruz Server instance
-    let veracruz_server = veracruz_server::server::server(&policy_json);
+    veracruz_server::server::server(&policy_json).unwrap();
 
     println!(
         "Veracruz Server running on {}",
         policy.veracruz_server_url()
     );
-    rt.block_on(async { veracruz_server.await })
-        .unwrap_or_else(|err| {
-            eprintln!("{}", err);
-            process::exit(1);
-        });
+
+    loop {
+        std::thread::sleep(std::time::Duration::MAX);
+    }
 }

--- a/veracruz-server/src/common.rs
+++ b/veracruz-server/src/common.rs
@@ -15,7 +15,6 @@ use err_derive::Error;
 #[cfg(feature = "nitro")]
 use io_utils::nitro::NitroError;
 use std::error::Error;
-use tokio::sync::mpsc;
 
 pub type VeracruzServerResponder = Result<String, VeracruzServerError>;
 
@@ -31,10 +30,6 @@ pub enum VeracruzServerError {
     LockError(String),
     #[error(display = "VeracruzServer: ParseIntError: {}.", _0)]
     ParseIntError(#[error(source)] std::num::ParseIntError),
-    #[error(display = "VeracruzServer: mpsc SendError (of type ()) Error: {}.", _0)]
-    MpscSendEmptyError(#[error(source)] mpsc::error::SendError<()>),
-    #[error(display = "VeracruzServer: FromUtf8Error")]
-    FromUtf8Error(#[error(source)] std::string::FromUtf8Error),
     #[cfg(any(feature = "linux", feature = "nitro"))]
     #[error(display = "VeracruzServer: BincodeError: {:?}", _0)]
     BincodeError(bincode::ErrorKind),

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -2486,7 +2486,7 @@ name = "veracruz-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "base64",
+ "bincode",
  "env_logger",
  "err-derive",
  "hex",
@@ -2496,7 +2496,6 @@ dependencies = [
  "rand",
  "serde_json",
  "structopt",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]
@@ -2525,7 +2524,6 @@ dependencies = [
  "signal-hook",
  "structopt",
  "tempfile",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -2324,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2486,7 +2486,7 @@ name = "veracruz-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "base64",
+ "bincode",
  "env_logger",
  "err-derive",
  "hex",
@@ -2496,7 +2496,6 @@ dependencies = [
  "rand",
  "serde_json",
  "structopt",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]
@@ -2525,7 +2524,6 @@ dependencies = [
  "signal-hook",
  "structopt",
  "tempfile",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -2486,7 +2486,7 @@ name = "veracruz-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "base64",
+ "bincode",
  "env_logger",
  "err-derive",
  "hex",
@@ -2496,7 +2496,6 @@ dependencies = [
  "rand",
  "serde_json",
  "structopt",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]
@@ -2525,7 +2524,6 @@ dependencies = [
  "signal-hook",
  "structopt",
  "tempfile",
- "tokio",
  "transport-protocol",
  "veracruz-utils",
 ]


### PR DESCRIPTION
- No async in veracruz-client.
- No async in veracruz-server.
- No base64-encoding in communication between client and server.
- veracruz_server::server::server now returns only when the server is ready and listening.
- Remove sleeps from integration_test.rs and server_test.rs.
