### PR TITLE
Add TF Lite native inference example

### DIFF
--- a/examples/rust-examples/tflite-inference-native-mnist/Cargo.toml
+++ b/examples/rust-examples/tflite-inference-native-mnist/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "A test program for calling the TensorFlow Lite inference module on a MNIST model."
+name = "tflite-inference-native-mnist"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.14"
+image = "=0.24.4"
+libc = "0.2.137"
+postcard = { version = "0.7.2", features = [ "alloc", "use-std" ] }
+serde = { version = "1.0.3", features = ["derive"] }

--- a/examples/rust-examples/tflite-inference-native-mnist/Makefile
+++ b/examples/rust-examples/tflite-inference-native-mnist/Makefile
@@ -1,0 +1,26 @@
+# Example Makefile
+#
+# AUTHORS
+#
+# The Veracruz Development Team.
+#
+# COPYRIGHT AND LICENSING
+#
+# See the `LICENSING.markdown` file in the Veracruz root directory for
+# licensing and copyright information.
+
+.PHONY: all doc clean fmt
+
+all:
+	cargo build --target wasm32-wasi --release
+
+doc:
+	cargo doc
+
+fmt:
+	cargo fmt
+
+clean: 
+	cargo clean
+	rm -f Cargo.lock
+

--- a/examples/rust-examples/tflite-inference-native-mnist/src/main.rs
+++ b/examples/rust-examples/tflite-inference-native-mnist/src/main.rs
@@ -1,0 +1,109 @@
+//! An example program to call the TensorFlow Lite inference module on a MNIST
+//! model, which can be downloaded at https://github.com/boncheolgu/tflite-rs/blob/master/data/MNISTnet_uint8_quant.tflite
+//!
+//! ## Context
+//!
+//! It calls the module mounted at path `/services/tflite_inference.dat` via a
+//! `TfLiteInferenceInput` structure serialized with postcard.
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSE_MIT.markdown` in the Veracruz root directory for
+//! licensing and copyright information.
+
+use image::imageops;
+use libc::c_int;
+use serde::Serialize;
+use std::{
+    fs::{read, write},
+    path::{Path, PathBuf},
+};
+
+/// The interface with the TensorFlow Lite inference service. This structure
+/// should reflect the one expected by the native module, defined in
+/// `tflite_inference.rs`
+#[derive(Serialize, Debug)]
+pub struct TfLiteInferenceInput {
+    /// Path to the input tensor to be fed to the network.
+    input_tensor_path: PathBuf,
+    /// Path to the model serialized with FlatBuffers.
+    model_path: PathBuf,
+    /// Path to the output tensor containing the result of the prediction.
+    output_tensor_path: PathBuf,
+    /// Number of CPU threads to use for the TensorFlow Lite interpreter.
+    num_threads: c_int,
+}
+
+const MNIST_MODEL_INPUT_SIZE: (u32, u32) = (28, 28);
+
+/// Example to invoke the TensorFlow Lite inference service.
+/// Pass a MNIST model, an input tensor encoding a handwritten digit as a
+/// grayscale image, and additional configuration for the TensorFlow Lite
+/// interpreter (number of threads), to the service.
+/// The output tensor corresponding to the detection probability for each digit
+/// is read from `output_tensor_path` and post-processed.
+fn main() -> anyhow::Result<()> {
+    // Read image of a handwritten digit. The digit must be white on a black
+    // background
+    let img = image::open("/input/digit.png")?;
+    // Resize image to model's input size
+    let img = imageops::resize(
+        &img,
+        MNIST_MODEL_INPUT_SIZE.0,
+        MNIST_MODEL_INPUT_SIZE.1,
+        imageops::FilterType::Triangle,
+    );
+    // Convert image to gray scale
+    let img = imageops::colorops::grayscale(&img);
+    let grayscale_image_binary = img.as_raw();
+    write(
+        "/program_internal/grayscale_image.bin",
+        &grayscale_image_binary,
+    )?;
+
+    // Invoke service
+    let tflite_inference_input = TfLiteInferenceInput {
+        input_tensor_path: PathBuf::from("/program_internal/grayscale_image.bin"),
+        model_path: PathBuf::from("/input/MNISTnet_uint8_quant.tflite"),
+        output_tensor_path: PathBuf::from("/program_internal/output.dat"),
+        num_threads: -1, // Let TF Lite pick how many threads it needs
+    };
+    println!("service input {:x?}", tflite_inference_input);
+    let tflite_inference_input_bytes = postcard::to_allocvec(&tflite_inference_input)?;
+    println!("calling TensorFlow Lite Inference service...");
+    write(
+        "/services/tflite_inference.dat",
+        tflite_inference_input_bytes,
+    )?;
+    println!("service return");
+
+    // Post-process results
+    let result = read(tflite_inference_input.output_tensor_path)?;
+    if result.len() != 10 {
+        return Err(anyhow::anyhow!("Unexpected output size"));
+    }
+    let mut result_map = vec![];
+    for i in 0..result.len() {
+        let percentage = (result[i] as f32) * 100.0 / 255.0;
+        result_map.push((i, percentage));
+    }
+    result_map.sort_by(|a, b| {
+        if b.1 > a.1 {
+            std::cmp::Ordering::Greater
+        } else if b.1 < a.1 {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+    println!("Detection probability per digit (descending):");
+    for (i, percentage) in result_map {
+        println!("{}: {:.2}%", i, percentage);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add TF Lite native inference example.
Requires:
* [TF Lite native module](https://github.com/veracruz-project/tflite-nm)
* The dynamic native module loading mechanism implemented in #587 
* This [MNIST model](https://github.com/boncheolgu/tflite-rs/blob/master/data/MNISTnet_uint8_quant.tflite)