### PR TITLE
Add Darknet inference native example

### DIFF
--- a/examples/rust-examples/darknet-inference-native/Cargo.toml
+++ b/examples/rust-examples/darknet-inference-native/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["The Veracruz Development Team"]
+description = "The test program for calling the Darknet inference module."
+name = "darknet-inference-native"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.14"
+postcard = { version = "0.7.2", features = [ "alloc", "use-std" ] }
+serde = { version = "1.0.3", features = ["derive"] }

--- a/examples/rust-examples/darknet-inference-native/src/main.rs
+++ b/examples/rust-examples/darknet-inference-native/src/main.rs
@@ -1,0 +1,64 @@
+//! An example program to call the Darknet inference module.
+//!
+//! ## Context
+//!
+//! It calls the module mounted at path `/services/darknet_inference.dat`, via
+//! the postcard encoding of the interface,
+//! ```
+//! pub struct DarknetInferenceInput {
+//!     input_path: PathBuf,
+//!     cfg_path: PathBuf,
+//!     model_path: PathBuf,
+//!     labels_path: PathBuf,
+//!     output_path: PathBuf,
+//! }
+//! ```
+//!
+//! ## Authors
+//!
+//! The Veracruz Development Team.
+//!
+//! ## Copyright
+//!
+//! See the file `LICENSE_MIT.markdown` in the Veracruz root directory for licensing
+//! and copyright information.
+
+use serde::Serialize;
+use std::{
+    fs::{read_to_string, write},
+    path::PathBuf,
+};
+
+/// The interface with the Darknet inference service
+#[derive(Serialize, Debug)]
+pub struct DarknetInferenceInput {
+    input_path: PathBuf,
+    cfg_path: PathBuf,
+    model_path: PathBuf,
+    labels_path: PathBuf,
+    output_path: PathBuf,
+}
+
+/// Example to invoke the Darknet inference service.
+/// Pass an image, a YOLO model with its configuration and a labels file to the
+/// service.
+/// The prediction is written to `output_path`
+fn main() -> anyhow::Result<()> {
+    let darknet_inference_input = DarknetInferenceInput {
+        input_path: PathBuf::from("input/image.jpg"),
+        cfg_path: PathBuf::from("input/yolov3-tiny.cfg"),
+        model_path: PathBuf::from("input/yolov3-tiny.weights"),
+        labels_path: PathBuf::from("input/coco.names"),
+        output_path: PathBuf::from("output/prediction.dat"),
+    };
+    println!("service input {:x?}", darknet_inference_input);
+
+    let darknet_inference_input_bytes = postcard::to_allocvec(&darknet_inference_input)?;
+    println!("calling Darknet Inference service...");
+    write("/services/darknet_inference.dat", darknet_inference_input_bytes)?;
+    let result = read_to_string(darknet_inference_input.output_path)?;
+    println!("prediction:\n{:x?}", result);
+    println!("service return");
+
+    Ok(())
+}

--- a/examples/rust-examples/darknet-inference-native/src/main.rs
+++ b/examples/rust-examples/darknet-inference-native/src/main.rs
@@ -2,17 +2,8 @@
 //!
 //! ## Context
 //!
-//! It calls the module mounted at path `/services/darknet_inference.dat`, via
-//! the postcard encoding of the interface,
-//! ```
-//! pub struct DarknetInferenceInput {
-//!     input_path: PathBuf,
-//!     cfg_path: PathBuf,
-//!     model_path: PathBuf,
-//!     labels_path: PathBuf,
-//!     output_path: PathBuf,
-//! }
-//! ```
+//! It calls the module mounted at path `/services/darknet_inference.dat` by
+//! serializing a `DarknetInferenceInput` structure with postcard.
 //!
 //! ## Authors
 //!
@@ -29,33 +20,62 @@ use std::{
     path::PathBuf,
 };
 
-/// The interface with the Darknet inference service
+/// The interface with the Darknet inference service.
 #[derive(Serialize, Debug)]
 pub struct DarknetInferenceInput {
+    /// Path to the input (image) to be fed to the network.
     input_path: PathBuf,
+    /// Path to the model's configuration.
     cfg_path: PathBuf,
+    /// Path to the actual model (weights).
     model_path: PathBuf,
+    /// Path to the labels file containing all the objects that can be detected.
     labels_path: PathBuf,
+    /// Path to the output file containing the result of the prediction.
     output_path: PathBuf,
+    /// Threshold above which an object is considered detected.
+    objectness_threshold: f32,
+    /// Threshold above which a class is considered detected assuming objectness
+    /// within the detection box. Darknet internally sets class probabilities to
+    /// 0 if they are below the objectness threshold, so this should be above it
+    /// to make any difference.
+    class_threshold: f32,
+    /// Hierarchical threshold. Only used in YOLO9000, a model able to detect
+    /// hierarchised objects.
+    hierarchical_threshold: f32,
+    /// Intersection-over-union threshold. Used to eliminate irrelevant
+    /// detection boxes.
+    iou_threshold: f32,
+    /// Whether the image should be letterboxed, i.e. padded while preserving
+    /// its aspect ratio, or resized, before being fed to the model.
+    letterbox: bool,
 }
 
-/// Example to invoke the Darknet inference service.
-/// Pass an image, a YOLO model with its configuration and a labels file to the
-/// service.
-/// The prediction is written to `output_path`
+/// Example to invoke the Darknet inference service on a YOLO model.
+/// Pass an image, a YOLO model with its configuration, various parameters and
+/// a labels file to the service.
+/// The prediction, a list of detected boxes, is written to `output_path`.
 fn main() -> anyhow::Result<()> {
     let darknet_inference_input = DarknetInferenceInput {
         input_path: PathBuf::from("input/image.jpg"),
-        cfg_path: PathBuf::from("input/yolov3-tiny.cfg"),
-        model_path: PathBuf::from("input/yolov3-tiny.weights"),
+        cfg_path: PathBuf::from("input/yolov3.cfg"),
+        model_path: PathBuf::from("input/yolov3.weights"),
         labels_path: PathBuf::from("input/coco.names"),
-        output_path: PathBuf::from("output/prediction.dat"),
+        output_path: PathBuf::from("output/prediction.log"),
+        objectness_threshold: 0.25,
+        class_threshold: 0.25,
+        hierarchical_threshold: 0.5,
+        iou_threshold: 0.45,
+        letterbox: true,
     };
     println!("service input {:x?}", darknet_inference_input);
 
     let darknet_inference_input_bytes = postcard::to_allocvec(&darknet_inference_input)?;
     println!("calling Darknet Inference service...");
-    write("/services/darknet_inference.dat", darknet_inference_input_bytes)?;
+    write(
+        "/services/darknet_inference.dat",
+        darknet_inference_input_bytes,
+    )?;
     let result = read_to_string(darknet_inference_input.output_path)?;
     println!("prediction:\n{:x?}", result);
     println!("service return");

--- a/examples/rust-examples/darknet-inference-native/src/main.rs
+++ b/examples/rust-examples/darknet-inference-native/src/main.rs
@@ -2,8 +2,8 @@
 //!
 //! ## Context
 //!
-//! It calls the module mounted at path `/services/darknet_inference.dat` by
-//! serializing a `DarknetInferenceInput` structure with postcard.
+//! It calls the module mounted at path `/services/darknet_inference.dat` via a
+//! `DarknetInferenceInput` structure serialized with postcard.
 //!
 //! ## Authors
 //!

--- a/examples/rust-examples/darknet-inference-native/src/main.rs
+++ b/examples/rust-examples/darknet-inference-native/src/main.rs
@@ -20,7 +20,9 @@ use std::{
     path::PathBuf,
 };
 
-/// The interface with the Darknet inference service.
+/// The interface with the Darknet inference service. This structure should
+/// reflect the one expected by the native module, defined in
+/// `darknet_inference.rs`
 #[derive(Serialize, Debug)]
 pub struct DarknetInferenceInput {
     /// Path to the input (image) to be fed to the network.


### PR DESCRIPTION
Add Darknet inference native example.
Supersedes #571
Associated native module: https://github.com/veracruz-project/darknet-inference-nm