### PR TITLE
WIP: Add C++ support to build system

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && \
         g++ \
         gcc \
         gcc-aarch64-linux-gnu \
+        g++-aarch64-linux-gnu \
         gdb \
         ghc \
         git \

--- a/docker/nitro/Dockerfile
+++ b/docker/nitro/Dockerfile
@@ -59,6 +59,12 @@ ENV \
     AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_INCLUDE_DIR=/work/veracruz-nitro-root-enclave/musl/include \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_INCLUDE_DIR=/work/veracruz-nitro-root-enclave/musl/include
 
+RUN wget https://musl.cc/${ARCH}-linux-musl-native.tgz && \
+    tar zxvf ${ARCH}-linux-musl-native.tgz && \
+    cp ${ARCH}-linux-musl-native/bin/${ARCH}-linux-musl-gcc /bin && \
+    cp ${ARCH}-linux-musl-native/bin/${ARCH}-linux-musl-g++ /bin && \
+    rm -rf ${ARCH}-linux-musl-native ${ARCH}-linux-musl-native.tgz
+
 RUN mkdir -p /var/log/nitro_enclaves ; \
     touch /var/log/nitro_enclaves/nitro_enclaves.log ; \
     chmod -R a+rw /var/log/nitro_enclaves ; \

--- a/workspaces/icecap-runtime/Makefile
+++ b/workspaces/icecap-runtime/Makefile
@@ -16,6 +16,7 @@ PROJECT = .
 HOST_CC ?= gcc
 LD = $(abspath $(shell RUSTC_BOOTSTRAP=1 cargo -Z unstable-options rustc --print target-libdir 2>/dev/null)/../bin/rust-lld)
 CC = aarch64-linux-gnu-gcc
+CXX = aarch64-linux-gnu-g++
 
 deps := deps
 src := src
@@ -242,6 +243,7 @@ rust-project: $(now) sysroot-install userspace_c sel4
 	$(call cargo_target_config_prefix,$(rust_target))RUSTFLAGS="$(icecap_rustflags)" \
 	$(call cargo_target_config_prefix,$(rust_target))LINKER="$(LD)" \
 	CC_$(call kebab_to_caml,$(rust_target))="$(CC)" \
+	CXX_$(call kebab_to_caml,$(rust_target))="$(CXX)" \
 	BINDGEN_EXTRA_CLANG_ARGS="$(icecap_c_include_flags) -I$(compiler_some_libc_include) -I/usr/aarch64-linux-gnu/include" \
 		cargo build \
 			-Z unstable-options \

--- a/workspaces/nitro-runtime/Makefile
+++ b/workspaces/nitro-runtime/Makefile
@@ -38,7 +38,8 @@ target/$(ARCH)-unknown-linux-musl/$(PROFILE_PATH)/runtime_manager_enclave: runti
 
 runtime-manager-enclave:
 	rustup target add $(ARCH)-unknown-linux-musl
-	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
+	CC_$(ARCH)_unknown_linux_musl=$(ARCH)-linux-musl-gcc \
+	CXX_$(ARCH)_unknown_linux_musl=$(ARCH)-linux-musl-g++ \
 	RUSTFLAGS="-C link-args=-Wl,--build-id=none" \
 	cargo build --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
 		--features nitro -p runtime_manager_enclave
@@ -49,7 +50,8 @@ doc:
 
 clippy:
 	rustup target add $(ARCH)-unknown-linux-musl
-	CC_$(ARCH)_unknown_linux_musl=musl-gcc \
+	CC_$(ARCH)_unknown_linux_musl=$(ARCH)-linux-musl-gcc \
+	CXX_$(ARCH)_unknown_linux_musl=$(ARCH)-linux-musl-g++ \
 	cargo clippy --target $(ARCH)-unknown-linux-musl $(PROFILE_FLAG) $(V_FLAG) \
 		-p runtime_manager_enclave -p execution-engine \
 		-p session-manager -p policy-utils -p platform-services \


### PR DESCRIPTION
Currently the build system doesn't allow the Nitro and IceCap runtimes to link against C++ code. This is an obstacle on the critical path towards building complex native modules (https://github.com/veracruz-project/veracruz/pull/553).
We propose to:
* Add a C++ compiler to build the IceCap runtime, which is simply missing
* Replace `musl` with [`musl-cross-make`](https://github.com/richfelker/musl-cross-make) for the Nitro runtime, to overcome musl's limitations