### PR TITLE
Revert "Fix docker images name"

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -105,7 +105,7 @@ localci-exec:
 	docker exec -i -t $(CONTAINER)-localci-$(USER)-$(VERSION) /bin/bash || true
 
 localci-base: ci/Dockerfile.local ci-base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/localci/$(USER):$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/localci:$(VERSION) -f $< .
 
 .PHONY: all-ci
 all-ci: ci-image localci-base
@@ -126,7 +126,7 @@ icecap-exec:
 
 .PHONY: icecap-base
 icecap-base: icecap/Dockerfile base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/icecap/$(USER):$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/icecap:$(VERSION) -f $< .
 
 #####################################################################
 # Linux-related targets
@@ -143,7 +143,7 @@ linux-exec:
 
 .PHONY:
 linux-base: linux/Dockerfile base
-	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/linux/$(USER):$(VERSION) -f $< .
+	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) -t $(IMAGE)/linux:$(VERSION) -f $< .
 
 #####################################################################
 # Nitro-related targets
@@ -185,4 +185,4 @@ endif
 		(git fetch ; git checkout $(AWS_NITRO_CLI_REVISION))
 	make -C aws-nitro-enclaves-cli HOST_MACHINE=$(ARCH) nitro-cli
 	$(DOCKER_BUILD_CMD) $(BUILD_ARGS) \
-		--build-arg NE_GID=$(NE_GID) -t $(IMAGE)/nitro/$(USER):$(VERSION) -f $< .
+		--build-arg NE_GID=$(NE_GID) -t $(IMAGE)/nitro:$(VERSION) -f $< .


### PR DESCRIPTION
This reverts commit f5af8054ddc8e72b1758d2f47f900cac69cf4711.

The docker image names should perhaps be changed, but that commit changes only some of them and breaks things: I tested `make localci-build` after doing `docker rmi ...` to get rid of the existing images that might otherwise get used.