### PR TITLE
Update spin from 0.9.* to 0.9.8 in workspaces/*/Cargo.lock.

### DIFF
--- a/workspaces/applications/Cargo.lock
+++ b/workspaces/applications/Cargo.lock
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/data-generators/Cargo.lock
+++ b/workspaces/data-generators/Cargo.lock
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/host/Cargo.lock
+++ b/workspaces/host/Cargo.lock
@@ -865,7 +865,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1814,9 +1814,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/icecap-host/Cargo.lock
+++ b/workspaces/icecap-host/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1825,9 +1825,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/icecap-runtime/Cargo.lock
+++ b/workspaces/icecap-runtime/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2197,9 +2197,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/linux-host/Cargo.lock
+++ b/workspaces/linux-host/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1825,9 +1825,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/linux-runtime/Cargo.lock
+++ b/workspaces/linux-runtime/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.4",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2105,9 +2105,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/nitro-host/Cargo.lock
+++ b/workspaces/nitro-host/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1825,9 +1825,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/workspaces/nitro-runtime/Cargo.lock
+++ b/workspaces/nitro-runtime/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin 0.9.2",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2183,9 +2183,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
This is an extension of dependabot's PR #599, which updated just 0.9.3 to 0.9.8.

There are still uses of spin 0.5.2, because of rust-mbedtls.