### PR TITLE
Make veracruz-client use a persistent connection.

### DIFF
--- a/veracruz-client/src/veracruz_client.rs
+++ b/veracruz-client/src/veracruz_client.rs
@@ -275,10 +275,7 @@ impl VeracruzClient {
         let serialized_data = serialize_functor(data, &path)?;
         let response = self.send(&serialized_data)?;
 
-        let parsed_response = transport_protocol::parse_runtime_manager_response(
-            Some(self.remote_session_id.load(Ordering::SeqCst)),
-            &response,
-        )?;
+        let parsed_response = transport_protocol::parse_runtime_manager_response(None, &response)?;
         let status = parsed_response.get_status();
         match status {
             transport_protocol::ResponseStatus::SUCCESS => Ok(parsed_response),


### PR DESCRIPTION
The `session_id` is no longer used in `veracruz-client`.

This is probably just the first step, changing how the client communicates with the server. The next step will probably be to change how the server communicates with the enclave.

This change seems to make transferring a 100 MB file into the enclave 3x faster, and transferring a 100 MB file out of the enclave 140x faster. On Linux with `PROFILE=release`. If I've measured it correctly. (The new speeds are 65 MB/s in and 50 MB/s out.)

The changes to `Cargo.lock` files are caused by previous PRs. This change does not affect the `Cargo.lock` files.