### PR TITLE
Stabilize VOD deployment job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,14 @@ jobs:
           rm -rf output
       - name: Run VOD in wasmtime
         run: |
+          # Fetch wasmtime's latest version using $GITHUB_TOKEN to increase
+          # Github REST API's rate limit
+          latest_version=$(curl -s "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" \
+             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
+             grep tag_name | cut -d '"' -f 4)
+          # Install wasmtime
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version $latest_version && \
+          . ~/.bashrc
           # grab every bash code block for this step, remove line continuation,
           # and only keep lines that start with '$' (of course removing that '$'
           # in the process)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'veracruz-project/video-object-detection'
-          ref: 'main'
+          ref: '20230509'
           submodules: recursive
           set-safe-directory: true
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'veracruz-project/video-object-detection'
-          ref: '20230509'
+          ref: 'main'
           submodules: recursive
           set-safe-directory: true
       - name: Build


### PR DESCRIPTION
This PR should stabilize the CI and make it harder to break:
- Point VOD deployment job to a specific tag of VOD
- Fetch wasmtime's latest version using $GITHUB_TOKEN to increase [Github REST API's rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)