### PR TITLE
Fix docker images name and reference the right build instructions in README

### DIFF
--- a/BUILD_INSTRUCTIONS.markdown
+++ b/BUILD_INSTRUCTIONS.markdown
@@ -1,1 +1,0 @@
-Please follow [the build instructions](https://github.com/veracruz-project/veracruz-docker-image) in the Docker submodule.

--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,7 @@ To learn more about Veracruz, the motivation, design, use-cases, and so on, plea
 The latest project news is available on the [Veracruz project homepage](https://veracruz-project.github.io).
 
 To jump straight into the codebase, please read the growing number of guides we have on how to get started with Veracruz:
-- [BUILD_INSTRUCTIONS.markdown](BUILD_INSTRUCTIONS.markdown) - Set up a build environment for Veracruz
+- [BUILD INSTRUCTIONS](docker/README.md) - Set up a build environment for Veracruz
 - [CLI_QUICKSTART.markdown](CLI_QUICKSTART.markdown) - Quickly run Veracruz with a prepared demo program
 
 ## News

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -105,7 +105,7 @@ localci-exec:
 	docker exec -i -t $(CONTAINER)-localci-$(USER)-$(VERSION) /bin/bash || true
 
 localci-base: ci/Dockerfile.local ci-base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/localci:$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/localci/$(USER):$(VERSION) -f $< .
 
 .PHONY: all-ci
 all-ci: ci-image localci-base
@@ -126,7 +126,7 @@ icecap-exec:
 
 .PHONY: icecap-base
 icecap-base: icecap/Dockerfile base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/icecap:$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/icecap/$(USER):$(VERSION) -f $< .
 
 #####################################################################
 # Linux-related targets
@@ -143,7 +143,7 @@ linux-exec:
 
 .PHONY:
 linux-base: linux/Dockerfile base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/linux:$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/linux/$(USER):$(VERSION) -f $< .
 
 #####################################################################
 # Nitro-related targets
@@ -185,4 +185,4 @@ endif
 		(git fetch ; git checkout $(AWS_NITRO_CLI_REVISION))
 	make -C aws-nitro-enclaves-cli HOST_MACHINE=$(ARCH) nitro-cli
 	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) \
-		--build-arg NE_GID=$(NE_GID) -t $(IMAGE)/nitro:$(VERSION) -f $< .
+		--build-arg NE_GID=$(NE_GID) -t $(IMAGE)/nitro/$(USER):$(VERSION) -f $< .


### PR DESCRIPTION
This PR should fix the docker Makefile and Readme: 
- Currently the Makefile builds a docker image that follows `$(IMAGE)/localci/$(USER):$(VERSION)` naming but when we try to create a container we use a different name that doesn't specify the user `$(IMAGE)/localci:$(VERSION)` (this is the case for most targets .. localci, linux and icecap). 
- The build instructions links redirects to a build_instructions file which itself redirects to an old docker-image repository.