### PR TITLE
Add "std" feature to "serde" dependency of virtio-console-server.

### DIFF
--- a/workspaces/icecap-runtime/src/virtio-console-server/Cargo.toml
+++ b/workspaces/icecap-runtime/src/virtio-console-server/Cargo.toml
@@ -9,5 +9,5 @@ icecap-driver-interfaces = { path =  "../../crates/icecap/crates/framework/drive
 icecap-pl011-driver = { path =  "../../crates/icecap/crates/framework/drivers/devices/pl011" }
 icecap-start-generic = { path =  "../../crates/icecap/crates/framework/base/icecap-start/generic" }
 libc = { path = "../../crates/icecap/sysroot/libc", optional = true }
-serde = { version = "*", default-features = false, features = [ "alloc", "derive" ] }
+serde = { version = "*", default-features = false, features = [ "alloc", "derive", "std" ] }
 virtio-drivers = { path = "../../crates/icecap/crates/framework/drivers/devices/virtio-drivers" }


### PR DESCRIPTION
We can see that this is a real requirement by trying to build virtio-console-server on its own. We have survived without it so far because virtio-console-server was only ever built in the same workspace together with runtime-manager, which depends on veracruz-utils, which depends on mbedtls, which has the "default" feature, that includes "std", that specifies "serde/std".

It is better to make the requirement explicit rather than depend on the intricacies of Cargo.