### PR TITLE
Grant networking capabilities to sandboxee

### DIFF
--- a/crates/execution-engine/src/native_module_manager.rs
+++ b/crates/execution-engine/src/native_module_manager.rs
@@ -314,6 +314,7 @@ impl NativeModuleManager {
                     &mount_mappings,
                     "--sandbox2tool_file_size_creation_limit",
                     "1048576",
+                    "--sandbox2tool_need_networking",
                     entry_point,
                 ])
                 .output()?;


### PR DESCRIPTION
This is useful for the DPU work.
There are security implications but the sandbox is allowing every syscall anyway. The real solution is to specify sandbox2 policies as an extension of the global policies.

Edit: Don't trust the PR ID, this PR is harmless :innocent: 