### PR TITLE
Add `psmisc` to base image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -94,6 +94,7 @@ RUN apt-get update && \
         pkg-config \
         protobuf-compiler \
         procps \
+        psmisc \
         python3-dev \
         python3-pip \
         python3-protobuf \


### PR DESCRIPTION
For compatibility reasons (GLIBC), Veracruz must be deployed in a Docker container provided by us.
The issue is that my deployment scripts depend on `killall`, which is part of `psmisc`, which isn't part of the base image.