### PR TITLE
Veracruz-Linux: Resolve symlinks to source locations in debug info at build time

### DIFF
--- a/workspaces/linux-host/Makefile
+++ b/workspaces/linux-host/Makefile
@@ -35,10 +35,13 @@ TEST_PARAMETERS = VERACRUZ_POLICY_DIR=$(OUT_DIR) \
 
 CLIPPY_OPTIONS = --no-deps -A clippy::type_complexity -A clippy::module_inception -D warnings
 
+unresolved_crates_path := $(shell pwd)/crates
+
 all: build test-collateral
 
 build:
 	RUNTIME_ENCLAVE_BINARY_PATH=$(RUNTIME_ENCLAVE_BINARY_PATH) \
+	RUSTFLAGS="--remap-path-prefix $(unresolved_crates_path)=$(shell readlink -f $(unresolved_crates_path))" \
 	$(CC) \
 		cargo build $(PROFILE_FLAG) $(V_FLAG) \
 		-p veracruz-client -p veracruz-server \

--- a/workspaces/linux-runtime/Makefile
+++ b/workspaces/linux-runtime/Makefile
@@ -17,11 +17,14 @@ WORKSPACE_DIR = $(abspath ..)
 
 include $(WORKSPACE_DIR)/common.mk
 
+unresolved_crates_path := $(shell pwd)/crates
+
 all: linux
 
 linux: runtime-manager-enclave
 
 runtime-manager-enclave:
+	RUSTFLAGS="--remap-path-prefix $(unresolved_crates_path)=$(shell readlink -f $(unresolved_crates_path))" \
 	cargo build $(PROFILE_FLAG) $(V_FLAG) --features linux -p runtime_manager_enclave
 
 doc:


### PR DESCRIPTION
rustc doesn't seem to resolve symlinks to source locations in debug info by default, and since we're using symlinks for our workspaces (https://github.com/veracruz-project/veracruz/tree/main/workspaces/linux-host/crates and https://github.com/veracruz-project/veracruz/tree/main/workspaces/linux-runtime/crates), this causes debugging complications down the line (cf. https://github.com/vadimcn/codelldb/discussions/931).
Several workarounds exist at the debugger level but I propose to resolve source locations by remapping them at build time, as it seems to be the lowest hanging fruit and generates very little friction overall.
This PR does that, resulting in improved debugging in VSCode using the CodeLLDB, one of the few if not only solution to interactively debug Rust code in VSCode