### PR TITLE
Implement WASM bypass

### DIFF
--- a/execution-engine/src/fs.rs
+++ b/execution-engine/src/fs.rs
@@ -2065,10 +2065,22 @@ impl FileSystem {
         self.read_std_stream(Fd(1))
     }
 
+    /// A public API for writing to stdout.
+    #[inline]
+    pub fn write_stdout(&mut self, buf: &[u8]) -> FileSystemResult<usize> {
+        self.fd_write(Fd(1), &[buf])
+    }
+
     /// A public API for reading from stderr.
     #[inline]
     pub fn read_stderr(&mut self) -> FileSystemResult<Vec<u8>> {
         self.read_std_stream(Fd(2))
+    }
+
+    /// A public API for writing to stderr.
+    #[inline]
+    pub fn write_stderr(&mut self, buf: &[u8]) -> FileSystemResult<usize> {
+        self.fd_write(Fd(2), &[buf])
     }
 
     /// Read from std streaming.

--- a/execution-engine/src/native_module_manager.rs
+++ b/execution-engine/src/native_module_manager.rs
@@ -195,9 +195,9 @@ impl NativeModuleManager {
                         self.copy_fs_to_vfs(&path_unprefixed)?;
                     }
                 } else {
-                    // Read file on the kernel fileystem, chunk by chunk
+                    // Read file on the kernel fileystem by chunks of 1MiB
                     let mut f = File::open(&path_prefixed)?;
-                    let mut buf: [u8; 128] = [0; 128];
+                    let mut buf: [u8; 1048576] = [0; 1048576];
 
                     // Copy file to the VFS. First truncate the VFS file then
                     // append to it. If the principal doesn't have write access,

--- a/execution-engine/src/native_modules/common.rs
+++ b/execution-engine/src/native_modules/common.rs
@@ -16,13 +16,9 @@ use crate::{
 use lazy_static::lazy_static;
 use std::{collections::HashMap, sync::Mutex};
 
-/// Specifications for static native modules, i.e. native modules which are
-/// always part of the Veracruz runtime and don't have to be loaded as separate
-/// binaries.
-/// Despite their static behaviour, they have to be explicitly declared in the
-/// policy file to be used in a computation. See
-/// `policy_utils::principal::NativeModule` and `generate-policy` for more
-/// details.
+/// Specifications for static native module crates.
+/// See `policy_utils::principal::NativeModule` and `generate-policy` for more
+/// details on static native modules.
 pub trait StaticNativeModule: Send {
     fn name(&self) -> &str;
     //fn configure(&mut self, config: Self::Configuration) -> FileSystemResult<()>;

--- a/policy-utils/src/principal.rs
+++ b/policy-utils/src/principal.rs
@@ -157,11 +157,11 @@ pub enum NativeModuleType {
     Dynamic { special_file: PathBuf, entry_point: PathBuf },
     /// Native module that is provisioned to the enclave and executed just like
     /// a regular WASM program, i.e. via a result request from a participant.
-    /// Provisioning external shared libraries to the execution environment is
-    /// not supported yet, therefore the binary must whether be statically
-    /// linked, or depend on shared libraries provided by the underlying
-    /// operating system.
-    Provisioned(Program),
+    /// Dynamic linking is supported if the shared libraries can be found.
+    /// The execution principal corresponding to the native module should have
+    /// read access to every directory containing the execution artifacts
+    /// (binary and optional shared libraries).
+    Provisioned { entry_point: PathBuf },
 }
 
 /// Defines a native module that can be loaded directly (provisioned native
@@ -173,20 +173,17 @@ pub struct NativeModule {
     name: String,
     /// Native's module type
     r#type: NativeModuleType,
-    /// Native module's ID
-    id: u32,
     // TODO: add sandbox policy
 }
 
 impl NativeModule {
     /// Creates a Veracruz native module.
     #[inline]
-    pub fn new<T: Into<u32>>(name: String, r#type: NativeModuleType, id: T) -> Self
+    pub fn new(name: String, r#type: NativeModuleType) -> Self
     {
         Self {
             name,
             r#type,
-            id: id.into(),
         }
     }
 
@@ -200,12 +197,6 @@ impl NativeModule {
     #[inline]
     pub fn r#type(&self) -> &NativeModuleType {
         &self.r#type
-    }
-
-    /// Return the native module's id.
-    #[inline]
-    pub fn id(&self) -> u32 {
-        self.id
     }
 
     /// Return whether the native module is static

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -434,11 +434,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         )?).into_owned();
 
         let nm_type = if entry_point_path == &PathBuf::from("") {
-            NativeModuleType::Static
+            NativeModuleType::Static { special_file: PathBuf::from(special_file) }
         } else {
-            NativeModuleType::Dynamic
+            NativeModuleType::Dynamic { special_file: PathBuf::from(special_file), entry_point: entry_point_path.to_path_buf() }
         };
-        native_modules.push(NativeModule::new(name.to_string(), nm_type, entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
+        native_modules.push(NativeModule::new(name.to_string(), nm_type, id as u32));
     }
 
     let mut vfs = FileSystem::new(right_table, native_modules)?;

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -30,7 +30,7 @@ use log::*;
 use policy_utils::{
     parsers::{parse_pipeline, enforce_leading_slash},
     pipeline::Expr, 
-    principal::{ExecutionStrategy, NativeModule, Principal},
+    principal::{ExecutionStrategy, NativeModule, NativeModuleType, Principal},
     CANONICAL_STDERR_FILE_PATH, CANONICAL_STDIN_FILE_PATH, CANONICAL_STDOUT_FILE_PATH,
 };
 use std::{
@@ -433,7 +433,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             anyhow!("Fail to convert special_file to str."),
         )?).into_owned();
 
-        native_modules.push(NativeModule::new(name.to_string(), entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
+        let nm_type = if entry_point_path == &PathBuf::from("") {
+            NativeModuleType::Static
+        } else {
+            NativeModuleType::Dynamic
+        };
+        native_modules.push(NativeModule::new(name.to_string(), nm_type, entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
     }
 
     let mut vfs = FileSystem::new(right_table, native_modules)?;

--- a/sdk/freestanding-execution-engine/src/main.rs
+++ b/sdk/freestanding-execution-engine/src/main.rs
@@ -69,7 +69,7 @@ const VERSION: &str = "pre-alpha";
 struct CommandLineOptions {
     /// The list of file names passed as input data-sources.
     input_sources: Vec<String>,
-    /// The list of file names passed as ouput.
+    /// The list of file names passed as output.
     output_sources: Vec<String>,
     /// The execution strategy to use when performing the computation.
     execution_strategy: ExecutionStrategy,
@@ -421,11 +421,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     assert_eq!(cmdline.native_modules_entry_points.len(), cmdline.native_modules_special_files.len());
 
     let mut native_modules = Vec::new();
-    for (id, ((name, entry_point_path), special_file)) in cmdline.native_modules_names
+    for ((name, entry_point_path), special_file) in cmdline.native_modules_names
         .iter()
         .zip(&cmdline.native_modules_entry_points)
         .zip(&cmdline.native_modules_special_files)
-        .enumerate()
     {
         // Add a backslash (VFS requirement)
         let special_file = enforce_leading_slash(special_file.to_str()
@@ -438,7 +437,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else {
             NativeModuleType::Dynamic { special_file: PathBuf::from(special_file), entry_point: entry_point_path.to_path_buf() }
         };
-        native_modules.push(NativeModule::new(name.to_string(), nm_type, id as u32));
+        native_modules.push(NativeModule::new(name.to_string(), nm_type));
     }
 
     let mut vfs = FileSystem::new(right_table, native_modules)?;

--- a/sdk/generate-policy/src/main.rs
+++ b/sdk/generate-policy/src/main.rs
@@ -601,11 +601,11 @@ impl Arguments {
             )?).into_owned();
 
             let nm_type = if entry_point_path == &PathBuf::from("") {
-                NativeModuleType::Static
+                NativeModuleType::Static { special_file: PathBuf::from(special_file) }
             } else {
-                NativeModuleType::Dynamic
+                NativeModuleType::Dynamic { special_file: PathBuf::from(special_file), entry_point: entry_point_path.to_path_buf() }
             };
-            result.push(NativeModule::new(name.to_string(), nm_type, entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
+            result.push(NativeModule::new(name.to_string(), nm_type, id as u32));
         }
         Ok(result)
     }

--- a/sdk/generate-policy/src/main.rs
+++ b/sdk/generate-policy/src/main.rs
@@ -18,7 +18,7 @@ use policy_utils::{
     expiry::Timepoint,
     parsers::{enforce_leading_slash, parse_renamable_paths},
     policy::Policy,
-    principal::{ExecutionStrategy, FileHash, FileRights, Identity, NativeModule, Pipeline, Program},
+    principal::{ExecutionStrategy, FileHash, FileRights, Identity, NativeModule, NativeModuleType, Pipeline, Program},
 };
 use regex::Regex;
 use serde_json::{json, to_string_pretty, Value};
@@ -600,7 +600,12 @@ impl Arguments {
                 anyhow!("Fail to convert special_file to str."),
             )?).into_owned();
 
-            result.push(NativeModule::new(name.to_string(), entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
+            let nm_type = if entry_point_path == &PathBuf::from("") {
+                NativeModuleType::Static
+            } else {
+                NativeModuleType::Dynamic
+            };
+            result.push(NativeModule::new(name.to_string(), nm_type, entry_point_path.to_path_buf(), PathBuf::from(special_file), id as u32));
         }
         Ok(result)
     }

--- a/sdk/generate-policy/src/main.rs
+++ b/sdk/generate-policy/src/main.rs
@@ -587,12 +587,11 @@ impl Arguments {
         assert_eq!(self.native_modules_entry_points.len(), self.native_modules_special_files.len());
 
         let mut result = Vec::new();
-        for (id, ((name, entry_point_path), special_file)) in self
+        for ((name, entry_point_path), special_file) in self
             .native_modules_names
             .iter()
             .zip(&self.native_modules_entry_points)
             .zip(&self.native_modules_special_files)
-            .enumerate()
         {
             // Add a backslash (VFS requirement)
             let special_file = enforce_leading_slash(special_file.to_str()
@@ -605,7 +604,7 @@ impl Arguments {
             } else {
                 NativeModuleType::Dynamic { special_file: PathBuf::from(special_file), entry_point: entry_point_path.to_path_buf() }
             };
-            result.push(NativeModule::new(name.to_string(), nm_type, id as u32));
+            result.push(NativeModule::new(name.to_string(), nm_type));
         }
         Ok(result)
     }


### PR DESCRIPTION
On some systems where WASM is not supported, it might be beneficial to be able to invoke native binaries straight away without needing a call from a WASM program.
This PR implements just that. We add a new type of native modules, provisioned, which is provisioned like a WASM program, but is executed just like a dynamic native module, i.e. in a sandbox environment. Programs provisioned without a `*.wasm` extension are interpreted as provisioned native modules.
Note the program must have read access to itself so that it can be copied to the kernel's filesystem upon invocation.
Also note there is no support for providing an execution configuration to a provisioned native module. It's not hard to implement but would bloat policies a bit.

~~NB: This PR sits on top of https://github.com/veracruz-project/veracruz/pull/587 which will have to be merged beforehand~~