### PR TITLE
Switch back to building parse-capDL with stack

### DIFF
--- a/docker/ci/Dockerfile.base
+++ b/docker/ci/Dockerfile.base
@@ -39,21 +39,24 @@ RUN \
         six \
         sortedcontainers
 
-RUN \
-    git clone https://gitlab.com/tseenshe/stack2cabal.git &&  \
-    cd stack2cabal && \
-    cabal v2-update && \
-    cabal v2-build -j --disable-optimization --ghc-options "-O0" all && \
-    cp $(cabal v2-exec --disable-optimization -v0 which -- stack2cabal) /usr/local/bin && \
-    cd .. && \
-    rm -rf stack2cabal && \
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) arch='x86_64'; fileSha256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d' ;; \
+        arm64) arch='aarch64'; fileSha256='741cf6552adcd41ca0c38c4f03b1e8f244873d988f70ef5ed4b502c0df28ea5a' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    curl -L -o stack.tar.gz "https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-${arch}.tar.gz" && \
+    echo "${fileSha256} *stack.tar.gz" | sha256sum -c - ; \
+    tar zxf stack.tar.gz && \
+    cp stack-2.9.1-linux-${arch}/stack /usr/bin && \
+    chmod a+x /usr/bin/stack && \
+    rm -rf stack* && \
     git clone https://gitlab.com/arm-research/security/icecap/capdl.git && \
     cd capdl/capDL-tool && \
-    /usr/local/bin/stack2cabal && \
-    perl -i -pe 's/with-compiler: ghc-.*/with-compiler: ghc-8.8.4/' cabal.project && \
-    cabal v2-build -j --disable-optimization --ghc-options "-O0" all && \
-    cp $(cabal v2-exec --disable-optimization -v0 which -- parse-capDL) /usr/local/bin && \
+    stack --version && \
+    make && \
+    cp parse-capDL /usr/local/bin && \
     cd ../.. && \
     rm -rf capdl && \
-    cabal v2-clean && \
-    rm -rf $HOME/.cabal
+    rm -rf $HOME/.stack


### PR DESCRIPTION
The dependencies for stack2cabal are not fully pinned, so it seems a dependency update broke the build.