### PR TITLE
Add dynamic native modules (MVP 0)

### DIFF
--- a/CLI_QUICKSTART.markdown
+++ b/CLI_QUICKSTART.markdown
@@ -186,7 +186,7 @@ $ vc-pgen \
     --capability "/input/:w" \
     --certificate example/example-result-cert.pem \
     --capability "/program/:x,/output/:r" \
-    --binary /program/example-binary.wasm=example/example-binary.wasm \
+    --program-binary /program/example-binary.wasm=example/example-binary.wasm \
     --capability "/input/:r,/output/:w" \
     --output-policy-file example/example-policy.json \
     --max-memory-mib 256

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -18,6 +18,7 @@ nitro = [
   "wasmtime",
 ]
 std = [
+  "nix",
   "platform-services/std",
   "policy-utils/std",
   "wasmtime",
@@ -34,6 +35,7 @@ ctor = "=0.1.16"
 err-derive = "0.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 mbedtls = { path = "../third-party/rust-mbedtls/mbedtls" }
+nix = { version = "0.20.2", optional = true }
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -2109,6 +2109,6 @@ where
     }
 }
 
-pub fn strip_root_slash(path: &Path) -> &Path {
+pub(crate) fn strip_root_slash(path: &Path) -> &Path {
     path.strip_prefix("/").unwrap_or(path)
 }

--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -408,7 +408,7 @@ impl Debug for InodeTable {
                     k,
                     service
                         .try_lock()
-                        .map_or_else(|_| "(failed to lock)".to_string(), |o| String::from(o.name().to_owned() + &" (".to_owned() + o.special_file_path().to_str().unwrap_or("failed to convert path to unicode") + &")".to_owned()))
+                        .map_or_else(|_| "(failed to lock)".to_string(), |o| format!("{:?}", o))
                 )?,
                 InodeImpl::Directory(d) => write!(f, "\t{:?} -> {:?}\n", k, d)?,
             }
@@ -1274,7 +1274,7 @@ impl FileSystem {
                 .lock()
                 .map_err(|_| ErrNo::Busy)?;
 
-            // Prepare sandbox environment
+            // Invoke native module manager
             let mut native_module_manager = NativeModuleManager::new(*native_module.clone(), self.service_fs()?);
             // Invoke native module with execution configuration
             native_module_manager.execute(exec_config)?;

--- a/execution-engine/src/lib.rs
+++ b/execution-engine/src/lib.rs
@@ -24,6 +24,7 @@ extern crate num_derive;
 
 mod engines;
 pub mod fs;
+mod native_module_manager;
 mod native_modules;
 mod pipeline;
 // Expose the error to the external.

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -140,6 +140,12 @@ impl NativeModuleManager {
                 let entry = entry?;
                 let path_prefixed = entry.path();
                 let path_unprefixed = path_prefixed.strip_prefix(&self.native_module_directory).map_err(|_| ErrNo::Access)?;
+
+                // Ignore execution configuration file
+                if path_unprefixed == PathBuf::from(EXECUTION_CONFIGURATION_FILE) {
+                    continue;
+                }
+
                 let path_unprefixed = PathBuf::from("/").join(path_unprefixed);
                 if path_prefixed.is_dir() {
                     // Create directory on the VFS with `path_open()`

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -33,7 +33,7 @@ use crate::{
     fs::{FileSystem, FileSystemResult, strip_root_slash},
     native_modules::common::STATIC_NATIVE_MODULES
 };
-use log::debug;
+use log::info;
 use policy_utils::principal::NativeModule;
 use std::{
     fs::{create_dir, create_dir_all, File, read_dir},
@@ -236,9 +236,9 @@ impl NativeModuleManager {
                 nm.serve(&mut self.native_module_vfs, &input)?;
             }
         } else {
-            debug!("Preparing the native module's filesystem...");
+            info!("Preparing the native module's filesystem...");
             let top_level_files = self.prepare_fs()?;
-            debug!("OK");
+            info!("OK");
 
             // Inject execution configuration into the native module's directory
             let mut file = File::create(self.native_module_directory.join(EXECUTION_CONFIGURATION_FILE))?;
@@ -261,7 +261,7 @@ impl NativeModuleManager {
                 .expect("sigaction failed");
             }
 
-            debug!("Calling sandboxer...");
+            info!("Calling sandboxer...");
             let mount_mappings = self.build_mappings(top_level_files)?;
             Command::new(NATIVE_MODULE_MANAGER_SANDBOXER_PATH)
                 .args([
@@ -273,9 +273,9 @@ impl NativeModuleManager {
                 ])
                 .output()?;
 
-            debug!("Propagating side effects to the VFS...");
+            info!("Propagating side effects to the VFS...");
             self.copy_fs_to_vfs(&PathBuf::from(""))?;
-            debug!("OK");
+            info!("OK");
 
             // TODO:
             //self.teardown_fs()?;

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -2,9 +2,19 @@
 //!
 //! This module prepares a sandbox environment for each native module, before
 //! running them inside it.
-//! The execution environment is torn down after computation as a security
-//! precaution.
+//! The execution environment can optionally be torn down after computation as
+//! a security precaution.
 //!
+//! Native modules follow the specifications below:
+//!  - Each native module has a name, special file and entry point
+//!  - A native module has the same access rights to the VFS as the WASM program
+//!    calling it
+//!  - The WASM program passes the execution configuration to the native module
+//!    via the native module's special file on the VFS.
+//!    It is up to the WASM program and native module to determine how the data
+//!    is encoded, however the native module MUST read the data from
+//!    `EXECUTION_CONFIGURATION_FILE` (defined here), a file copied into the
+//!    sandbox environment by the native module manager
 //! ## Authors
 //!
 //! The Veracruz Development Team.

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -222,8 +222,9 @@ impl NativeModuleManager {
             .spawn()?;
         let _ = child.wait_with_output();
 
-        println!("Propagating side effects to the VFS...");
+        print!("Propagating side effects to the VFS...");
         self.copy_fs_to_vfs(&PathBuf::from(""))?;
+        println!("OK");
 
         // TODO:
         //self.teardown_fs()?;

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -36,10 +36,10 @@ use crate::{
 use log::debug;
 use policy_utils::principal::NativeModule;
 use std::{
-    fs::{create_dir, create_dir_all, File, read_dir, remove_dir_all},
+    fs::{create_dir, create_dir_all, File, read_dir},
     io::{Read, Write},
     path::{Path, PathBuf},
-    process::{Command, Stdio}
+    process::Command
 };
 #[cfg(feature = "std")]
 use nix::sys::signal;
@@ -215,10 +215,11 @@ impl NativeModuleManager {
     /// native module executions stateful. In the future, we might consider
     /// giving native modules access to only a subset of the program's VFS with
     /// limited permissions.
-    fn teardown_fs(&self) -> FileSystemResult<()> {
+    /// TODO: use it
+    /*fn teardown_fs(&self) -> FileSystemResult<()> {
         remove_dir_all(self.native_module_directory.as_path())?;
         Ok(())
-    }
+    }*/
 
     /// Run the native module. The input is passed by the WASM program via the
     /// native module's special file.
@@ -262,7 +263,7 @@ impl NativeModuleManager {
 
             debug!("Calling sandboxer...");
             let mount_mappings = self.build_mappings(top_level_files)?;
-            let output = Command::new(NATIVE_MODULE_MANAGER_SANDBOXER_PATH)
+            Command::new(NATIVE_MODULE_MANAGER_SANDBOXER_PATH)
                 .args([
                     "--sandbox2tool_resolve_and_add_libraries",
                     "--sandbox2tool_mount_tmp",
@@ -270,7 +271,7 @@ impl NativeModuleManager {
                     &mount_mappings,
                     &self.native_module.entry_point_path().to_str().ok_or(ErrNo::Inval)?.to_owned(),
                 ])
-                .output();
+                .output()?;
 
             debug!("Propagating side effects to the VFS...");
             self.copy_fs_to_vfs(&PathBuf::from(""))?;

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -36,7 +36,7 @@ use crate::{
 use log::info;
 use policy_utils::principal::NativeModule;
 use std::{
-    fs::{create_dir, create_dir_all, File, read_dir},
+    fs::{create_dir, create_dir_all, File, read_dir, remove_dir_all},
     io::{Read, Write},
     path::{Path, PathBuf},
     process::Command
@@ -215,11 +215,10 @@ impl NativeModuleManager {
     /// native module executions stateful. In the future, we might consider
     /// giving native modules access to only a subset of the program's VFS with
     /// limited permissions.
-    /// TODO: use it
-    /*fn teardown_fs(&self) -> FileSystemResult<()> {
+    fn teardown_fs(&self) -> FileSystemResult<()> {
         remove_dir_all(self.native_module_directory.as_path())?;
         Ok(())
-    }*/
+    }
 
     /// Run the native module. The input is passed by the WASM program via the
     /// native module's special file.
@@ -277,8 +276,7 @@ impl NativeModuleManager {
             self.copy_fs_to_vfs(&PathBuf::from(""))?;
             info!("OK");
 
-            // TODO:
-            //self.teardown_fs()?;
+            self.teardown_fs()?;
         }
 
         Ok(())
@@ -288,6 +286,6 @@ impl NativeModuleManager {
 impl Drop for NativeModuleManager {
     /// Drop the native module manager.
     fn drop(&mut self) {
-        //let _ = self.teardown_fs();
+        let _ = self.teardown_fs();
     }
 }

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -87,10 +87,14 @@ impl NativeModuleManager {
     fn build_mappings(&self, unprefixed_files: Vec<PathBuf>) -> FileSystemResult<String> {
         let mut mappings = String::new();
         for f in unprefixed_files {
-            let mapping = self.native_module_directory.join(strip_root_slash(&f));
-            let mapping = mapping.to_str().ok_or(ErrNo::Inval)?.to_owned()
-                          + "=>"
-                          + &f.to_str().ok_or(ErrNo::Inval)?.to_owned();
+            let mapping = self
+                .native_module_directory
+                .join(strip_root_slash(&f))
+                .to_str()
+                .ok_or(ErrNo::Inval)?
+                .to_owned()
+                + "=>"
+                + &f.to_str().ok_or(ErrNo::Inval)?.to_owned();
             mappings = mappings + &mapping + ",";
         }
 
@@ -191,13 +195,13 @@ impl NativeModuleManager {
                     let mut f = File::open(self.native_module_directory.join(&path_prefixed))?;
                     let mut buf: [u8; 128] = [0; 128];
 
-                    // Copy it to the VFS. First truncate the VFS file first
-                    // then append to it. If the principal doesn't have write
-                    // access, just ignore it
+                    // Copy file to the VFS. First truncate the VFS file then
+                    // append to it. If the principal doesn't have write access,
+                    // just ignore it
                     if self.native_module_vfs.write_file_by_absolute_path(&path_unprefixed, vec![], false).is_ok() {
                         loop {
                             let n = f.read(&mut buf)?;
-                            if n <= 0 {
+                            if n == 0 {
                                 break;
                             }
                             self.native_module_vfs.write_file_by_absolute_path(&path_unprefixed, buf[..n].to_vec(), true)?;

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -33,6 +33,7 @@ use crate::{
     fs::{FileSystem, FileSystemResult, strip_root_slash},
     native_modules::common::STATIC_NATIVE_MODULES
 };
+use log::debug;
 use policy_utils::principal::NativeModule;
 use std::{
     fs::{create_dir, create_dir_all, File, read_dir, remove_dir_all},
@@ -234,9 +235,9 @@ impl NativeModuleManager {
                 nm.serve(&mut self.native_module_vfs, &input)?;
             }
         } else {
-            print!("Preparing the native module's filesystem...");
+            debug!("Preparing the native module's filesystem...");
             let top_level_files = self.prepare_fs()?;
-            println!("OK");
+            debug!("OK");
 
             // Inject execution configuration into the native module's directory
             let mut file = File::create(self.native_module_directory.join(EXECUTION_CONFIGURATION_FILE))?;
@@ -259,7 +260,7 @@ impl NativeModuleManager {
                 .expect("sigaction failed");
             }
 
-            println!("Calling sandboxer...");
+            debug!("Calling sandboxer...");
             let mount_mappings = self.build_mappings(top_level_files)?;
             let output = Command::new(NATIVE_MODULE_MANAGER_SANDBOXER_PATH)
                 .args([
@@ -271,9 +272,9 @@ impl NativeModuleManager {
                 ])
                 .output();
 
-            print!("Propagating side effects to the VFS...");
+            debug!("Propagating side effects to the VFS...");
             self.copy_fs_to_vfs(&PathBuf::from(""))?;
-            println!("OK");
+            debug!("OK");
 
             // TODO:
             //self.teardown_fs()?;

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -1,0 +1,126 @@
+//! The Veracruz native module manager
+//!
+//! This module prepares a sandbox environment for each native module, before running them inside it.
+//! The execution environment is torn down after computation as a security precaution.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Licensing and copyright notice
+//!
+//! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
+//! information on licensing and copyright.
+
+use crate::fs::{FileSystem, FileSystemResult};
+//use libc::{c_int, c_void};
+use policy_utils::principal::NativeModule;
+use std::fs::{create_dir, create_dir_all, File, remove_dir_all};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use wasi_types::ErrNo;
+
+/// Path to the native module's manager sysroot on the kernel filesystem. Native
+/// module directories are created under this directory.
+const NATIVE_MODULE_MANAGER_SYSROOT: &str = "/tmp/nmm";
+
+/// Path to the native module sandboxer. This is the program that actually prepares
+/// the sandbox environment and runs the native module in it.
+const NATIVE_MODULE_MANAGER_SANDBOXER_PATH: &str = "/tmp/nmm/native-module-sandboxer";
+
+/// Execution configuration file name. The input from the calling program is
+/// written to this file, under the native module's directory, before running
+/// the native module.
+const EXECUTION_CONFIGURATION_FILE: &str = "execution_config";
+
+pub struct NativeModuleManager {
+    /// Native module to execute.
+    native_module: NativeModule,
+    /// Native module's view of the VFS. This is used to copy files from the VFS
+    /// to the kernel filesystem.
+    native_module_filesystem: FileSystem,
+    /// Native module directory. Gets mounted into the sandbox environment
+    /// before the native module is executed.
+    native_module_directory: PathBuf,
+}
+
+impl NativeModuleManager {
+    pub fn new(native_module: NativeModule, native_module_filesystem: FileSystem) -> Self
+    {
+        let native_module_directory = PathBuf::from(NATIVE_MODULE_MANAGER_SYSROOT).join(native_module.name());
+        Self {
+            native_module,
+            native_module_filesystem,
+            native_module_directory,
+        }
+    }
+
+    /// Prepare native module's filesystem by copying to the kernel filesystem
+    /// all the part of the VFS visible to the native module.
+    /// To be useful, this function must be called after provisioning files to
+    /// the VFS, and maybe even after the WASM program invokes the native module.
+    pub fn prepare_filesystem(&mut self) -> FileSystemResult<()> {
+        create_dir(self.native_module_directory.as_path()).map_err(|_| ErrNo::Access)?;
+
+        let visible_files_and_dirs = self.native_module_filesystem.read_all_files_and_dirs_by_absolute_path(Path::new("/"))?;
+        for (path, buffer) in visible_files_and_dirs {
+            let path = self.native_module_directory.join(path);
+
+            // Create parent directories
+            let parent_path = path.parent().ok_or(ErrNo::NoEnt)?;
+            create_dir_all(parent_path)?;
+
+            match buffer {
+                Some(b) => {
+                    let mut file = File::create(path)?;
+                    file.write_all(&b)?;
+                },
+                None => create_dir(path)?
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete native module's filesystem on the kernel filesystem.
+    pub fn teardown_filesystem(&self) -> FileSystemResult<()>
+    {
+        remove_dir_all(self.native_module_directory.as_path())?;
+        Ok(())
+    }
+
+    /// Run the native module. The input is passed by the WASM program via the
+    /// native module's special file.
+    pub fn execute(&mut self, input: Vec<u8>) -> FileSystemResult<()> {
+        self.prepare_filesystem()?;
+
+        // Inject input (execution configuration) into the native module's directory
+        let mut file = File::create(self.native_module_directory.join(EXECUTION_CONFIGURATION_FILE))?;
+        file.write_all(&input)?;
+
+        // Call sandboxer
+        let mount_mapping = self.native_module_directory.to_str().ok_or(ErrNo::Inval)?.to_owned() + "=>/";
+        let child = Command::new(NATIVE_MODULE_MANAGER_SANDBOXER_PATH)
+            .args([
+                "--sandbox2tool_resolve_and_add_libraries",
+                "--sandbox2tool_additional_bind_mounts",
+                &mount_mapping,
+                &self.native_module.entry_point_path().to_str().ok_or(ErrNo::Inval)?.to_owned(),
+            ])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn child process");
+
+        let output = child.wait_with_output().expect("Failed to read stdout");
+        println!("<<output: {:?}", &output.stdout);
+
+        Ok(())
+    }
+}
+
+impl Drop for NativeModuleManager {
+    /// Drop the native module manager.
+    fn drop(&mut self) {
+        let _ = self.teardown_filesystem();
+    }
+}

--- a/execution-engine/src/native_modules/aead.rs
+++ b/execution-engine/src/native_modules/aead.rs
@@ -10,7 +10,7 @@
 //! information on licensing and copyright.
 
 use crate::fs::{FileSystem, FileSystemResult};
-use crate::native_modules::common::Service;
+use crate::native_modules::common::StaticNativeModule;
 use mbedtls::cipher::{Authenticated, Cipher, Decryption, Encryption, Fresh};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -33,7 +33,7 @@ pub(crate) struct AeadService {
     is_encryption: bool,
 }
 
-impl Service for AeadService {
+impl StaticNativeModule for AeadService {
     /// Return the name of this service
     fn name(&self) -> &str {
         "AEAD Service"

--- a/execution-engine/src/native_modules/aes.rs
+++ b/execution-engine/src/native_modules/aes.rs
@@ -10,7 +10,7 @@
 //! information on licensing and copyright.
 
 use crate::fs::{FileSystem, FileSystemResult};
-use crate::native_modules::common::Service;
+use crate::native_modules::common::StaticNativeModule;
 use mbedtls::cipher::{Cipher, Decryption, Encryption, Fresh, Traditional};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -32,7 +32,7 @@ pub(crate) struct AesCounterModeService {
     is_encryption: bool,
 }
 
-impl Service for AesCounterModeService {
+impl StaticNativeModule for AesCounterModeService {
     /// Return the name of this service
     fn name(&self) -> &str {
         "Counter mode AES Service"

--- a/execution-engine/src/native_modules/common.rs
+++ b/execution-engine/src/native_modules/common.rs
@@ -9,14 +9,20 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use crate::fs::{FileSystem, FileSystemResult};
+use crate::{
+    fs::{FileSystem, FileSystemResult},
+    native_modules::{aead::AeadService, aes::AesCounterModeService, postcard::PostcardService}
+};
+use lazy_static::lazy_static;
+use std::{collections::HashMap, sync::Mutex};
 
 /// Specifications for static native modules, i.e. native modules which are
 /// always part of the Veracruz runtime and don't have to be loaded as separate
 /// binaries.
 /// Despite their static behaviour, they have to be explicitly declared in the
-/// policy file to be used. See `policy_utils::principal::NativeModule` and
-/// `generate-policy` for more details.
+/// policy file to be used in a computation. See
+/// `policy_utils::principal::NativeModule` and `generate-policy` for more
+/// details.
 pub trait StaticNativeModule: Send {
     fn name(&self) -> &str;
     //fn configure(&mut self, config: Self::Configuration) -> FileSystemResult<()>;
@@ -25,4 +31,22 @@ pub trait StaticNativeModule: Send {
     fn serve(&mut self, fs: &mut FileSystem, input: &[u8]) -> FileSystemResult<()>;
     // try_parse may buffer any result, hence we pass a mutable self here.
     fn try_parse(&mut self, input: &[u8]) -> FileSystemResult<bool>;
+}
+
+// Static native modules table.
+// Note that only the ones specified in the policy will actually be exposed to
+// WASM programs over the VFS.
+lazy_static! {
+    pub static ref STATIC_NATIVE_MODULES: Mutex<HashMap<String, Box<dyn StaticNativeModule>>> = {
+        let mut h = HashMap::<String, Box<dyn StaticNativeModule>>::new();
+        let list: Vec<Box<dyn StaticNativeModule>> = vec![
+            Box::new(AeadService::new()),
+            Box::new(AesCounterModeService::new()),
+            Box::new(PostcardService::new()),
+        ];
+        for nm in list {
+            h.insert(nm.name().to_string(), nm);
+        }
+        Mutex::new(h)
+    };
 }

--- a/execution-engine/src/native_modules/common.rs
+++ b/execution-engine/src/native_modules/common.rs
@@ -9,21 +9,33 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use crate::fs::{FileSystem, FileSystemResult};
+use policy_utils::principal::NativeModule;
 use std::fmt::Debug;
 
-pub trait Service: Send {
-    fn name(&self) -> &str;
-    //fn configure(&mut self, config: Self::Configuration) -> FileSystemResult<()>;
-    // The FS will prepare the Input and call the serve function at an appropriate time.
-    // Result may depend on the configure.
-    fn serve(&mut self, fs: &mut FileSystem, input: &[u8]) -> FileSystemResult<()>;
-    // try_parse may buffer any result, hence we pass a mutable self here.
-    fn try_parse(&mut self, input: &[u8]) -> FileSystemResult<bool>;
+pub struct Service {
+    /// Native module
+    native_module: NativeModule,
 }
 
-impl Debug for dyn Service {
+impl Service {
+    /// Creates a Service.
+    #[inline]
+    pub fn new(native_module: NativeModule) -> Self
+    {
+        Self {
+            native_module,
+        }
+    }
+
+    /// Returns the native module.
+    #[inline]
+    pub fn native_module(&self) -> &NativeModule
+    {
+        &self.native_module
+    }
+}
+impl Debug for Service {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Service: {}", self.name())
+        write!(f, "Service: {}", self.native_module.interface_path().to_str().unwrap_or_default())
     }
 }

--- a/execution-engine/src/native_modules/common.rs
+++ b/execution-engine/src/native_modules/common.rs
@@ -36,6 +36,6 @@ impl Service {
 }
 impl Debug for Service {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Service: {}", self.native_module.interface_path().to_str().unwrap_or_default())
+        write!(f, "Service: {}", self.native_module.special_file_path().to_str().unwrap_or_default())
     }
 }

--- a/execution-engine/src/native_modules/common.rs
+++ b/execution-engine/src/native_modules/common.rs
@@ -9,33 +9,20 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-use policy_utils::principal::NativeModule;
-use std::fmt::Debug;
+use crate::fs::{FileSystem, FileSystemResult};
 
-pub struct Service {
-    /// Native module
-    native_module: NativeModule,
-}
-
-impl Service {
-    /// Creates a Service.
-    #[inline]
-    pub fn new(native_module: NativeModule) -> Self
-    {
-        Self {
-            native_module,
-        }
-    }
-
-    /// Returns the native module.
-    #[inline]
-    pub fn native_module(&self) -> &NativeModule
-    {
-        &self.native_module
-    }
-}
-impl Debug for Service {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Service: {}", self.native_module.special_file_path().to_str().unwrap_or_default())
-    }
+/// Specifications for static native modules, i.e. native modules which are
+/// always part of the Veracruz runtime and don't have to be loaded as separate
+/// binaries.
+/// Despite their static behaviour, they have to be explicitly declared in the
+/// policy file to be used. See `policy_utils::principal::NativeModule` and
+/// `generate-policy` for more details.
+pub trait StaticNativeModule: Send {
+    fn name(&self) -> &str;
+    //fn configure(&mut self, config: Self::Configuration) -> FileSystemResult<()>;
+    // The FS will prepare the Input and call the serve function at an appropriate time.
+    // Result may depend on the configure.
+    fn serve(&mut self, fs: &mut FileSystem, input: &[u8]) -> FileSystemResult<()>;
+    // try_parse may buffer any result, hence we pass a mutable self here.
+    fn try_parse(&mut self, input: &[u8]) -> FileSystemResult<bool>;
 }

--- a/execution-engine/src/native_modules/mod.rs
+++ b/execution-engine/src/native_modules/mod.rs
@@ -9,7 +9,4 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
-pub(crate) mod aead;
-pub(crate) mod aes;
 pub(crate) mod common;
-pub(crate) mod postcard;

--- a/execution-engine/src/native_modules/mod.rs
+++ b/execution-engine/src/native_modules/mod.rs
@@ -9,4 +9,7 @@
 //! See the `LICENSE_MIT.markdown` file in the Veracruz root directory for
 //! information on licensing and copyright.
 
+pub(crate) mod aead;
+pub(crate) mod aes;
 pub(crate) mod common;
+pub(crate) mod postcard;

--- a/execution-engine/src/native_modules/postcard.rs
+++ b/execution-engine/src/native_modules/postcard.rs
@@ -11,7 +11,7 @@
 //! information on licensing and copyright.
 
 use crate::fs::{FileSystem, FileSystemResult};
-use crate::native_modules::common::Service;
+use crate::native_modules::common::StaticNativeModule;
 use postcard::from_bytes;
 use serde::{Deserialize, Serialize};
 use wasi_types::ErrNo;
@@ -70,7 +70,7 @@ pub struct Struct3 {
     e3: Enum2,
 }
 
-impl Service for PostcardService {
+impl StaticNativeModule for PostcardService {
     fn name(&self) -> &str {
         "Postcard Service"
     }

--- a/policy-utils/src/policy.rs
+++ b/policy-utils/src/policy.rs
@@ -37,7 +37,7 @@
 use super::{
     error::PolicyError,
     expiry::Timepoint,
-    principal::{ExecutionStrategy, FileHash, Identity, Pipeline, Principal, Program, RightsTable},
+    principal::{ExecutionStrategy, FileHash, Identity, NativeModule, Pipeline, Principal, Program, RightsTable},
     Platform,
 };
 use anyhow::{anyhow, Result};
@@ -66,6 +66,8 @@ pub struct Policy {
     identities: Vec<Identity<String>>,
     /// The candidate programs that can be loaded in the execution engine.
     programs: Vec<Program>,
+    /// The candidate native modules that can be loaded.
+    native_modules: Vec<NativeModule>,
     /// The list of files, e.g. binaries and configurations, that must match given hashes.
     file_hashes: Vec<FileHash>,
     /// The list of pipelines.
@@ -115,6 +117,7 @@ impl Policy {
     pub fn new(
         identities: Vec<Identity<String>>,
         programs: Vec<Program>,
+        native_modules: Vec<NativeModule>,
         mut pipelines: Vec<Pipeline>,
         veracruz_server_url: String,
         enclave_cert_expiry: Timepoint,
@@ -138,6 +141,7 @@ impl Policy {
             identities,
             proxy_service_cert,
             programs,
+            native_modules,
             pipelines,
             veracruz_server_url,
             enclave_cert_expiry,

--- a/policy-utils/src/policy.rs
+++ b/policy-utils/src/policy.rs
@@ -189,6 +189,12 @@ impl Policy {
         &self.identities
     }
 
+    /// Returns the native modules associated with this policy.
+    #[inline]
+    pub fn native_modules(&self) -> &Vec<NativeModule> {
+        &self.native_modules
+    }
+
     /// Returns the URL of the Veracruz server associated with this policy.
     #[inline]
     pub fn veracruz_server_url(&self) -> &String {

--- a/policy-utils/src/principal.rs
+++ b/policy-utils/src/principal.rs
@@ -34,6 +34,8 @@ pub enum Principal {
     Program(String),
     /// Pipeline in Veracruz, identified by the pipeline name.
     Pipeline(String),
+    /// Native module in Veracruz, identified by its name.
+    NativeModule(String),
     /// No Capability, the bottom Capability. It is used in some Initialization.
     NoCap,
 }
@@ -128,6 +130,61 @@ impl Program {
     #[inline]
     pub fn file_rights_map(&self) -> HashMap<PathBuf, Rights> {
         FileRights::compute_right_map(&self.file_rights)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Native module
+////////////////////////////////////////////////////////////////////////////////
+/// Defines a native module that can be loaded.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct NativeModule {
+    /// TODO: add name
+    //name: String,
+    /// Native module's entry point (path to main binary)
+    entry_point_path: PathBuf,
+    /// Path to native module's special interface. Writing data to this file triggers the execution of the native module with some input
+	interface_path: PathBuf,
+    /// The native module's ID
+    id: u32,
+	// TODO: add sandbox policy
+}
+
+impl NativeModule {
+    /// Creates a Veracruz native module.
+    #[inline]
+    pub fn new<T: Into<u32>>(entry_point_path: PathBuf, interface_path: PathBuf, id: T) -> Self
+    {
+        Self {
+            //name,
+            entry_point_path,
+			interface_path,
+            id: id.into(),
+        }
+    }
+
+    /// Return the name.
+    /*#[inline]
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }*/
+
+    /// Return path to entry point.
+    #[inline]
+    pub fn entry_point_path(&self) -> &PathBuf {
+        &self.entry_point_path
+    }
+
+    /// Return path to interface.
+    #[inline]
+    pub fn interface_path(&self) -> &PathBuf {
+        &self.interface_path
+    }
+
+    /// Return the native module's id.
+    #[inline]
+    pub fn id(&self) -> u32 {
+        self.id
     }
 }
 

--- a/policy-utils/src/principal.rs
+++ b/policy-utils/src/principal.rs
@@ -139,35 +139,37 @@ impl Program {
 /// Defines a native module that can be loaded.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NativeModule {
-    /// TODO: add name
-    //name: String,
-    /// Native module's entry point (path to main binary)
+    /// Native module's name
+    name: String,
+    /// Native module's entry point, i.e. path to the main binary relative to
+    /// the native module's root directory
     entry_point_path: PathBuf,
-    /// Path to native module's special interface. Writing data to this file triggers the execution of the native module with some input
-	interface_path: PathBuf,
-    /// The native module's ID
+    /// Path to native module's special file. Writing data to this file triggers
+    /// the execution of the native module with data as input
+    special_file_path: PathBuf,
+    /// Native module's ID
     id: u32,
-	// TODO: add sandbox policy
+    // TODO: add sandbox policy
 }
 
 impl NativeModule {
     /// Creates a Veracruz native module.
     #[inline]
-    pub fn new<T: Into<u32>>(entry_point_path: PathBuf, interface_path: PathBuf, id: T) -> Self
+    pub fn new<T: Into<u32>>(name: String, entry_point_path: PathBuf, special_file_path: PathBuf, id: T) -> Self
     {
         Self {
-            //name,
+            name,
             entry_point_path,
-			interface_path,
+            special_file_path,
             id: id.into(),
         }
     }
 
     /// Return the name.
-    /*#[inline]
+    #[inline]
     pub fn name(&self) -> &str {
         self.name.as_str()
-    }*/
+    }
 
     /// Return path to entry point.
     #[inline]
@@ -177,8 +179,8 @@ impl NativeModule {
 
     /// Return path to interface.
     #[inline]
-    pub fn interface_path(&self) -> &PathBuf {
-        &self.interface_path
+    pub fn special_file_path(&self) -> &PathBuf {
+        &self.special_file_path
     }
 
     /// Return the native module's id.

--- a/policy-utils/src/principal.rs
+++ b/policy-utils/src/principal.rs
@@ -177,7 +177,7 @@ impl NativeModule {
         &self.entry_point_path
     }
 
-    /// Return path to interface.
+    /// Return path to special file.
     #[inline]
     pub fn special_file_path(&self) -> &PathBuf {
         &self.special_file_path

--- a/runtime-manager/src/managers/mod.rs
+++ b/runtime-manager/src/managers/mod.rs
@@ -95,7 +95,8 @@ impl ProtocolState {
         rights_table.insert(Principal::InternalSuperUser, su_read_rights);
 
         let digest_table = global_policy.get_file_hash_table()?;
-        let vfs = FileSystem::new(rights_table)?;
+        let native_modules = global_policy.native_modules();
+        let vfs = FileSystem::new(rights_table, native_modules.to_vec())?;
 
         Ok(ProtocolState {
             global_policy,

--- a/sdk/freestanding-execution-engine/Cargo.toml
+++ b/sdk/freestanding-execution-engine/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 clap = "2.33.3"
 env_logger = "0.9.0"
 execution-engine = { path = "../../execution-engine", features = ["std"] }

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -3,7 +3,7 @@
 //! ## About
 //!
 //! The WASM binary to execute, and any data sources being passed to the binary,
-//! are passed with the `--binary` and `--data` flags, respectively.  A
+//! are passed with the `--program-binary` and `--data` flags, respectively.  A
 //! runtime error is raised if the number of input data sources does not match
 //! the number specified in the configuration TOML.
 //!

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -139,7 +139,9 @@ This must be of the form \"--native-module-name name\". Multiple --native-module
                 .long("native-module-entry-point")
                 .value_name("FILE")
                 .help("Specifies the path to the entry point of the native module to use for the computation. \
-This must be of the form \"--native-module-entry-point path\". Multiple --native-module-entry-point flags may be provided.")
+This must be of the form \"--native-module-entry-point path\". Multiple --native-module-entry-point flags may be provided. \
+If the value is an empty string, the native module is assumed to be static, i.e. part of the Veracruz runtime, \
+and is looked up by name in the static native modules table.")
                 .required(false)
                 .multiple(true),
         )

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -28,7 +28,7 @@ use clap::{App, Arg};
 use execution_engine::{execute, fs::FileSystem, Options};
 use log::*;
 use policy_utils::{
-    parsers::{parse_pipeline, enforce_leading_backslash},
+    parsers::{parse_pipeline, enforce_leading_slash},
     pipeline::Expr, 
     principal::{ExecutionStrategy, NativeModule, Principal},
     CANONICAL_STDERR_FILE_PATH, CANONICAL_STDIN_FILE_PATH, CANONICAL_STDOUT_FILE_PATH,
@@ -428,7 +428,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .enumerate()
     {
         // Add a backslash (VFS requirement)
-        let special_file = enforce_leading_backslash(special_file.to_str()
+        let special_file = enforce_leading_slash(special_file.to_str()
         .ok_or(
             anyhow!("Fail to convert special_file to str."),
         )?).into_owned();

--- a/sdk/generate-policy/src/main.rs
+++ b/sdk/generate-policy/src/main.rs
@@ -256,7 +256,9 @@ impl Arguments {
                     .long("native-module-entry-point")
                     .value_name("FILE")
                     .help("Specifies the path to the entry point of the native module to use for the computation. \
-    This must be of the form \"--native-module-entry-point path\". Multiple --native-module-entry-point flags may be provided.")
+    This must be of the form \"--native-module-entry-point path\". Multiple --native-module-entry-point flags may be provided. \
+    If the value is an empty string, the native module is assumed to be static, i.e. part of the Veracruz runtime, \
+    and is looked up by name in the static native modules table.")
                     .required(false)
                     .multiple(true),
             )

--- a/sdk/generate-policy/src/main.rs
+++ b/sdk/generate-policy/src/main.rs
@@ -595,7 +595,7 @@ impl Arguments {
             .enumerate()
         {
             // Add a backslash (VFS requirement)
-            let special_file = enforce_leading_backslash(special_file.to_str()
+            let special_file = enforce_leading_slash(special_file.to_str()
             .ok_or(
                 anyhow!("Fail to convert special_file to str."),
             )?).into_owned();

--- a/tests/tests/server_test.rs
+++ b/tests/tests/server_test.rs
@@ -48,6 +48,7 @@ use veracruz_utils::VERACRUZ_RUNTIME_HASH_EXTENSION_ID;
 
 // Policy files
 const POLICY: &'static str = "single_client.json";
+const POLICY_POSTCARD_NATIVE: &'static str = "single_client_postcard_native.json";
 const CLIENT_CERT: &'static str = "client_cert.pem";
 const CLIENT_KEY: &'static str = "client_key.pem";
 const UNAUTHORIZED_CERT: &'static str = "data_client_cert.pem";
@@ -295,7 +296,7 @@ fn basic_postcard_native_module() {
         TestEvent::ShutDown,
     ];
 
-    TestExecutor::test_template(POLICY, CLIENT_CERT, CLIENT_KEY, events, TIME_OUT_SECS, true)
+    TestExecutor::test_template(POLICY_POSTCARD_NATIVE, CLIENT_CERT, CLIENT_KEY, events, TIME_OUT_SECS, true)
         .unwrap();
 }
 

--- a/veracruz-mcu-client/MCU_CLIENT_INSTRUCTIONS.markdown
+++ b/veracruz-mcu-client/MCU_CLIENT_INSTRUCTIONS.markdown
@@ -81,7 +81,7 @@ $ vc-pgen \
     --capability "input-1:w" \
     --certificate veracruz-mcu-client/example/mcu2-cert.pem \
     --capability "input-2:w" \
-    --binary audio-event-triangulation.wasm=veracruz-mcu-client/example/audio-event-triangulation.wasm \
+    --program-binary audio-event-triangulation.wasm=veracruz-mcu-client/example/audio-event-triangulation.wasm \
     --capability "input-0:r,input-1:r,input-2:r,output:w" \
     --output-policy-file veracruz-mcu-client/example/policy.json
 ```

--- a/veracruz-mcu-client/run_mcu_demo_server.sh
+++ b/veracruz-mcu-client/run_mcu_demo_server.sh
@@ -75,7 +75,7 @@ vc-pgen \
     --capability "input-1:w" \
     --certificate veracruz-mcu-client/example/mcu2-cert.pem \
     --capability "input-2:w" \
-    --binary audio-event-triangulation.wasm=veracruz-mcu-client/example/audio-event-triangulation.wasm \
+    --program-binary audio-event-triangulation.wasm=veracruz-mcu-client/example/audio-event-triangulation.wasm \
     --capability "input-0:r,input-1:r,input-2:r,output:w" \
     --output-policy-file veracruz-mcu-client/example/policy.json
 

--- a/veracruz-mcu-client/run_mcu_test_server.sh
+++ b/veracruz-mcu-client/run_mcu_test_server.sh
@@ -53,7 +53,7 @@ vc-pgen \
     --css-file runtime-manager/css-sgx.bin \
     --certificate veracruz-mcu-client/test-data/test-cert.pem \
     --capability "test-binary.wasm:w,input-0:w,input-1:w,input-2:w,output:r" \
-    --binary test-binary.wasm=veracruz-mcu-client/test-data/test-binary.wasm \
+    --program-binary test-binary.wasm=veracruz-mcu-client/test-data/test-binary.wasm \
     --capability "input-0:r,input-1:r,input-2:r,output:w" \
     --output-policy-file veracruz-mcu-client/test-data/test-policy.json
 

--- a/workspaces/host/Cargo.lock
+++ b/workspaces/host/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mbedtls",
+ "nix",
  "num",
  "num-derive",
  "num-traits",
@@ -747,6 +748,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 name = "freestanding-execution-engine"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "clap",
  "env_logger",
  "execution-engine",

--- a/workspaces/icecap-runtime/Cargo.lock
+++ b/workspaces/icecap-runtime/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mbedtls",
+ "nix",
  "num",
  "num-derive",
  "num-traits",

--- a/workspaces/linux-runtime/Cargo.lock
+++ b/workspaces/linux-runtime/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mbedtls",
+ "nix",
  "num",
  "num-derive",
  "num-traits",

--- a/workspaces/nitro-runtime/Cargo.lock
+++ b/workspaces/nitro-runtime/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mbedtls",
+ "nix",
  "num",
  "num-derive",
  "num-traits",

--- a/workspaces/shared.mk
+++ b/workspaces/shared.mk
@@ -155,7 +155,8 @@ POLICY_FILES ?= \
 	triple_policy_1.json \
 	triple_policy_2.json \
 	triple_policy_4.json \
-	quadruple_policy.json
+	quadruple_policy.json \
+	single_client_postcard_native.json
 
 PGEN = $(WORKSPACE_DIR)/host/target/$(PROFILE_PATH)/generate-policy
 
@@ -226,3 +227,14 @@ $(OUT_DIR)/quadruple_policy.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RU
 	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
 	    --veracruz-server-ip 127.0.0.1:3030 --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    --enable-clock $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
+
+$(OUT_DIR)/single_client_postcard_native.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUNTIME_ENCLAVE_BINARY_PATH)
+	cd $(OUT_DIR) ; $(PGEN) --certificate $(CLIENT_CRT) \
+	    --capability "/input/: $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)") \
+	    --pipeline "$(PROGRAM_DIR)random-u32-list.wasm ; if /output/unsorted_numbers.txt { $(PROGRAM_DIR)sort-numbers.wasm ; }" --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)" \
+            --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 \
+	    --enclave-debug-mode $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) \
+		--native-module-name "Postcard Service" --native-module-special-file "/services/postcard_string.dat" --native-module-entry-point "" \
+		--output-policy-file $@
+

--- a/workspaces/shared.mk
+++ b/workspaces/shared.mk
@@ -178,7 +178,7 @@ MAX_MEMORY_MIB = 256
 $(OUT_DIR)/single_client.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUNTIME_ENCLAVE_BINARY_PATH)
 	cd $(OUT_DIR) ; $(PGEN) --certificate $(CLIENT_CRT) \
 	    --capability "/input/: $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)") \
 	    --pipeline "$(PROGRAM_DIR)random-u32-list.wasm ; if /output/unsorted_numbers.txt { $(PROGRAM_DIR)sort-numbers.wasm ; }" --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)" \
             --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    --enclave-debug-mode $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
@@ -186,7 +186,7 @@ $(OUT_DIR)/single_client.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUNTI
 $(OUT_DIR)/single_client_no_debug.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUNTIME_ENCLAVE_BINARY_PATH)
 	cd $(OUT_DIR) ; $(PGEN) --certificate $(CLIENT_CRT) \
 	    --capability "/input/: $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT), /services/ : $(READ_WRITE_RIGHT)") \
             --veracruz-server-ip 127.0.0.1:3011 --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
 
@@ -194,7 +194,7 @@ $(OUT_DIR)/dual_policy.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUNTIME
 	cd $(OUT_DIR) ; $(PGEN) \
 	    --certificate $(PROGRAM_CRT) --capability "$(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
 	    --certificate $(DATA_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), stdin : $(WRITE_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
 		--veracruz-server-ip 127.0.0.1:3012 --proxy-attestation-server-ip 127.0.0.1:3010 \
 		--enable-clock $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
 
@@ -202,7 +202,7 @@ $(OUT_DIR)/dual_parallel_policy.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) 
 	cd $(OUT_DIR) ; $(PGEN) \
 	    --certificate $(PROGRAM_CRT) --capability "$(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
 	    --certificate $(DATA_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
 	    --veracruz-server-ip 127.0.0.1:3013 --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    --enable-clock $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
 
@@ -212,7 +212,7 @@ $(OUT_DIR)/triple_policy_%.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RUN
 	    --certificate $(PROGRAM_CRT) --capability "$(PROGRAM_DIR) : $(WRITE_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT), stderr : $(READ_RIGHT), stdout : $(READ_RIGHT)" \
 	    --certificate $(DATA_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT)" \
 	    --certificate $(RESULT_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
 	    --veracruz-server-ip 127.0.0.1:$(shell echo "3020 + $*" | bc) \
 	    --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    --enable-clock $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@
@@ -223,6 +223,6 @@ $(OUT_DIR)/quadruple_policy.json: $(PGEN) $(CREDENTIALS) $(WASM_PROG_FILES) $(RU
 	    --certificate $(DATA_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT)" \
 	    --certificate $(NEVER_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT), stdin : $(WRITE_RIGHT)" \
 	    --certificate $(RESULT_CRT) --capability "/input/ : $(WRITE_RIGHT), /output/ : $(READ_RIGHT), $(PROGRAM_DIR) : $(OPEN_EXECUTE_RIGHT)" \
-	    $(foreach prog_name,$(WASM_PROG_FILES),--binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
+	    $(foreach prog_name,$(WASM_PROG_FILES),--program-binary $(PROGRAM_DIR)$(notdir $(prog_name))=$(prog_name) --capability "/input/ : $(READ_RIGHT), /output/ : $(READ_WRITE_RIGHT), stdin : $(READ_RIGHT), stderr : $(WRITE_RIGHT), stdout : $(WRITE_RIGHT)") \
 	    --veracruz-server-ip 127.0.0.1:3030 --proxy-attestation-server-ip 127.0.0.1:3010 \
 	    --enable-clock $(PGEN_COMMON_PARAMS) --max-memory-mib $(MAX_MEMORY_MIB) --output-policy-file $@


### PR DESCRIPTION
Implement dynamic native modules based on https://github.com/veracruz-project/veracruz/discussions/577
This is the first step of an MVP.

### Done
* Add extension to policy file to specify name, special file (VFS file that interfaces with the native module) and entry point (path to main binary) per native module. For this MVP we're not looking at implementing a full fledged packaging system with checksums, signatures, links to artifacts, etc. The artifacts will have to be injected into the execution environment before deployment
* Replace legacy native module system with new system supporting dynamic native modules
* Write [sandboxer](https://github.com/veracruz-project/native-module-manager) (sandbox2 client)
* Implement native module management in the RM (sandbox environment init & teardown, native module launch)
* Unify static and dynamic NM

### Todo
* Polish

### Usage
Since no packaging system has been implemented yet, some binaries have to be injected into the execution environment before execution:
* Compile Veracruz, the [native module sandboxer](https://github.com/veracruz-project/native-module-sandboxer) and the [TF Lite native module](https://github.com/veracruz-project/tflite-nm)
* Create the `/tmp/nmm` directory in the execution environment (the machine/container where the Runtime Manager is to be executed)
* Copy `native-module-sandboxer` to `/tmp/nmm/`
* Copy `tflite-nm` to `/tmp/nmm/tflite-nm/`
* Deploy Veracruz

Note:
Dynamic native modules are expected to read the execution configuration file (default `/execution_config` within the sandbox) in order to know what to do, where to get inputs and where to write outputs.